### PR TITLE
Added "--version-label" switch to provide the ability to specify a version tag for the deployed version of code.

### DIFF
--- a/src/Amazon.ElasticBeanstalk.Tools/Commands/CommandProperties.cs
+++ b/src/Amazon.ElasticBeanstalk.Tools/Commands/CommandProperties.cs
@@ -29,6 +29,7 @@ namespace Amazon.ElasticBeanstalk.Tools.Commands
         public string HealthCheckUrl { get; set; }
         public string InstanceProfile { get; set; }
         public string ServiceRole { get; set; }
+        public string VersionLabel { get; set; }
 
 
         internal void ParseCommandArguments(CommandOptions values)
@@ -48,6 +49,8 @@ namespace Amazon.ElasticBeanstalk.Tools.Commands
                 this.IISWebSite = tuple.Item2.StringValue;
             if ((tuple = values.FindCommandOption(EBDefinedCommandOptions.ARGUMENT_WAIT_FOR_UPDATE.Switch)) != null)
                 this.WaitForUpdate = tuple.Item2.BoolValue;
+            if ((tuple = values.FindCommandOption(EBDefinedCommandOptions.ARGUMENT_EB_VERSION_LABEL.Switch)) != null)
+                this.VersionLabel = tuple.Item2.StringValue;
             if ((tuple = values.FindCommandOption(EBDefinedCommandOptions.ARGUMENT_EB_TAGS.Switch)) != null)
                 this.Tags = tuple.Item2.KeyValuePairs;
             if ((tuple = values.FindCommandOption(EBDefinedCommandOptions.ARGUMENT_EB_ADDITIONAL_OPTIONS.Switch)) != null)

--- a/src/Amazon.ElasticBeanstalk.Tools/Commands/DeployEnvironmentCommand.cs
+++ b/src/Amazon.ElasticBeanstalk.Tools/Commands/DeployEnvironmentCommand.cs
@@ -25,6 +25,7 @@ namespace Amazon.ElasticBeanstalk.Tools.Commands
 
             EBDefinedCommandOptions.ARGUMENT_EB_APPLICATION,
             EBDefinedCommandOptions.ARGUMENT_EB_ENVIRONMENT,
+            EBDefinedCommandOptions.ARGUMENT_EB_VERSION_LABEL,
             EBDefinedCommandOptions.ARGUMENT_EB_TAGS,
             EBDefinedCommandOptions.ARGUMENT_APP_PATH,
             EBDefinedCommandOptions.ARGUMENT_IIS_WEBSITE,
@@ -104,7 +105,7 @@ namespace Amazon.ElasticBeanstalk.Tools.Commands
 
                 string application = this.GetStringValueOrDefault(this.DeployEnvironmentOptions.Application, EBDefinedCommandOptions.ARGUMENT_EB_APPLICATION, true);
                 string environment = this.GetStringValueOrDefault(this.DeployEnvironmentOptions.Environment, EBDefinedCommandOptions.ARGUMENT_EB_ENVIRONMENT, true);
-                string versionLabel = DateTime.Now.Ticks.ToString();
+                string versionLabel = this.GetStringValueOrDefault(this.DeployEnvironmentOptions.VersionLabel, EBDefinedCommandOptions.ARGUMENT_EB_VERSION_LABEL, false) ?? DateTime.Now.Ticks.ToString();
 
                 bool doesApplicationExist = await DoesApplicationExist(application);
                 bool doesEnvironmentExist = doesApplicationExist ? await DoesEnvironmentExist(application, environment) : false;

--- a/src/Amazon.ElasticBeanstalk.Tools/EBDefinedCommandOptions.cs
+++ b/src/Amazon.ElasticBeanstalk.Tools/EBDefinedCommandOptions.cs
@@ -89,6 +89,14 @@ namespace Amazon.ElasticBeanstalk.Tools
                 ValueType = CommandOption.CommandOptionValueType.StringValue,
                 Description = "IAM role to allow Beanstalk to make calls to AWS services."
             };
+        public static readonly CommandOption ARGUMENT_EB_VERSION_LABEL =
+            new CommandOption
+            {
+                Name = "Version Label",
+                Switch = "--version-label",
+                ValueType = CommandOption.CommandOptionValueType.StringValue,
+                Description = "Version label that will be assigned to the uploaded version of code. The default is current tick count."
+            };
         public static readonly CommandOption ARGUMENT_EB_TAGS =
             new CommandOption
             {


### PR DESCRIPTION
This is related to the issue #7.

*Description of changes:*
- In EBDefinedCommandOptions added a CommandOption with "--version-label" switch;
- Added it to options list of DeployEnvironmentCommand;
- Added VersionLabel property to DeployEnvironmentProperties;
- In DeployEnvironmentProperties added lines of code responsible for parsing the option;
- In DeployEnvironmentCommand now using VersionLabel parameter, and if it isn't specified - using default value (DateTime.Now.Ticks.ToString()).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
