### PR TITLE
Rework how deploy-serverless and package-ci work

### DIFF
--- a/src/Amazon.Common.DotNetCli.Tools/Amazon.Common.DotNetCli.Tools.csproj
+++ b/src/Amazon.Common.DotNetCli.Tools/Amazon.Common.DotNetCli.Tools.csproj
@@ -6,10 +6,10 @@
     <FileVersion>3.0.0.0</FileVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="AWSSDK.Core" Version="3.3.22.2" />
-    <PackageReference Include="AWSSDK.IdentityManagement" Version="3.3.6.3" />
-    <PackageReference Include="AWSSDK.S3" Version="3.3.18.2" />
-    <PackageReference Include="AWSSDK.SecurityToken" Version="3.3.4.3" />
+    <PackageReference Include="AWSSDK.Core" Version="3.3.27" />
+    <PackageReference Include="AWSSDK.IdentityManagement" Version="3.3.7.11" />
+    <PackageReference Include="AWSSDK.S3" Version="3.3.24.3" />
+    <PackageReference Include="AWSSDK.SecurityToken" Version="3.3.4.18" />
   </ItemGroup>
   <PropertyGroup Condition="'$(TargetFramework)' == 'netcoreapp2.1' ">
     <DefineConstants>$(DefineConstants);NETCORE</DefineConstants>

--- a/src/Amazon.Common.DotNetCli.Tools/Commands/BaseCommand.cs
+++ b/src/Amazon.Common.DotNetCli.Tools/Commands/BaseCommand.cs
@@ -31,7 +31,8 @@ namespace Amazon.Common.DotNetCli.Tools.Commands
         public BaseCommand(IToolLogger logger, string workingDirectory, IList<CommandOption> possibleOptions, string[] args)
             : this(logger, workingDirectory)
         {
-            this.OriginalCommandLineArguments = args ?? new string[0];
+            args = args ?? new string[0];
+            this.OriginalCommandLineArguments = args;
             var values = CommandLineParser.ParseArguments(possibleOptions, args);
             ParseCommandArguments(values);
         }

--- a/src/Amazon.ECS.Tools/Amazon.ECS.Tools.csproj
+++ b/src/Amazon.ECS.Tools/Amazon.ECS.Tools.csproj
@@ -20,15 +20,15 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AWSSDK.CloudWatchEvents" Version="3.3.3.3" />
-    <PackageReference Include="AWSSDK.CloudWatchLogs" Version="3.3.4.8" />
-    <PackageReference Include="AWSSDK.Core" Version="3.3.22.2" />
-    <PackageReference Include="AWSSDK.EC2" Version="3.3.48.2" />
-    <PackageReference Include="AWSSDK.ECR" Version="3.3.3.8" />
-    <PackageReference Include="AWSSDK.ECS" Version="3.3.13.3" />
-    <PackageReference Include="AWSSDK.IdentityManagement" Version="3.3.6.3" />
-    <PackageReference Include="AWSSDK.S3" Version="3.3.18.2" />
-    <PackageReference Include="AWSSDK.SecurityToken" Version="3.3.4.3" />
+    <PackageReference Include="AWSSDK.CloudWatchEvents" Version="3.3.6.6" />
+    <PackageReference Include="AWSSDK.CloudWatchLogs" Version="3.3.6.4" />
+    <PackageReference Include="AWSSDK.Core" Version="3.3.27" />
+    <PackageReference Include="AWSSDK.EC2" Version="3.3.64.2" />
+    <PackageReference Include="AWSSDK.ECR" Version="3.3.3.23" />
+    <PackageReference Include="AWSSDK.ECS" Version="3.3.18.3" />
+    <PackageReference Include="AWSSDK.IdentityManagement" Version="3.3.7.11" />
+    <PackageReference Include="AWSSDK.S3" Version="3.3.24.3" />
+    <PackageReference Include="AWSSDK.SecurityToken" Version="3.3.4.18" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Amazon.ElasticBeanstalk.Tools/Amazon.ElasticBeanstalk.Tools.csproj
+++ b/src/Amazon.ElasticBeanstalk.Tools/Amazon.ElasticBeanstalk.Tools.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <Import Project="..\..\buildtools\common.props" />
 
@@ -25,10 +25,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="AWSSDK.ElasticBeanstalk" Version="3.3.8.1" />
-    <PackageReference Include="AWSSDK.IdentityManagement" Version="3.3.6.3" />
-    <PackageReference Include="AWSSDK.S3" Version="3.3.18.2" />
-    <PackageReference Include="AWSSDK.SecurityToken" Version="3.3.4.3" />
+    <PackageReference Include="AWSSDK.ElasticBeanstalk" Version="3.3.10.6" />
+    <PackageReference Include="AWSSDK.IdentityManagement" Version="3.3.7.11" />
+    <PackageReference Include="AWSSDK.S3" Version="3.3.24.3" />
+    <PackageReference Include="AWSSDK.SecurityToken" Version="3.3.4.18" />
   </ItemGroup>
 
   <PropertyGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.1' ">

--- a/src/Amazon.Lambda.Tools/Amazon.Lambda.Tools.csproj
+++ b/src/Amazon.Lambda.Tools/Amazon.Lambda.Tools.csproj
@@ -28,11 +28,11 @@
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
     <PackageReference Include="System.Runtime.Loader" Version="4.0.0" />
-    <PackageReference Include="AWSSDK.CloudFormation" Version="3.3.11.14" />
-    <PackageReference Include="AWSSDK.Lambda" Version="3.3.16.4" />
-    <PackageReference Include="AWSSDK.IdentityManagement" Version="3.3.7.10" />
-    <PackageReference Include="AWSSDK.SecurityToken" Version="3.3.4.17" />
-    <PackageReference Include="AWSSDK.S3" Version="3.3.24.2" />
+    <PackageReference Include="AWSSDK.CloudFormation" Version="3.3.11.15" />
+    <PackageReference Include="AWSSDK.Lambda" Version="3.3.16.5" />
+    <PackageReference Include="AWSSDK.IdentityManagement" Version="3.3.7.11" />
+    <PackageReference Include="AWSSDK.SecurityToken" Version="3.3.4.18" />
+    <PackageReference Include="AWSSDK.S3" Version="3.3.24.3" />
     <PackageReference Include="YamlDotNet.Signed" Version="4.2.1" />
   </ItemGroup>
   <PropertyGroup>

--- a/src/Amazon.Lambda.Tools/Amazon.Lambda.Tools.csproj
+++ b/src/Amazon.Lambda.Tools/Amazon.Lambda.Tools.csproj
@@ -15,7 +15,7 @@
     <Copyright>Copyright 2009-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.</Copyright>
     <Product>AWS Lambda Tools for .NET CLI</Product>
     <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
-    <Version>3.0.1</Version>
+    <Version>3.1.0</Version>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Amazon.Common.DotNetCli.Tools\Amazon.Common.DotNetCli.Tools.csproj">
@@ -26,13 +26,13 @@
     <EmbeddedResource Include="Resources\netcore.runtime.hierarchy.json" Exclude="bin\**;obj\**;**\*.xproj;packages\**;@(EmbeddedResource)" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="AWSSDK.SecurityToken" Version="3.3.4.3" />
     <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
     <PackageReference Include="System.Runtime.Loader" Version="4.0.0" />
-    <PackageReference Include="AWSSDK.CloudFormation" Version="3.3.10.2" />
-    <PackageReference Include="AWSSDK.Lambda" Version="3.3.13.2" />
-    <PackageReference Include="AWSSDK.IdentityManagement" Version="3.3.6.3" />
-    <PackageReference Include="AWSSDK.S3" Version="3.3.18.2" />
+    <PackageReference Include="AWSSDK.CloudFormation" Version="3.3.11.14" />
+    <PackageReference Include="AWSSDK.Lambda" Version="3.3.16.4" />
+    <PackageReference Include="AWSSDK.IdentityManagement" Version="3.3.7.10" />
+    <PackageReference Include="AWSSDK.SecurityToken" Version="3.3.4.17" />
+    <PackageReference Include="AWSSDK.S3" Version="3.3.24.2" />
     <PackageReference Include="YamlDotNet.Signed" Version="4.2.1" />
   </ItemGroup>
   <PropertyGroup>

--- a/src/Amazon.Lambda.Tools/Commands/DeployFunctionCommand.cs
+++ b/src/Amazon.Lambda.Tools/Commands/DeployFunctionCommand.cs
@@ -124,7 +124,7 @@ namespace Amazon.Lambda.Tools.Commands
             {
                 EnsureInProjectDirectory();
 
-                string configuration = this.GetStringValueOrDefault(this.Configuration, CommonDefinedCommandOptions.ARGUMENT_CONFIGURATION, true);
+                string configuration = this.GetStringValueOrDefault(this.Configuration, CommonDefinedCommandOptions.ARGUMENT_CONFIGURATION, false);
                 string targetFramework = this.GetStringValueOrDefault(this.TargetFramework, CommonDefinedCommandOptions.ARGUMENT_FRAMEWORK, true);
                 string msbuildParameters = this.GetStringValueOrDefault(this.MSBuildParameters, CommonDefinedCommandOptions.ARGUMENT_MSBUILD_PARAMETERS, false);
 

--- a/src/Amazon.Lambda.Tools/Commands/DeployFunctionCommand.cs
+++ b/src/Amazon.Lambda.Tools/Commands/DeployFunctionCommand.cs
@@ -124,7 +124,9 @@ namespace Amazon.Lambda.Tools.Commands
             {
                 EnsureInProjectDirectory();
 
+                // Release will be the default configuration if nothing set.
                 string configuration = this.GetStringValueOrDefault(this.Configuration, CommonDefinedCommandOptions.ARGUMENT_CONFIGURATION, false);
+
                 string targetFramework = this.GetStringValueOrDefault(this.TargetFramework, CommonDefinedCommandOptions.ARGUMENT_FRAMEWORK, true);
                 string msbuildParameters = this.GetStringValueOrDefault(this.MSBuildParameters, CommonDefinedCommandOptions.ARGUMENT_MSBUILD_PARAMETERS, false);
 

--- a/src/Amazon.Lambda.Tools/Commands/DeployServerlessCommand.cs
+++ b/src/Amazon.Lambda.Tools/Commands/DeployServerlessCommand.cs
@@ -150,7 +150,7 @@ namespace Amazon.Lambda.Tools.Commands
             templateBody = LambdaUtilities.ProcessTemplateSubstitions(this.Logger, templateBody, this.GetKeyValuePairOrDefault(this.TemplateSubstitutions, LambdaDefinedCommandOptions.ARGUMENT_CLOUDFORMATION_TEMPLATE_SUBSTITUTIONS, false), Utilities.DetermineProjectLocation(this.WorkingDirectory, projectLocation));
             
             
-            var options = new TemplateProcessorManager.DefaultLocationOption
+            var options = new DefaultLocationOption
             {
                 Configuration = this.GetStringValueOrDefault(this.Configuration, CommonDefinedCommandOptions.ARGUMENT_CONFIGURATION, false),
                 TargetFramework = this.GetStringValueOrDefault(this.TargetFramework, CommonDefinedCommandOptions.ARGUMENT_FRAMEWORK, false),

--- a/src/Amazon.Lambda.Tools/Commands/PackageCICommand.cs
+++ b/src/Amazon.Lambda.Tools/Commands/PackageCICommand.cs
@@ -119,7 +119,7 @@ namespace Amazon.Lambda.Tools.Commands
             // Process any template substitutions
             templateBody = LambdaUtilities.ProcessTemplateSubstitions(this.Logger, templateBody, this.GetKeyValuePairOrDefault(this.TemplateSubstitutions, LambdaDefinedCommandOptions.ARGUMENT_CLOUDFORMATION_TEMPLATE_SUBSTITUTIONS, false), Utilities.DetermineProjectLocation(this.WorkingDirectory, projectLocation));
                         
-            var options = new TemplateProcessorManager.DefaultLocationOption
+            var options = new DefaultLocationOption
             {
                 Configuration = this.GetStringValueOrDefault(this.Configuration, CommonDefinedCommandOptions.ARGUMENT_CONFIGURATION, false),
                 TargetFramework = this.GetStringValueOrDefault(this.TargetFramework, CommonDefinedCommandOptions.ARGUMENT_FRAMEWORK, false),

--- a/src/Amazon.Lambda.Tools/Commands/PackageCommand.cs
+++ b/src/Amazon.Lambda.Tools/Commands/PackageCommand.cs
@@ -89,7 +89,9 @@ namespace Amazon.Lambda.Tools.Commands
 
             return Task.Run(() =>
             {
+                // Release will be the default configuration if nothing set.
                 var configuration = this.GetStringValueOrDefault(this.Configuration, CommonDefinedCommandOptions.ARGUMENT_CONFIGURATION, false);
+
                 var targetFramework = this.GetStringValueOrDefault(this.TargetFramework, CommonDefinedCommandOptions.ARGUMENT_FRAMEWORK, true);
                 var projectLocation = this.GetStringValueOrDefault(this.ProjectLocation, CommonDefinedCommandOptions.ARGUMENT_PROJECT_LOCATION, false);
                 var msbuildParameters = this.GetStringValueOrDefault(this.MSBuildParameters, CommonDefinedCommandOptions.ARGUMENT_MSBUILD_PARAMETERS, false);

--- a/src/Amazon.Lambda.Tools/Commands/PackageCommand.cs
+++ b/src/Amazon.Lambda.Tools/Commands/PackageCommand.cs
@@ -89,7 +89,7 @@ namespace Amazon.Lambda.Tools.Commands
 
             return Task.Run(() =>
             {
-                var configuration = this.GetStringValueOrDefault(this.Configuration, CommonDefinedCommandOptions.ARGUMENT_CONFIGURATION, true);
+                var configuration = this.GetStringValueOrDefault(this.Configuration, CommonDefinedCommandOptions.ARGUMENT_CONFIGURATION, false);
                 var targetFramework = this.GetStringValueOrDefault(this.TargetFramework, CommonDefinedCommandOptions.ARGUMENT_FRAMEWORK, true);
                 var projectLocation = this.GetStringValueOrDefault(this.ProjectLocation, CommonDefinedCommandOptions.ARGUMENT_PROJECT_LOCATION, false);
                 var msbuildParameters = this.GetStringValueOrDefault(this.MSBuildParameters, CommonDefinedCommandOptions.ARGUMENT_MSBUILD_PARAMETERS, false);

--- a/src/Amazon.Lambda.Tools/Commands/UpdateFunctionConfigCommand.cs
+++ b/src/Amazon.Lambda.Tools/Commands/UpdateFunctionConfigCommand.cs
@@ -25,8 +25,6 @@ namespace Amazon.Lambda.Tools.Commands
 
         public static readonly IList<CommandOption> UpdateCommandOptions = BuildLineOptions(new List<CommandOption>
         {
-            CommonDefinedCommandOptions.ARGUMENT_CONFIGURATION,
-            CommonDefinedCommandOptions.ARGUMENT_FRAMEWORK,
             LambdaDefinedCommandOptions.ARGUMENT_FUNCTION_NAME,
             LambdaDefinedCommandOptions.ARGUMENT_FUNCTION_DESCRIPTION,
             LambdaDefinedCommandOptions.ARGUMENT_FUNCTION_PUBLISH,

--- a/src/Amazon.Lambda.Tools/Exceptions.cs
+++ b/src/Amazon.Lambda.Tools/Exceptions.cs
@@ -46,6 +46,8 @@ namespace Amazon.Lambda.Tools
             ServerlessTemplateParseError,
             ServerlessTemplateMissingResourceSection,
             ServerlessTemplateSubstitutionError,
+            ServerlessTemplateMissingLocalPath,
+            ServerlessTemplateUnknownActionForLocalPath,
             WaitingForStackError,
 
             FailedToFindZipProgram

--- a/src/Amazon.Lambda.Tools/LambdaConstants.cs
+++ b/src/Amazon.Lambda.Tools/LambdaConstants.cs
@@ -20,6 +20,8 @@ namespace Amazon.Lambda.Tools
 
         public const int MAX_TEMPLATE_BODY_IN_REQUEST_SIZE = 50000;
 
+        public const string DEFAULT_BUILD_CONFIGURATION = "Release";
+
         // The .NET Core 1.0 version of the runtime hierarchies for .NET Core taken from the corefx repository
         // https://github.com/dotnet/corefx/blob/release/1.0.0/pkg/Microsoft.NETCore.Platforms/runtime.json
         internal const string RUNTIME_HIERARCHY = "netcore.runtime.hierarchy.json";

--- a/src/Amazon.Lambda.Tools/LambdaPackager.cs
+++ b/src/Amazon.Lambda.Tools/LambdaPackager.cs
@@ -133,6 +133,58 @@ namespace Amazon.Lambda.Tools
 #endif            
         }
 
+        public static void BundleFiles(string zipArchivePath, string rootDirectory, string[] files, IToolLogger logger)
+        {
+            var includedFiles = ConvertToMapOfFiles(rootDirectory, files);
+
+#if NETCORE
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                BundleWithDotNetCompression(zipArchivePath, rootDirectory, includedFiles, logger);
+            }
+            else
+            {
+                // Use the native zip utility if it exist which will maintain linux/osx file permissions
+                var zipCLI = LambdaDotNetCLIWrapper.FindExecutableInPath("zip");
+                if (!string.IsNullOrEmpty(zipCLI))
+                {
+                    BundleWithZipCLI(zipCLI, zipArchivePath, rootDirectory, includedFiles, logger);
+                }
+                else
+                {
+                    throw new LambdaToolsException("Failed to find the \"zip\" utility program in path. This program is required to maintain Linux file permissions in the zip archive.", LambdaToolsException.LambdaErrorCode.FailedToFindZipProgram);
+                }
+            }
+#else
+            BundleWithDotNetCompression(zipArchivePath, sourceDirectory, flattenRuntime, logger);
+#endif            
+        }
+
+
+        public static IDictionary<string, string> ConvertToMapOfFiles(string rootDirectory, string[] files)
+        {
+            rootDirectory = rootDirectory.Replace("\\", "/");
+            if (!rootDirectory.EndsWith("/"))
+                rootDirectory += "/";
+
+            var includedFiles = new Dictionary<string, string>(files.Length);
+            foreach (var file in files)
+            {
+                var normalizedFile = file.Replace("\\", "/");
+                if (Path.IsPathRooted(file))
+                {
+                    var relativePath = file.Substring(rootDirectory.Length);
+                    includedFiles[relativePath] = normalizedFile;
+                }
+                else
+                {
+                    includedFiles[normalizedFile] = Path.Combine(rootDirectory, normalizedFile).Replace("\\", "/");
+                }
+            }
+
+            return includedFiles;
+        }
+
         /// <summary>
         /// Return the targets node which declares all the dependencies for the project along with the dependency's dependencies.
         /// </summary>
@@ -417,9 +469,21 @@ namespace Amazon.Lambda.Tools
         /// <param name="logger">Logger instance.</param>
         private static void BundleWithDotNetCompression(string zipArchivePath, string publishLocation, bool flattenRuntime, IToolLogger logger)
         {
+            var includedFiles = GetFilesToIncludeInArchive(publishLocation, flattenRuntime);
+            BundleWithDotNetCompression(zipArchivePath, publishLocation, includedFiles, logger);
+        }
+
+        /// <summary>
+        /// Zip up the publish folder using the .NET compression libraries. This is what is used when run on Windows.
+        /// </summary>
+        /// <param name="zipArchivePath">The path and name of the zip archive to create.</param>
+        /// <param name="rootDirectory">The root directory where all of the relative paths in includedFiles is pointing to.</param>
+        /// <param name="includedFiles">Map of relative to absolute path of files to include in bundle.</param>
+        /// <param name="logger">Logger instance.</param>
+        private static void BundleWithDotNetCompression(string zipArchivePath, string rootDirectory, IDictionary<string, string> includedFiles, IToolLogger logger)
+        {
             using (var zipArchive = ZipFile.Open(zipArchivePath, ZipArchiveMode.Create))
             {
-                var includedFiles = GetFilesToIncludeInArchive(publishLocation, flattenRuntime);
                 foreach (var kvp in includedFiles)
                 {
                     zipArchive.CreateEntryFromFile(kvp.Value, kvp.Key);
@@ -440,10 +504,24 @@ namespace Amazon.Lambda.Tools
         /// <param name="logger">Logger instance.</param>
         private static void BundleWithZipCLI(string zipCLI, string zipArchivePath, string publishLocation, bool flattenRuntime, IToolLogger logger)
         {
+            var allFiles = GetFilesToIncludeInArchive(publishLocation, flattenRuntime);
+            BundleWithZipCLI(zipCLI, zipArchivePath, publishLocation, allFiles, logger);
+        }
+
+        /// <summary>
+        /// Creates the deployment bundle using the native zip tool installed
+        /// on the system (default /usr/bin/zip). This is what is typically used on Linux and OSX
+        /// </summary>
+        /// <param name="zipCLI">The path to the located zip binary.</param>
+        /// <param name="zipArchivePath">The path and name of the zip archive to create.</param>
+        /// <param name="rootDirectory">The root directory where all of the relative paths in includedFiles is pointing to.</param>
+        /// <param name="includedFiles">Map of relative to absolute path of files to include in bundle.</param>
+        /// <param name="logger">Logger instance.</param>
+        private static void BundleWithZipCLI(string zipCLI, string zipArchivePath, string rootDirectory, IDictionary<string, string> includedFiles, IToolLogger logger)
+        {
             var args = new StringBuilder("\"" + zipArchivePath + "\"");
 
-            var allFiles = GetFilesToIncludeInArchive(publishLocation, flattenRuntime);
-            foreach (var kvp in allFiles)
+            foreach (var kvp in includedFiles)
             {
                 args.AppendFormat(" \"{0}\"", kvp.Key);
             }
@@ -452,7 +530,7 @@ namespace Amazon.Lambda.Tools
             {
                 FileName = zipCLI,
                 Arguments = args.ToString(),
-                WorkingDirectory = publishLocation,
+                WorkingDirectory = rootDirectory,
                 RedirectStandardOutput = true,
                 RedirectStandardError = true,
                 UseShellExecute = false,

--- a/src/Amazon.Lambda.Tools/LambdaPackager.cs
+++ b/src/Amazon.Lambda.Tools/LambdaPackager.cs
@@ -41,7 +41,7 @@ namespace Amazon.Lambda.Tools
             out string publishLocation, ref string zipArchivePath)
         {
             if(string.IsNullOrEmpty(configuration))
-                configuration = "Release";
+                configuration = LambdaConstants.DEFAULT_BUILD_CONFIGURATION;
             
             string lambdaRuntimePackageStoreManifestContent = null;
             var computedProjectLocation = Utilities.DetermineProjectLocation(workingDirectory, projectLocation);

--- a/src/Amazon.Lambda.Tools/LambdaPackager.cs
+++ b/src/Amazon.Lambda.Tools/LambdaPackager.cs
@@ -103,10 +103,17 @@ namespace Amazon.Lambda.Tools
             }
 
 
+            BundleDirectory(zipArchivePath, publishLocation, flattenRuntime, logger);
+
+            return true;
+        }
+
+        public static void BundleDirectory(string zipArchivePath, string sourceDirectory, bool flattenRuntime, IToolLogger logger)
+        {
 #if NETCORE
             if(RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
-                BundleWithDotNetCompression(zipArchivePath, publishLocation, flattenRuntime, logger);
+                BundleWithDotNetCompression(zipArchivePath, sourceDirectory, flattenRuntime, logger);
             }
             else
             {
@@ -114,7 +121,7 @@ namespace Amazon.Lambda.Tools
                 var zipCLI = LambdaDotNetCLIWrapper.FindExecutableInPath("zip");
                 if (!string.IsNullOrEmpty(zipCLI))
                 {
-                    BundleWithZipCLI(zipCLI, zipArchivePath, publishLocation, flattenRuntime, logger);
+                    BundleWithZipCLI(zipCLI, zipArchivePath, sourceDirectory, flattenRuntime, logger);
                 }
                 else
                 {
@@ -122,12 +129,8 @@ namespace Amazon.Lambda.Tools
                 }
             }
 #else
-            BundleWithDotNetCompression(zipArchivePath, publishLocation, flattenRuntime, logger);
-#endif
-
-
-
-            return true;
+            BundleWithDotNetCompression(zipArchivePath, sourceDirectory, flattenRuntime, logger);
+#endif            
         }
 
         /// <summary>

--- a/src/Amazon.Lambda.Tools/LambdaPackager.cs
+++ b/src/Amazon.Lambda.Tools/LambdaPackager.cs
@@ -40,6 +40,9 @@ namespace Amazon.Lambda.Tools
             string projectLocation, string configuration, string targetFramework, string msbuildParameters, bool disableVersionCheck,
             out string publishLocation, ref string zipArchivePath)
         {
+            if(string.IsNullOrEmpty(configuration))
+                configuration = "Release";
+            
             string lambdaRuntimePackageStoreManifestContent = null;
             var computedProjectLocation = Utilities.DetermineProjectLocation(workingDirectory, projectLocation);
 

--- a/src/Amazon.Lambda.Tools/LambdaUtilities.cs
+++ b/src/Amazon.Lambda.Tools/LambdaUtilities.cs
@@ -18,6 +18,25 @@ namespace Amazon.Lambda.Tools
     {
         public static readonly IList<string> ValidProjectExtensions = new List<string> { ".csproj", ".fsproj", ".vbproj" };
 
+
+        public static string DetermineTargetFrameworkFromLambdaRuntime(string lambdaRuntime)
+        {
+            if (lambdaRuntime == Amazon.Lambda.Runtime.Dotnetcore21)
+            {
+                return "netcoreapp2.1";
+            }
+            if (lambdaRuntime == Amazon.Lambda.Runtime.Dotnetcore20)
+            {
+                return "netcoreapp2.0";
+            }
+            if (lambdaRuntime == Amazon.Lambda.Runtime.Dotnetcore10)
+            {
+                return "netcoreapp1.0";
+            }
+
+            return null;
+        }
+        
         /// <summary>
         /// Make sure nobody is trying to deploy a function based on a higher .NET Core framework then the Lambda runtime knows about.
         /// </summary>

--- a/src/Amazon.Lambda.Tools/LambdaUtilities.cs
+++ b/src/Amazon.Lambda.Tools/LambdaUtilities.cs
@@ -18,27 +18,24 @@ namespace Amazon.Lambda.Tools
     {
         public static readonly IList<string> ValidProjectExtensions = new List<string> { ".csproj", ".fsproj", ".vbproj" };
 
+        static readonly IReadOnlyDictionary<string, string> _lambdaRuntimeToDotnetFramework = new Dictionary<string, string>()
+        {
+            {Amazon.Lambda.Runtime.Dotnetcore21.Value, "netcoreapp2.1"},
+            {Amazon.Lambda.Runtime.Dotnetcore20.Value, "netcoreapp2.0"},
+            {Amazon.Lambda.Runtime.Dotnetcore10.Value, "netcoreapp1.0"}
+        };
 
         public static string DetermineTargetFrameworkFromLambdaRuntime(string lambdaRuntime)
         {
-            if (lambdaRuntime == Amazon.Lambda.Runtime.Dotnetcore21)
-            {
-                return "netcoreapp2.1";
-            }
-            if (lambdaRuntime == Amazon.Lambda.Runtime.Dotnetcore20)
-            {
-                return "netcoreapp2.0";
-            }
-            if (lambdaRuntime == Amazon.Lambda.Runtime.Dotnetcore10)
-            {
-                return "netcoreapp1.0";
-            }
+            string runtime;
+            if (_lambdaRuntimeToDotnetFramework.TryGetValue(lambdaRuntime, out runtime))
+                return runtime;
 
             return null;
         }
         
         /// <summary>
-        /// Make sure nobody is trying to deploy a function based on a higher .NET Core framework then the Lambda runtime knows about.
+        /// Make sure nobody is trying to deploy a function based on a higher .NET Core framework than the Lambda runtime knows about.
         /// </summary>
         /// <param name="lambdaRuntime"></param>
         /// <param name="targetFramework"></param>
@@ -112,7 +109,7 @@ namespace Amazon.Lambda.Tools
             }
 
             // If the file is not a valid proj file then skip validation. This could happen
-            // if the project is an F# project or an older style project.json.
+            // if the project is an older style project.json.
             if (!ValidProjectExtensions.Contains(Path.GetExtension(profPath)))
                 return;
 

--- a/src/Amazon.Lambda.Tools/LambdaUtilities.cs
+++ b/src/Amazon.Lambda.Tools/LambdaUtilities.cs
@@ -16,7 +16,7 @@ namespace Amazon.Lambda.Tools
 {
     public static class LambdaUtilities
     {
-
+        public static readonly IList<string> ValidProjectExtensions = new List<string> { ".csproj", ".fsproj", ".vbproj" };
 
         /// <summary>
         /// Make sure nobody is trying to deploy a function based on a higher .NET Core framework then the Lambda runtime knows about.
@@ -78,12 +78,12 @@ namespace Amazon.Lambda.Tools
 
         public static void ValidateMicrosoftAspNetCoreAllReferenceFromProjectPath(IToolLogger logger, string targetFramework, string manifestContent, string profPath)
         {
-            HashSet<string> validProjectExtensions = new HashSet<string> { ".csproj", ".fsproj", ".vbproj" };
+            
 
             if (Directory.Exists(profPath))
             {
                 var projectFiles = Directory.GetFiles(profPath, "*.??proj", SearchOption.TopDirectoryOnly)
-                    .Where(x => validProjectExtensions.Contains(Path.GetExtension(x))).ToArray();
+                    .Where(x => ValidProjectExtensions.Contains(Path.GetExtension(x))).ToArray();
                 if (projectFiles.Length != 1)
                 {
                     logger?.WriteLine("Unable to determine project file when validating version of Microsoft.AspNetCore.All");
@@ -94,7 +94,7 @@ namespace Amazon.Lambda.Tools
 
             // If the file is not a valid proj file then skip validation. This could happen
             // if the project is an F# project or an older style project.json.
-            if (!validProjectExtensions.Contains(Path.GetExtension(profPath)))
+            if (!ValidProjectExtensions.Contains(Path.GetExtension(profPath)))
                 return;
 
             var projectContent = File.ReadAllText(profPath);

--- a/src/Amazon.Lambda.Tools/TemplateProcessor/DefaultLocationOption.cs
+++ b/src/Amazon.Lambda.Tools/TemplateProcessor/DefaultLocationOption.cs
@@ -14,14 +14,14 @@ namespace Amazon.Lambda.Tools.TemplateProcessor
         /// .NET Target Framework e.g. netcoreapp2.1
         /// </summary>
         public string TargetFramework { get; set; }
-        
+
         /// <summary>
-        /// Additional parameters passed in when invoke dotnet publish
+        /// Additional parameters to pass when invoking dotnet publish
         /// </summary>
         public string MSBuildParameters { get; set; }
         
         /// <summary>
-        /// If true disables checking for correct version of Microsoft.AspNetCore.App version.
+        /// If true disables checking for correct version of Microsoft.AspNetCore.App.
         /// </summary>
         public bool DisableVersionCheck { get; set; }
         

--- a/src/Amazon.Lambda.Tools/TemplateProcessor/DefaultLocationOption.cs
+++ b/src/Amazon.Lambda.Tools/TemplateProcessor/DefaultLocationOption.cs
@@ -1,0 +1,11 @@
+namespace Amazon.Lambda.Tools.TemplateProcessor
+{
+    public class DefaultLocationOption
+    {
+        public string Configuration { get; set; }
+        public string TargetFramework { get; set; }
+        public string MSBuildParameters { get; set; }
+        public bool DisableVersionCheck { get; set; }
+        public string Package { get; set; }
+    }
+}

--- a/src/Amazon.Lambda.Tools/TemplateProcessor/DefaultLocationOption.cs
+++ b/src/Amazon.Lambda.Tools/TemplateProcessor/DefaultLocationOption.cs
@@ -1,11 +1,33 @@
 namespace Amazon.Lambda.Tools.TemplateProcessor
 {
+    /// <summary>
+    /// Properties to use when building the current project which might have come from the command line.
+    /// </summary>
     public class DefaultLocationOption
     {
+        /// <summary>
+        /// Build Configuration e.g. Release
+        /// </summary>
+        /// 
         public string Configuration { get; set; }
+        /// <summary>
+        /// .NET Target Framework e.g. netcoreapp2.1
+        /// </summary>
         public string TargetFramework { get; set; }
+        
+        /// <summary>
+        /// Additional parameters passed in when invoke dotnet publish
+        /// </summary>
         public string MSBuildParameters { get; set; }
+        
+        /// <summary>
+        /// If true disables checking for correct version of Microsoft.AspNetCore.App version.
+        /// </summary>
         public bool DisableVersionCheck { get; set; }
+        
+        /// <summary>
+        /// If the current project is already built pass in the current compiled package zip file.
+        /// </summary>
         public string Package { get; set; }
     }
 }

--- a/src/Amazon.Lambda.Tools/TemplateProcessor/ITemplateParser.cs
+++ b/src/Amazon.Lambda.Tools/TemplateProcessor/ITemplateParser.cs
@@ -21,10 +21,15 @@ namespace Amazon.Lambda.Tools.TemplateProcessor
         string ResourceType { get; }
 
         string LambdaRuntime { get; }
+        
+        IList<IUpdateResourceField> Fields { get; }
+    }
 
+    public interface IUpdateResourceField
+    {
+        IUpdatableResource Resource { get; }
         string GetLocalPath();
-
-        void SetS3Location(string s3Bucket, string s3Key);        
+        void SetS3Location(string s3Bucket, string s3Key);
     }
 
     public interface IUpdatableResourceDataSource

--- a/src/Amazon.Lambda.Tools/TemplateProcessor/ITemplateParser.cs
+++ b/src/Amazon.Lambda.Tools/TemplateProcessor/ITemplateParser.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using ThirdParty.Json.LitJson;
+using YamlDotNet.RepresentationModel;
+
+namespace Amazon.Lambda.Tools.TemplateProcessor
+{
+    public interface ITemplateParser
+    {
+        IEnumerable<IUpdatableResource> UpdatableResources();
+
+        string GetUpdatedTemplate();
+    }
+
+    public interface IUpdatableResource
+    {
+        string ResourceType { get; }
+
+        string GetLocalPath();
+
+        void SetS3Location(string s3Bucket, string s3Key);
+    }
+
+    public interface IUpdatableResourceDataSource
+    {
+        string GetValue(params string[] keyPath);
+
+        void SetValue(string value, params string[] keyPath);
+    }
+}

--- a/src/Amazon.Lambda.Tools/TemplateProcessor/ITemplateParser.cs
+++ b/src/Amazon.Lambda.Tools/TemplateProcessor/ITemplateParser.cs
@@ -7,35 +7,102 @@ using YamlDotNet.RepresentationModel;
 
 namespace Amazon.Lambda.Tools.TemplateProcessor
 {
+    /// <summary>
+    /// Interface to iterate over the CloudFormation resources that can be updated.
+    /// </summary>
     public interface ITemplateParser
     {
+        /// <summary>
+        /// Iterator for the updatable resources.
+        /// </summary>
+        /// <returns></returns>
         IEnumerable<IUpdatableResource> UpdatableResources();
 
+        /// <summary>
+        /// Get the new template after the resources have been updated.
+        /// </summary>
+        /// <returns></returns>
         string GetUpdatedTemplate();
     }
 
+    /// <summary>
+    /// Interface for a CloudFormation resource that can be updated.
+    /// </summary>
     public interface IUpdatableResource
     {
+        /// <summary>
+        /// The CloudFormation name of the resource.
+        /// </summary>
         string Name { get; }
 
+        /// <summary>
+        /// The CloudFormation resource type.
+        /// </summary>
         string ResourceType { get; }
 
+        /// <summary>
+        /// If the resource is a AWS::Lambda::Function or AWS::Serverless::Function get the Lambda runtime for it.
+        /// </summary>
         string LambdaRuntime { get; }
         
+        /// <summary>
+        /// The list of fields that can be updated.
+        /// </summary>
         IList<IUpdateResourceField> Fields { get; }
     }
 
+    /// <summary>
+    /// Interface for the field in the IUpdatableResource that can be updated.
+    /// </summary>
     public interface IUpdateResourceField
     {
+        /// <summary>
+        /// Gets the name of the field.
+        /// </summary>
+        string Name { get; }
+        
+        /// <summary>
+        /// True if the field should contain code like a Lambda package bundle.
+        /// </summary>
+        bool IsCode { get; }
+        
+        
+        /// <summary>
+        /// Reference back to the containing updatable resource.
+        /// </summary>
         IUpdatableResource Resource { get; }
+        
+        /// <summary>
+        /// Gets the local path for the resource. If the value referencing an object in S3 then this returns null.
+        /// </summary>
+        /// <returns></returns>
         string GetLocalPath();
+        
+        /// <summary>
+        /// Updates the location the field is pointing to where the local path was uploaded to S3.
+        /// </summary>
+        /// <param name="s3Bucket"></param>
+        /// <param name="s3Key"></param>
         void SetS3Location(string s3Bucket, string s3Key);
     }
 
+    /// <summary>
+    /// Interface for the underlying datasource (JSON or YAML), 
+    /// </summary>
     public interface IUpdatableResourceDataSource
     {
+        /// <summary>
+        /// Gets value in datasource.
+        /// </summary>
+        /// <param name="keyPath"></param>
+        /// <returns></returns>
         string GetValue(params string[] keyPath);
 
+        /// <summary>
+        /// Set value in datasource.
+        /// </summary>
+        /// <param name="value"></param>
+        /// <param name="keyPath"></param>
         void SetValue(string value, params string[] keyPath);
     }
 }

--- a/src/Amazon.Lambda.Tools/TemplateProcessor/ITemplateParser.cs
+++ b/src/Amazon.Lambda.Tools/TemplateProcessor/ITemplateParser.cs
@@ -16,6 +16,8 @@ namespace Amazon.Lambda.Tools.TemplateProcessor
 
     public interface IUpdatableResource
     {
+        string Name { get; }
+
         string ResourceType { get; }
 
         string GetLocalPath();

--- a/src/Amazon.Lambda.Tools/TemplateProcessor/ITemplateParser.cs
+++ b/src/Amazon.Lambda.Tools/TemplateProcessor/ITemplateParser.cs
@@ -20,9 +20,11 @@ namespace Amazon.Lambda.Tools.TemplateProcessor
 
         string ResourceType { get; }
 
+        string LambdaRuntime { get; }
+
         string GetLocalPath();
 
-        void SetS3Location(string s3Bucket, string s3Key);
+        void SetS3Location(string s3Bucket, string s3Key);        
     }
 
     public interface IUpdatableResourceDataSource

--- a/src/Amazon.Lambda.Tools/TemplateProcessor/ITemplateParser.cs
+++ b/src/Amazon.Lambda.Tools/TemplateProcessor/ITemplateParser.cs
@@ -73,7 +73,7 @@ namespace Amazon.Lambda.Tools.TemplateProcessor
         IUpdatableResource Resource { get; }
         
         /// <summary>
-        /// Gets the local path for the resource. If the value referencing an object in S3 then this returns null.
+        /// Gets the local path for the resource. If the value is referencing an object in S3 then this returns null.
         /// </summary>
         /// <returns></returns>
         string GetLocalPath();

--- a/src/Amazon.Lambda.Tools/TemplateProcessor/JsonTemplateParser.cs
+++ b/src/Amazon.Lambda.Tools/TemplateProcessor/JsonTemplateParser.cs
@@ -5,6 +5,9 @@ using ThirdParty.Json.LitJson;
 
 namespace Amazon.Lambda.Tools.TemplateProcessor
 {
+    /// <summary>
+    /// JSON implementation of ITemplateParser
+    /// </summary>
     public class JsonTemplateParser : ITemplateParser
     {
         JsonData Root { get; }
@@ -53,6 +56,9 @@ namespace Amazon.Lambda.Tools.TemplateProcessor
             }
         }
 
+        /// <summary>
+        /// The JSON implementation of IUpdatableResourceDataSource
+        /// </summary>
         public class JsonUpdatableResourceDataSource : IUpdatableResourceDataSource
         {
             JsonData Properties { get; }

--- a/src/Amazon.Lambda.Tools/TemplateProcessor/JsonTemplateParser.cs
+++ b/src/Amazon.Lambda.Tools/TemplateProcessor/JsonTemplateParser.cs
@@ -43,10 +43,12 @@ namespace Amazon.Lambda.Tools.TemplateProcessor
                     continue;
 
                 var type = resource["Type"]?.ToString();
-                var updatableResource = new UpdatableResource(field, type, new JsonUpdatableResourceDataSource(properties));
-                if (!updatableResource.IsUpdatable)
+                UpdatableResourceDefinition updatableResourceDefinition;
+                if (!UpdatableResourceDefinition.ValidUpdatableResourceDefinitions.TryGetValue(type,
+                    out updatableResourceDefinition))
                     continue;
-
+                
+                var updatableResource = new UpdatableResource(field, updatableResourceDefinition, new JsonUpdatableResourceDataSource(properties));
                 yield return updatableResource;
             }
         }

--- a/src/Amazon.Lambda.Tools/TemplateProcessor/JsonTemplateParser.cs
+++ b/src/Amazon.Lambda.Tools/TemplateProcessor/JsonTemplateParser.cs
@@ -1,0 +1,95 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using ThirdParty.Json.LitJson;
+
+namespace Amazon.Lambda.Tools.TemplateProcessor
+{
+    public class JsonTemplateParser : ITemplateParser
+    {
+        JsonData Root { get; }
+        public JsonTemplateParser(string templateBody)
+        {
+            try
+            {
+                this.Root = JsonMapper.ToObject(templateBody);
+            }
+            catch (Exception e)
+            {
+                throw new LambdaToolsException($"Error parsing CloudFormation template: {e.Message}", LambdaToolsException.LambdaErrorCode.ServerlessTemplateParseError, e);
+            }
+        }
+
+        public string GetUpdatedTemplate()
+        {
+            var json = JsonMapper.ToJson(this.Root);
+            return json;
+        }
+
+        public IEnumerable<IUpdatableResource> UpdatableResources()
+        {
+            var resources = this.Root["Resources"];
+            if (resources == null)
+                throw new LambdaToolsException("CloudFormation template does not define any AWS resources", LambdaToolsException.LambdaErrorCode.ServerlessTemplateMissingResourceSection);
+
+            foreach (var field in resources.PropertyNames)
+            {
+                var resource = resources[field];
+                if (resource == null)
+                    continue;
+
+                var properties = resource["Properties"];
+                if (properties == null)
+                    continue;
+
+                var type = resource["Type"]?.ToString();
+                var updatableResource = new UpdatableResource(field, type, new JsonUpdatableResourceDataSource(properties));
+                if (!updatableResource.IsUpdatable)
+                    continue;
+
+                yield return updatableResource;
+            }
+        }
+
+        public class JsonUpdatableResourceDataSource : IUpdatableResourceDataSource
+        {
+            JsonData Properties { get; }
+
+            public JsonUpdatableResourceDataSource(JsonData properties)
+            {
+                this.Properties = properties;
+            }
+
+            public string GetValue(params string[] keyPath)
+            {
+                JsonData node = this.Properties;
+                foreach (var key in keyPath)
+                {
+                    if (node == null)
+                        return null;
+
+                    node = node[key];
+                }
+
+                return node?.ToString();
+            }
+
+            public void SetValue(string value, params string[] keyPath)
+            {
+                JsonData node = Properties;
+                for (int i = 0; i < keyPath.Length - 1; i++)
+                {
+                    var childNode = node[keyPath[i]];
+                    if (childNode == null)
+                    {
+                        childNode = new JsonData();
+                        node[keyPath[i]] = childNode;
+                    }
+                    node = childNode;
+                }
+
+                node[keyPath[keyPath.Length - 1]] = value;
+            }
+        }
+    }
+}

--- a/src/Amazon.Lambda.Tools/TemplateProcessor/TemplateProcessorManager.cs
+++ b/src/Amazon.Lambda.Tools/TemplateProcessor/TemplateProcessorManager.cs
@@ -35,7 +35,7 @@ namespace Amazon.Lambda.Tools.TemplateProcessor
         
         /// <summary>
         /// Options to use when a local path is pointing to the current directory. This is needed to maintain backwards compatibility
-        /// with the original version of the deploy-serverless and package-cu commands.
+        /// with the original version of the deploy-serverless and package-ci commands.
         /// </summary>
         DefaultLocationOption DefaultOptions { get; }
 
@@ -51,7 +51,7 @@ namespace Amazon.Lambda.Tools.TemplateProcessor
         /// <summary>
         /// 
         /// </summary>
-        /// <param name="templateDirectory">The diretory where the template was found.</param>
+        /// <param name="templateDirectory">The directory where the template was found.</param>
         /// <param name="templateBody">The template to search for updatable resources. The file isn't just read from
         /// templateDirectory because template substitutions might have occurred before this was executed.</param>
         /// <returns></returns>
@@ -193,7 +193,7 @@ namespace Amazon.Lambda.Tools.TemplateProcessor
                 LambdaUtilities.DetermineTargetFrameworkFromLambdaRuntime(field.Resource.LambdaRuntime);
 
             // If the project is in the same directory as the CloudFormation template then use any parameters
-            // there were specifed on the command to build the project.
+            // there were specified on the command to build the project.
             if (IsCurrentDirectory(field.GetLocalPath()))
             {
                 if (!string.IsNullOrEmpty(this.DefaultOptions.TargetFramework))
@@ -254,7 +254,7 @@ namespace Amazon.Lambda.Tools.TemplateProcessor
         }
 
         /// <summary>
-        /// Create the appropiate parser depending whether the template is JSON or YAML.
+        /// Create the appropriate parser depending whether the template is JSON or YAML.
         /// </summary>
         /// <param name="templateBody"></param>
         /// <returns></returns>

--- a/src/Amazon.Lambda.Tools/TemplateProcessor/TemplateProcessorManager.cs
+++ b/src/Amazon.Lambda.Tools/TemplateProcessor/TemplateProcessorManager.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Data;
 using System.IO;
+using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using Amazon.Common.DotNetCli.Tools;
@@ -8,27 +10,41 @@ using Amazon.S3;
 using Amazon.S3.Transfer;
 
 namespace Amazon.Lambda.Tools.TemplateProcessor
-{
+{    
     public class TemplateProcessorManager
     {
+        public class DefaultLocationOption
+        {
+            public string Configuration { get; set; }
+            public string TargetFramework { get; set; }
+            public string MSBuildParameters { get; set; }
+            public bool DisableVersionCheck { get; set; }
+            public string Package { get; set; }
+        }
+        
         public const string CF_TYPE_LAMBDA_FUNCTION = "AWS::Lambda::Function";
         public const string CF_TYPE_SERVERLESS_FUNCTION = "AWS::Serverless::Function";
 
         IToolLogger Logger { get; }
+        IAmazonS3 S3Client { get; }
         string S3Bucket { get; }
         string S3Prefix { get; }
-        IAmazonS3 S3Client { get; }
+        DefaultLocationOption DefaultOptions { get; }
 
-        public TemplateProcessorManager(IToolLogger logger, IAmazonS3 s3Client, string s3Bucket, string s3Prefix)
+        public TemplateProcessorManager(IToolLogger logger, IAmazonS3 s3Client, string s3Bucket, string s3Prefix, DefaultLocationOption defaultOptions)
         {
             this.Logger = logger;
             this.S3Client = s3Client;
             this.S3Bucket = s3Bucket;
             this.S3Prefix = s3Prefix;
+            this.DefaultOptions = defaultOptions;
         }
 
         public async Task<string> TransformTemplateAsync(string templateDirectory, string templateBody)
         {
+            if (File.Exists(templateDirectory))
+                templateDirectory = Path.GetDirectoryName(templateDirectory);
+            
             var cacheOfLocalPathsToS3Keys = new Dictionary<string, string>();
             var parser = CreateTemplateParser(templateBody);
 
@@ -40,12 +56,13 @@ namespace Amazon.Lambda.Tools.TemplateProcessor
                 string s3Key;
                 if(!cacheOfLocalPathsToS3Keys.TryGetValue(localPath, out s3Key))
                 {
+                    this.Logger?.WriteLine($"Initiate packaging of {updatableResource.GetLocalPath()} for resource {updatableResource.Name}");
                     s3Key = await ProcessUpdatableResourceAsync(templateDirectory, updatableResource);
                     cacheOfLocalPathsToS3Keys[localPath] = s3Key;
                 }
                 else
                 {
-                    this.Logger.WriteLine($"Using previous upload artifact s3://{this.S3Bucket}/{s3Key} for {updatableResource.Name}");
+                    this.Logger?.WriteLine($"Using previous upload artifact s3://{this.S3Bucket}/{s3Key} for resource {updatableResource.Name}");
                 }
 
                 updatableResource.SetS3Location(this.S3Bucket, s3Key);                
@@ -56,42 +73,76 @@ namespace Amazon.Lambda.Tools.TemplateProcessor
         }
 
 
-        public async Task<string> ProcessUpdatableResourceAsync(string templateDirectory, IUpdatableResource updatableResource)
+        private async Task<string> ProcessUpdatableResourceAsync(string templateDirectory, IUpdatableResource updatableResource)
         {
             var localPath = updatableResource.GetLocalPath();
 
             if (!Path.IsPathRooted(localPath))
                 localPath = Path.Combine(templateDirectory, localPath);
 
+            bool deleteArchiveAfterUploaded = false;
             string zipArchivePath = null;
             if(File.Exists(localPath) && string.Equals(Path.GetExtension(localPath), ".zip", StringComparison.OrdinalIgnoreCase))
-            {
+            {                
                 zipArchivePath = localPath;
+            }
+            else if (IsCurrentDirectory(updatableResource.GetLocalPath()) && !string.IsNullOrEmpty(this.DefaultOptions.Package))
+            {
+                zipArchivePath = this.DefaultOptions.Package;
             }
             else if(IsDotnetProjectDirectory(localPath))
             {
-                zipArchivePath = await PackageDotnetProjectAsync(updatableResource.Name, localPath);
+                zipArchivePath = await PackageDotnetProjectAsync(updatableResource, localPath);
+                deleteArchiveAfterUploaded = true;
             }
 
+            string s3Key;
             using (var stream = File.OpenRead(zipArchivePath))
             {
-                var s3Key = await Utilities.UploadToS3Async(this.Logger, this.S3Client, this.S3Bucket, this.S3Prefix, Path.GetFileName(zipArchivePath), stream);
-                return s3Key; 
+                s3Key = await Utilities.UploadToS3Async(this.Logger, this.S3Client, this.S3Bucket, this.S3Prefix, Path.GetFileName(zipArchivePath), stream);
             }
+
+            if (deleteArchiveAfterUploaded)
+            {
+                try
+                {
+                    File.Delete(zipArchivePath);
+                }
+                catch (Exception e)
+                {
+                    this.Logger?.WriteLine($"Warning: Unable to delete temporary archive, {zipArchivePath}, after uploading to S3: {e.Message}");
+                }
+            }
+
+            return s3Key;
         }
 
-        private async Task<string> PackageDotnetProjectAsync(string rootName, string location)
+        private async Task<string> PackageDotnetProjectAsync(IUpdatableResource updatableResource, string location)
         {
             var command = new Commands.PackageCommand(this.Logger, location, null);
-            var outputPackage = Path.Combine(Path.GetTempPath(), $"{rootName}-{DateTime.Now.Ticks}.zip");
+            var outputPackage = Path.Combine(Path.GetTempPath(), $"{updatableResource.Name}-{DateTime.Now.Ticks}.zip");
             command.OutputPackageFileName = outputPackage;
+            command.TargetFramework =
+                LambdaUtilities.DetermineTargetFrameworkFromLambdaRuntime(updatableResource.LambdaRuntime);
+
+            if (IsCurrentDirectory(updatableResource.GetLocalPath()))
+            {
+                if (!string.IsNullOrEmpty(this.DefaultOptions.TargetFramework))
+                    command.TargetFramework = this.DefaultOptions.TargetFramework;
+                
+                command.Configuration = this.DefaultOptions.Configuration;
+                command.DisableVersionCheck = this.DefaultOptions.DisableVersionCheck;
+                command.MSBuildParameters = this.DefaultOptions.MSBuildParameters;
+
+            }
+            
             if(!await command.ExecuteAsync())
             {
-                var message = $"Error packaging up project in {location} for CloudFormation resource {rootName}";
+                var message = $"Error packaging up project in {location} for CloudFormation resource {updatableResource.Name}";
                 if (command.LastToolsException != null)
                     message += $": {command.LastToolsException.Message}";
 
-                throw new LambdaToolsException($"Error packaging up project in {location} for CloudFormation resource {rootName}", ToolsException.CommonErrorCode.DotnetPublishFailed);
+                throw new LambdaToolsException(message, ToolsException.CommonErrorCode.DotnetPublishFailed);
             }
 
             return outputPackage;
@@ -102,14 +153,22 @@ namespace Amazon.Lambda.Tools.TemplateProcessor
             if (!Directory.Exists(localPath))
                 return false;
 
-            foreach(var projectType in LambdaUtilities.ValidProjectExtensions)
-            {
-                if(Directory.GetFiles(localPath, projectType, SearchOption.TopDirectoryOnly).Length != 0)
-                {
-                    return true;
-                }
-            }
+            var projectFiles = Directory.GetFiles(localPath, "*.??proj", SearchOption.TopDirectoryOnly)
+                .Where(x => LambdaUtilities.ValidProjectExtensions.Contains(Path.GetExtension(x))).ToArray();
+            
 
+            return projectFiles.Length == 1;
+        }
+
+        private bool IsCurrentDirectory(string localPath)
+        {
+            if (string.IsNullOrEmpty(localPath))
+                return true;
+            if (string.Equals(".", localPath))
+                return true;
+            if (string.Equals("./", localPath))
+                return true;
+            
             return false;
         }
 

--- a/src/Amazon.Lambda.Tools/TemplateProcessor/TemplateProcessorManager.cs
+++ b/src/Amazon.Lambda.Tools/TemplateProcessor/TemplateProcessorManager.cs
@@ -1,0 +1,96 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using System.Threading.Tasks;
+using Amazon.Common.DotNetCli.Tools;
+using Amazon.S3;
+using Amazon.S3.Transfer;
+
+namespace Amazon.Lambda.Tools.TemplateProcessor
+{
+    public class TemplateProcessorManager
+    {
+        public const string CF_TYPE_LAMBDA_FUNCTION = "AWS::Lambda::Function";
+        public const string CF_TYPE_SERVERLESS_FUNCTION = "AWS::Serverless::Function";
+
+        IToolLogger Logger { get; }
+        string S3Bucket { get; }
+        string S3Prefix { get; }
+        IAmazonS3 S3Client { get; }
+
+        public TemplateProcessorManager(IToolLogger logger, IAmazonS3 s3Client, string s3Bucket, string s3Prefix)
+        {
+            this.Logger = logger;
+            this.S3Client = s3Client;
+            this.S3Bucket = s3Bucket;
+            this.S3Prefix = s3Prefix;
+        }
+
+        public async Task<string> TransformTemplateAsync(string templateDirectory, string templateBody)
+        {
+            var parser = CreateTemplateParser(templateBody);
+
+            foreach(var updatableResource in parser.UpdatableResources())
+            {
+                await ProcessUpdatableResourceAsync(templateDirectory, updatableResource);                
+            }
+
+            var newTemplate = parser.GetUpdatedTemplate();
+            return newTemplate;
+        }
+
+        public async Task ProcessUpdatableResourceAsync(string templateDirectory, IUpdatableResource updatableResource)
+        {
+            var localPath = updatableResource.GetLocalPath();
+
+            if (!Path.IsPathRooted(localPath))
+                localPath = Path.Combine(templateDirectory, localPath);
+
+            string zipArchivePath = null;
+            if(File.Exists(localPath) && string.Equals(Path.GetExtension(localPath), ".zip", StringComparison.OrdinalIgnoreCase))
+            {
+                zipArchivePath = localPath;
+            }
+            else if(IsDotnetProjectDirectory(localPath))
+            {
+                
+            }
+
+            using (var stream = File.OpenRead(zipArchivePath))
+            {
+                var s3Key = await Utilities.UploadToS3Async(this.Logger, this.S3Client, this.S3Bucket, this.S3Prefix, Path.GetFileName(zipArchivePath), stream);
+                updatableResource.SetS3Location(this.S3Bucket, s3Key);
+            }
+        }
+
+        private bool IsDotnetProjectDirectory(string localPath)
+        {
+            if (!Directory.Exists(localPath))
+                return false;
+
+            foreach(var projectType in LambdaUtilities.ValidProjectExtensions)
+            {
+                if(Directory.GetFiles(localPath, projectType, SearchOption.TopDirectoryOnly).Length != 0)
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        public static ITemplateParser CreateTemplateParser(string templateBody)
+        {
+            switch (LambdaUtilities.DetermineTemplateFormat(templateBody))
+            {
+                case TemplateFormat.Json:
+                    return new JsonTemplateParser(templateBody);
+                case TemplateFormat.Yaml:
+                    return new YamlTemplateParser(templateBody);
+                default:
+                    throw new LambdaToolsException("Unable to determine template file format", LambdaToolsException.LambdaErrorCode.ServerlessTemplateParseError);
+            }
+        }
+    }
+}

--- a/src/Amazon.Lambda.Tools/TemplateProcessor/TemplateProcessorManager.cs
+++ b/src/Amazon.Lambda.Tools/TemplateProcessor/TemplateProcessorManager.cs
@@ -13,12 +13,30 @@ using Newtonsoft.Json.Schema;
 
 namespace Amazon.Lambda.Tools.TemplateProcessor
 {    
+    /// <summary>
+    /// This class is the entry point to traversing a CloudFormation template and looking for any resources that are pointing to local
+    /// paths. Those local paths are uploaded to S3 and the template is updated with the location in S3. Once this is complete this
+    /// template can be deployed to CloudFormation to create or update a stack.
+    /// </summary>
     public class TemplateProcessorManager
     {        
         IToolLogger Logger { get; }
         IAmazonS3 S3Client { get; }
+        
+        /// <summary>
+        /// The S3 bucket used to store all local paths in S3.
+        /// </summary>
         string S3Bucket { get; }
+        
+        /// <summary>
+        /// Prefix for any S3 objects uploaded to S3.
+        /// </summary>
         string S3Prefix { get; }
+        
+        /// <summary>
+        /// Options to use when a local path is pointing to the current directory. This is needed to maintain backwards compatibility
+        /// with the original version of the deploy-serverless and package-cu commands.
+        /// </summary>
         DefaultLocationOption DefaultOptions { get; }
 
         public TemplateProcessorManager(IToolLogger logger, IAmazonS3 s3Client, string s3Bucket, string s3Prefix, DefaultLocationOption defaultOptions)
@@ -30,12 +48,23 @@ namespace Amazon.Lambda.Tools.TemplateProcessor
             this.DefaultOptions = defaultOptions;
         }
 
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="templateDirectory">The diretory where the template was found.</param>
+        /// <param name="templateBody">The template to search for updatable resources. The file isn't just read from
+        /// templateDirectory because template substitutions might have occurred before this was executed.</param>
+        /// <returns></returns>
         public async Task<string> TransformTemplateAsync(string templateDirectory, string templateBody)
         {
+            // If templateDirectoruy is actually pointing the CloudFormation template then grab its root.
             if (File.Exists(templateDirectory))
                 templateDirectory = Path.GetDirectoryName(templateDirectory);
             
+            // Maintain a cache of local paths to S3 Keys so if the same local path is referred to for
+            // multiple Lambda functions it is only built and uploaded once.
             var cacheOfLocalPathsToS3Keys = new Dictionary<string, string>();
+            
             var parser = CreateTemplateParser(templateBody);
 
             foreach(var updatableResource in parser.UpdatableResources())
@@ -71,6 +100,14 @@ namespace Amazon.Lambda.Tools.TemplateProcessor
         }
 
 
+        /// <summary>
+        /// Determine the action to be done for the local path, like building a .NET Core package, then uploading the
+        /// package to S3. The S3 key is returned to be updated in the template.
+        /// </summary>
+        /// <param name="templateDirectory"></param>
+        /// <param name="field"></param>
+        /// <returns></returns>
+        /// <exception cref="LambdaToolsException"></exception>
         private async Task<string> ProcessUpdatableResourceAsync(string templateDirectory, IUpdateResourceField field)
         {
             var localPath = field.GetLocalPath();
@@ -79,19 +116,43 @@ namespace Amazon.Lambda.Tools.TemplateProcessor
                 localPath = Path.Combine(templateDirectory, localPath);
 
             bool deleteArchiveAfterUploaded = false;
-            string zipArchivePath = null;
+            string zipArchivePath;
             if(File.Exists(localPath))
             {                
                 zipArchivePath = localPath;
             }
+            // If IsCode is false then the local path needs to point to a file and not a directory. When IsCode is true
+            // it can point either to a file or a directory.
+            else if (!field.IsCode && !File.Exists(localPath))
+            {
+                throw new LambdaToolsException($"File that the field {field.Resource.Name}/{field.Name} is pointing doesn't exist", LambdaToolsException.LambdaErrorCode.ServerlessTemplateMissingLocalPath);                
+            }
+            else if (!Directory.Exists(localPath))
+            {
+                throw new LambdaToolsException($"Directory that the field {field.Resource.Name}/{field.Name} is pointing doesn't exist", LambdaToolsException.LambdaErrorCode.ServerlessTemplateMissingLocalPath);
+            }
+            // To maintain compatibility if the field is point to current directory or not set at all but a prepackaged zip archive is given
+            // then use it as the package source.
             else if (IsCurrentDirectory(field.GetLocalPath()) && !string.IsNullOrEmpty(this.DefaultOptions.Package))
             {
                 zipArchivePath = this.DefaultOptions.Package;
             }
-            else if(IsDotnetProjectDirectory(localPath))
+            else if(field.IsCode)
             {
-                zipArchivePath = await PackageDotnetProjectAsync(field, localPath);
-                deleteArchiveAfterUploaded = true;
+                if (IsDotnetProjectDirectory(localPath))
+                {
+                    zipArchivePath = await PackageDotnetProjectAsync(field, localPath);
+                }
+                else
+                {
+                    zipArchivePath = GenerateOutputZipFilename(field);
+                    LambdaPackager.BundleDirectory(zipArchivePath, localPath, false, this.Logger);                    
+                }
+                deleteArchiveAfterUploaded = true;                    
+            }
+            else
+            {
+                throw new LambdaToolsException($"Unable to determine package action for the field {field.Resource.Name}/{field.Name}", LambdaToolsException.LambdaErrorCode.ServerlessTemplateUnknownActionForLocalPath);
             }
 
             string s3Key;
@@ -100,6 +161,7 @@ namespace Amazon.Lambda.Tools.TemplateProcessor
                 s3Key = await Utilities.UploadToS3Async(this.Logger, this.S3Client, this.S3Bucket, this.S3Prefix, Path.GetFileName(zipArchivePath), stream);
             }
 
+            // Now that the temp zip file is uploaded to S3 clean up by deleting the temp file.
             if (deleteArchiveAfterUploaded)
             {
                 try
@@ -115,14 +177,23 @@ namespace Amazon.Lambda.Tools.TemplateProcessor
             return s3Key;
         }
 
+        /// <summary>
+        /// Executes the package command to create the deployment bundle for the .NET project and returns the path.
+        /// </summary>
+        /// <param name="field"></param>
+        /// <param name="location"></param>
+        /// <returns></returns>
+        /// <exception cref="LambdaToolsException"></exception>
         private async Task<string> PackageDotnetProjectAsync(IUpdateResourceField field, string location)
         {
             var command = new Commands.PackageCommand(this.Logger, location, null);
-            var outputPackage = Path.Combine(Path.GetTempPath(), $"{field.Resource.Name}-{DateTime.Now.Ticks}.zip");
+            var outputPackage = GenerateOutputZipFilename(field);
             command.OutputPackageFileName = outputPackage;
             command.TargetFramework =
                 LambdaUtilities.DetermineTargetFrameworkFromLambdaRuntime(field.Resource.LambdaRuntime);
 
+            // If the project is in the same directory as the CloudFormation template then use any parameters
+            // there were specifed on the command to build the project.
             if (IsCurrentDirectory(field.GetLocalPath()))
             {
                 if (!string.IsNullOrEmpty(this.DefaultOptions.TargetFramework))
@@ -131,7 +202,6 @@ namespace Amazon.Lambda.Tools.TemplateProcessor
                 command.Configuration = this.DefaultOptions.Configuration;
                 command.DisableVersionCheck = this.DefaultOptions.DisableVersionCheck;
                 command.MSBuildParameters = this.DefaultOptions.MSBuildParameters;
-
             }
             
             if(!await command.ExecuteAsync())
@@ -146,6 +216,17 @@ namespace Amazon.Lambda.Tools.TemplateProcessor
             return outputPackage;
         }
 
+        private static string GenerateOutputZipFilename(IUpdateResourceField field)
+        {
+            var outputPackage = Path.Combine(Path.GetTempPath(), $"{field.Resource.Name}-{field.Name}-{DateTime.Now.Ticks}.zip");
+            return outputPackage;
+        }
+
+        /// <summary>
+        /// Check to see if the directory contains a .NET project file.
+        /// </summary>
+        /// <param name="localPath"></param>
+        /// <returns></returns>
         private bool IsDotnetProjectDirectory(string localPath)
         {
             if (!Directory.Exists(localPath))
@@ -166,10 +247,18 @@ namespace Amazon.Lambda.Tools.TemplateProcessor
                 return true;
             if (string.Equals("./", localPath))
                 return true;
+            if (string.Equals(@".\", localPath))
+                return true;
             
             return false;
         }
 
+        /// <summary>
+        /// Create the appropiate parser depending whether the template is JSON or YAML.
+        /// </summary>
+        /// <param name="templateBody"></param>
+        /// <returns></returns>
+        /// <exception cref="LambdaToolsException"></exception>
         public static ITemplateParser CreateTemplateParser(string templateBody)
         {
             switch (LambdaUtilities.DetermineTemplateFormat(templateBody))

--- a/src/Amazon.Lambda.Tools/TemplateProcessor/TemplateProcessorManager.cs
+++ b/src/Amazon.Lambda.Tools/TemplateProcessor/TemplateProcessorManager.cs
@@ -118,8 +118,17 @@ namespace Amazon.Lambda.Tools.TemplateProcessor
             bool deleteArchiveAfterUploaded = false;
             string zipArchivePath;
             if(File.Exists(localPath))
-            {                
-                zipArchivePath = localPath;
+            {
+                if(field.IsCode && !string.Equals(Path.GetExtension(localPath), ".zip", StringComparison.OrdinalIgnoreCase))
+                {
+                    this.Logger.WriteLine($"Creating zip archive for {localPath} file");
+                    zipArchivePath = GenerateOutputZipFilename(field);
+                    LambdaPackager.BundleFiles(zipArchivePath, Path.GetDirectoryName(localPath), new string[] { localPath }, this.Logger);
+                }
+                else
+                {
+                    zipArchivePath = localPath;
+                }
             }
             // If IsCode is false then the local path needs to point to a file and not a directory. When IsCode is true
             // it can point either to a file or a directory.

--- a/src/Amazon.Lambda.Tools/TemplateProcessor/TemplateProcessorManager.cs
+++ b/src/Amazon.Lambda.Tools/TemplateProcessor/TemplateProcessorManager.cs
@@ -49,7 +49,9 @@ namespace Amazon.Lambda.Tools.TemplateProcessor
         }
 
         /// <summary>
-        /// 
+        /// Transforms the provided template by uploading to S3 any local resources the template is pointing to,
+        /// like .NET projects for a Lambda project, and then updating the CloudFormation resources to point to the
+        /// S3 locations.
         /// </summary>
         /// <param name="templateDirectory">The directory where the template was found.</param>
         /// <param name="templateBody">The template to search for updatable resources. The file isn't just read from
@@ -57,7 +59,7 @@ namespace Amazon.Lambda.Tools.TemplateProcessor
         /// <returns></returns>
         public async Task<string> TransformTemplateAsync(string templateDirectory, string templateBody)
         {
-            // If templateDirectoruy is actually pointing the CloudFormation template then grab its root.
+            // If templateDirectory is actually pointing the CloudFormation template then grab its root.
             if (File.Exists(templateDirectory))
                 templateDirectory = Path.GetDirectoryName(templateDirectory);
             
@@ -134,7 +136,7 @@ namespace Amazon.Lambda.Tools.TemplateProcessor
             // it can point either to a file or a directory.
             else if (!field.IsCode && !File.Exists(localPath))
             {
-                throw new LambdaToolsException($"File that the field {field.Resource.Name}/{field.Name} is pointing doesn't exist", LambdaToolsException.LambdaErrorCode.ServerlessTemplateMissingLocalPath);                
+                throw new LambdaToolsException($"File that the field {field.Resource.Name}/{field.Name} is pointing to doesn't exist", LambdaToolsException.LambdaErrorCode.ServerlessTemplateMissingLocalPath);                
             }
             else if (!Directory.Exists(localPath))
             {

--- a/src/Amazon.Lambda.Tools/TemplateProcessor/UpdatableResource.cs
+++ b/src/Amazon.Lambda.Tools/TemplateProcessor/UpdatableResource.cs
@@ -8,7 +8,10 @@ using System.Threading;
 namespace Amazon.Lambda.Tools.TemplateProcessor
 {
 
-    
+    /// <summary>
+    /// The updatable resource like a CloudFormation AWS::Lambda::Function. This class combines the UpdatableResourceDefinition
+    /// which identifies the fields that can be updated and IUpdatableResourceDataSource which abstracts the JSON or YAML definition.
+    /// </summary>
     public class UpdatableResource : IUpdatableResource
     {
         public string Name { get; }
@@ -45,6 +48,10 @@ namespace Amazon.Lambda.Tools.TemplateProcessor
                 this._resource = resource;
                 this.Field = field;
             }
+
+            public string Name => this.Field.Name;
+
+            public bool IsCode => this.Field.IsCode;
 
             public string GetLocalPath()
             {

--- a/src/Amazon.Lambda.Tools/TemplateProcessor/UpdatableResource.cs
+++ b/src/Amazon.Lambda.Tools/TemplateProcessor/UpdatableResource.cs
@@ -1,0 +1,71 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Amazon.Lambda.Tools.TemplateProcessor
+{
+    public class UpdatableResource : IUpdatableResource
+    {
+        public string Name { get; }
+        public string ResourceType { get; }
+        IUpdatableResourceDataSource DataSource { get; }
+
+        public UpdatableResource(string name, string resourceType, IUpdatableResourceDataSource dataSource)
+        {
+            this.Name = name;
+            this.ResourceType = resourceType;
+            this.DataSource = dataSource;
+        }
+
+        public string GetLocalPath()
+        {
+            if (string.Equals(this.ResourceType, TemplateProcessorManager.CF_TYPE_SERVERLESS_FUNCTION, StringComparison.Ordinal))
+            {
+                var localPath = this.DataSource.GetValue("CodeUri") ?? ".";
+                if (localPath.StartsWith("s3://"))
+                    return null;
+
+                return localPath;
+            }
+            else if (string.Equals(this.ResourceType, TemplateProcessorManager.CF_TYPE_LAMBDA_FUNCTION, StringComparison.Ordinal))
+            {
+                var bucket = this.DataSource.GetValue("Code", "S3Bucket");
+                if (!string.IsNullOrEmpty(bucket))
+                    return null;
+
+                return this.DataSource.GetValue("Code", "S3Key") ?? ".";
+            }
+
+            return null;
+        }
+
+        public void SetS3Location(string s3Bucket, string s3Key)
+        {
+            if (string.Equals(this.ResourceType, TemplateProcessorManager.CF_TYPE_SERVERLESS_FUNCTION, StringComparison.Ordinal))
+            {
+                var s3Url = $"s3://{s3Bucket}/{s3Key}";
+                this.DataSource.SetValue(s3Url, "CodeUri");
+            }
+            else if (string.Equals(this.ResourceType, TemplateProcessorManager.CF_TYPE_LAMBDA_FUNCTION, StringComparison.Ordinal))
+            {
+                this.DataSource.SetValue(s3Bucket, "Code", "S3Bucket");
+                this.DataSource.SetValue(s3Key, "Code", "S3Key");
+            }
+        }
+
+        public bool IsUpdatable
+        {
+            get
+            {
+                if ((string.Equals(this.ResourceType, TemplateProcessorManager.CF_TYPE_SERVERLESS_FUNCTION, StringComparison.Ordinal) ||
+                    string.Equals(this.ResourceType, TemplateProcessorManager.CF_TYPE_LAMBDA_FUNCTION, StringComparison.Ordinal)) && this.GetLocalPath() != null)
+                {
+                    return true;
+                }
+
+
+                return false;
+            }
+        }
+    }
+}

--- a/src/Amazon.Lambda.Tools/TemplateProcessor/UpdatableResource.cs
+++ b/src/Amazon.Lambda.Tools/TemplateProcessor/UpdatableResource.cs
@@ -17,6 +17,8 @@ namespace Amazon.Lambda.Tools.TemplateProcessor
             this.DataSource = dataSource;
         }
 
+        public string LambdaRuntime => this.DataSource.GetValue("Runtime");
+
         public string GetLocalPath()
         {
             if (string.Equals(this.ResourceType, TemplateProcessorManager.CF_TYPE_SERVERLESS_FUNCTION, StringComparison.Ordinal))

--- a/src/Amazon.Lambda.Tools/TemplateProcessor/UpdatableResourceDefinition.cs
+++ b/src/Amazon.Lambda.Tools/TemplateProcessor/UpdatableResourceDefinition.cs
@@ -95,7 +95,7 @@ namespace Amazon.Lambda.Tools.TemplateProcessor
             public Func<IUpdatableResourceDataSource, string> GetLocalPath { get; set; }
             
             /// <summary>
-            /// The Action that knows how to set the S3 location for the field into thje datasource.
+            /// The Action that knows how to set the S3 location for the field into this datasource.
             /// </summary>
             public Action<IUpdatableResourceDataSource, string, string> SetS3Location { get; set; }
 

--- a/src/Amazon.Lambda.Tools/TemplateProcessor/UpdatableResourceDefinition.cs
+++ b/src/Amazon.Lambda.Tools/TemplateProcessor/UpdatableResourceDefinition.cs
@@ -4,6 +4,9 @@ using System.Runtime.CompilerServices;
 
 namespace Amazon.Lambda.Tools.TemplateProcessor
 {
+    /// <summary>
+    /// Class that identifies the fields and the delegates to access those fields in a given IUpdatableResourceDataSource.
+    /// </summary>
     public class UpdatableResourceDefinition
     {
         public static readonly UpdatableResourceDefinition DEF_LAMBDA_FUNCTION = new UpdatableResourceDefinition(
@@ -47,7 +50,10 @@ namespace Amazon.Lambda.Tools.TemplateProcessor
             FieldDefinition.CreateFieldDefinitionUrlStyle(false, "TemplateUrl")
         );          
 
-        
+
+        /// <summary>
+        /// All of the known CloudFormation resources that have fields pointing to S3 locations that can be updated from a local path.
+        /// </summary>
         public static IDictionary<string, UpdatableResourceDefinition> ValidUpdatableResourceDefinitions = new
             Dictionary<string, UpdatableResourceDefinition>
             {
@@ -73,17 +79,38 @@ namespace Amazon.Lambda.Tools.TemplateProcessor
         
         public FieldDefinition[] Fields { get; }
 
+        
+        /// <summary>
+        /// FieldDefinition identity what fields in a CloudFormation resource can be updated and the delegates to retrieve
+        /// and set the information in the datasource.
+        /// </summary>
         public class FieldDefinition
         {
+            public string Name { get; set; }
             public bool IsCode { get; set; }
+            
+            /// <summary>
+            /// The Func that knows how to get the local path for the field from the datasource.
+            /// </summary>
             public Func<IUpdatableResourceDataSource, string> GetLocalPath { get; set; }
+            
+            /// <summary>
+            /// The Action that knows how to set the S3 location for the field into thje datasource.
+            /// </summary>
             public Action<IUpdatableResourceDataSource, string, string> SetS3Location { get; set; }
 
 
+            /// <summary>
+            /// Creates a field definition that is storing the S3 location as a S3 path like s3://mybucket/myfile.zip
+            /// </summary>
+            /// <param name="isCode"></param>
+            /// <param name="propertyName"></param>
+            /// <returns></returns>
             public static FieldDefinition CreateFieldDefinitionUrlStyle(bool isCode, string propertyName)
             {
                 return new FieldDefinition
                 {
+                    Name = propertyName,
                     IsCode = isCode,
                     GetLocalPath = (s) =>
                     {
@@ -110,10 +137,19 @@ namespace Amazon.Lambda.Tools.TemplateProcessor
                 };
             }
             
+            /// <summary>
+            /// Creates a field definition that is storing the S3 location using separate fields for bucket and key.
+            /// </summary>
+            /// <param name="isCode"></param>
+            /// <param name="containerName"></param>
+            /// <param name="s3BucketProperty"></param>
+            /// <param name="s3KeyProperty"></param>
+            /// <returns></returns>
             public static FieldDefinition CreateFieldDefinitionS3LocationStyle(bool isCode, string containerName, string s3BucketProperty, string s3KeyProperty)
             {
                 return new FieldDefinition
                 {
+                    Name = containerName,
                     IsCode = isCode,
                     GetLocalPath = (s) =>
                     {

--- a/src/Amazon.Lambda.Tools/TemplateProcessor/UpdatableResourceDefinition.cs
+++ b/src/Amazon.Lambda.Tools/TemplateProcessor/UpdatableResourceDefinition.cs
@@ -88,13 +88,16 @@ namespace Amazon.Lambda.Tools.TemplateProcessor
                     GetLocalPath = (s) =>
                     {
                         var localPath = s.GetValue(propertyName);
-                        if (string.IsNullOrEmpty(localPath) && isCode)
+                        if (string.IsNullOrEmpty(localPath))
                         {
-                            localPath = ".";
+                            if (isCode)
+                            {
+                                localPath = ".";                                
+                            }
                         }
                         else if (localPath.StartsWith("s3://"))
                         {
-                            return null;
+                            localPath = null;
                         }
 
                         return localPath;

--- a/src/Amazon.Lambda.Tools/TemplateProcessor/UpdatableResourceDefinition.cs
+++ b/src/Amazon.Lambda.Tools/TemplateProcessor/UpdatableResourceDefinition.cs
@@ -1,0 +1,138 @@
+using System;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+
+namespace Amazon.Lambda.Tools.TemplateProcessor
+{
+    public class UpdatableResourceDefinition
+    {
+        public static readonly UpdatableResourceDefinition DEF_LAMBDA_FUNCTION = new UpdatableResourceDefinition(
+            "AWS::Lambda::Function",
+            FieldDefinition.CreateFieldDefinitionS3LocationStyle(true, "Code", "S3Bucket", "S3Key")
+        );
+
+        public static readonly UpdatableResourceDefinition DEF_SERVERLESS_FUNCTION = new UpdatableResourceDefinition(
+            "AWS::Serverless::Function",
+            FieldDefinition.CreateFieldDefinitionUrlStyle(true, "CodeUri")
+        );
+
+        public static readonly UpdatableResourceDefinition DEF_APIGATEWAY_RESTAPI = new UpdatableResourceDefinition(
+            "AWS::ApiGateway::RestApi",
+            FieldDefinition.CreateFieldDefinitionS3LocationStyle(false, "BodyS3Location", "Bucket", "Key")
+        );
+        
+        public static readonly UpdatableResourceDefinition DEF_APPSYNC_GRAPHQLSCHEMA = new UpdatableResourceDefinition(
+            "AWS::AppSync::GraphQLSchema",
+            FieldDefinition.CreateFieldDefinitionUrlStyle(false, "DefinitionS3Location")
+        );        
+        
+        public static readonly UpdatableResourceDefinition DEF_APPSYNC_RESOLVER = new UpdatableResourceDefinition(
+            "AWS::AppSync::Resolver",
+            FieldDefinition.CreateFieldDefinitionUrlStyle(false, "ResponseMappingTemplateS3Location"),
+            FieldDefinition.CreateFieldDefinitionUrlStyle(false, "RequestMappingTemplateS3Location")
+        );  
+        
+        public static readonly UpdatableResourceDefinition DEF_SERVERLESS_API = new UpdatableResourceDefinition(
+            "AWS::Serverless::Api",
+            FieldDefinition.CreateFieldDefinitionUrlStyle(false, "DefinitionUri")
+        );   
+        
+        public static readonly UpdatableResourceDefinition DEF_ELASTICBEANSTALK_APPLICATIONVERSION = new UpdatableResourceDefinition(
+            "AWS::ElasticBeanstalk::ApplicationVersion",
+            FieldDefinition.CreateFieldDefinitionS3LocationStyle(false, "SourceBundle", "S3Bucket", "S3Key")
+        );  
+        
+        public static readonly UpdatableResourceDefinition DEF_CLOUDFORMATION_STACK = new UpdatableResourceDefinition(
+            "AWS::CloudFormation::Stack",
+            FieldDefinition.CreateFieldDefinitionUrlStyle(false, "TemplateUrl")
+        );          
+
+        
+        public static IDictionary<string, UpdatableResourceDefinition> ValidUpdatableResourceDefinitions = new
+            Dictionary<string, UpdatableResourceDefinition>
+            {
+                {DEF_APIGATEWAY_RESTAPI.Name, DEF_APIGATEWAY_RESTAPI},
+                {DEF_LAMBDA_FUNCTION.Name, DEF_LAMBDA_FUNCTION},
+                {DEF_SERVERLESS_FUNCTION.Name, DEF_SERVERLESS_FUNCTION},
+                {DEF_APPSYNC_GRAPHQLSCHEMA.Name, DEF_APPSYNC_GRAPHQLSCHEMA},
+                {DEF_APPSYNC_RESOLVER.Name, DEF_APPSYNC_RESOLVER},
+                {DEF_SERVERLESS_API.Name, DEF_SERVERLESS_API},
+                {DEF_ELASTICBEANSTALK_APPLICATIONVERSION.Name, DEF_ELASTICBEANSTALK_APPLICATIONVERSION},
+                {DEF_CLOUDFORMATION_STACK.Name, DEF_CLOUDFORMATION_STACK},
+            };
+
+
+        public UpdatableResourceDefinition(string name, params FieldDefinition[] fields)
+        {
+            this.Name = name;
+            this.Fields = fields;
+        }
+        
+        
+        public string Name { get; }
+        
+        public FieldDefinition[] Fields { get; }
+
+        public class FieldDefinition
+        {
+            public bool IsCode { get; set; }
+            public Func<IUpdatableResourceDataSource, string> GetLocalPath { get; set; }
+            public Action<IUpdatableResourceDataSource, string, string> SetS3Location { get; set; }
+
+
+            public static FieldDefinition CreateFieldDefinitionUrlStyle(bool isCode, string propertyName)
+            {
+                return new FieldDefinition
+                {
+                    IsCode = isCode,
+                    GetLocalPath = (s) =>
+                    {
+                        var localPath = s.GetValue(propertyName);
+                        if (string.IsNullOrEmpty(localPath) && isCode)
+                        {
+                            localPath = ".";
+                        }
+                        else if (localPath.StartsWith("s3://"))
+                        {
+                            return null;
+                        }
+
+                        return localPath;
+                    },
+                    SetS3Location = (s, b, k) =>
+                    {
+                        var s3Url = $"s3://{b}/{k}";
+                        s.SetValue(s3Url, propertyName);
+                    }
+                };
+            }
+            
+            public static FieldDefinition CreateFieldDefinitionS3LocationStyle(bool isCode, string containerName, string s3BucketProperty, string s3KeyProperty)
+            {
+                return new FieldDefinition
+                {
+                    IsCode = isCode,
+                    GetLocalPath = (s) =>
+                    {
+                        var bucket = s.GetValue(containerName, s3BucketProperty);
+                        if (!string.IsNullOrEmpty(bucket))
+                            return null;
+
+                        var value = s.GetValue(containerName, s3KeyProperty);
+                        if (string.IsNullOrEmpty(value) && isCode)
+                        {
+                            value = ".";
+                        }
+
+                        return value;
+                    },
+                    SetS3Location = (s, b, k) =>
+                    {
+                        s.SetValue(b, containerName, s3BucketProperty);
+                        s.SetValue(k, containerName, s3KeyProperty);
+                    }
+                };
+            }            
+        }
+    }
+}

--- a/src/Amazon.Lambda.Tools/TemplateProcessor/YamlTemplateParser.cs
+++ b/src/Amazon.Lambda.Tools/TemplateProcessor/YamlTemplateParser.cs
@@ -1,0 +1,112 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using YamlDotNet.RepresentationModel;
+
+namespace Amazon.Lambda.Tools.TemplateProcessor
+{
+    public class YamlTemplateParser : ITemplateParser
+    {
+        YamlStream Yaml { get; }
+        public YamlTemplateParser(string templateBody)
+        {
+            var input = new StringReader(templateBody);
+
+            // Load the stream
+            this.Yaml = new YamlStream();
+            this.Yaml.Load(input);
+        }
+
+        public string GetUpdatedTemplate()
+        {
+            var myText = new StringWriter();
+            this.Yaml.Save(myText);
+
+            return myText.ToString();
+        }
+
+        public IEnumerable<IUpdatableResource> UpdatableResources()
+        {
+            var root = (YamlMappingNode)this.Yaml.Documents[0].RootNode;
+
+            if (root == null)
+                throw new LambdaToolsException("CloudFormation template does not define any AWS resources", LambdaToolsException.LambdaErrorCode.ServerlessTemplateMissingResourceSection);
+
+            var resourcesKey = new YamlScalarNode("Resources");
+
+            if (!root.Children.ContainsKey(resourcesKey))
+                throw new LambdaToolsException("CloudFormation template does not define any AWS resources", LambdaToolsException.LambdaErrorCode.ServerlessTemplateMissingResourceSection);
+
+            var resources = (YamlMappingNode)root.Children[resourcesKey];
+
+            foreach (var resource in resources.Children)
+            {
+                var resourceBody = (YamlMappingNode)resource.Value;
+                var type = (YamlScalarNode)resourceBody.Children[new YamlScalarNode("Type")];
+                var properties = (YamlMappingNode)resourceBody.Children[new YamlScalarNode("Properties")];
+
+                if (properties == null) continue;
+                if (type == null) continue;
+
+                var updatableResource = new UpdatableResource(resource.Key.ToString(), type.Value, new YamlUpdatableResourceDataSource(properties));
+                if (!updatableResource.IsUpdatable)
+                    continue;
+
+                yield return updatableResource;
+            }
+
+        }
+
+        public class YamlUpdatableResourceDataSource : IUpdatableResourceDataSource
+        {
+            YamlMappingNode Properties { get; }
+
+            public YamlUpdatableResourceDataSource(YamlMappingNode properties)
+            {
+                this.Properties = properties;
+            }
+
+            public string GetValue(params string[] keyPath)
+            {
+                YamlNode node = this.Properties;
+                foreach (var key in keyPath)
+                {
+                    if (node == null || !(node is YamlMappingNode))
+                        return null;
+
+                    var mappingNode = ((YamlMappingNode)node);
+                    if (!mappingNode.Children.ContainsKey(key))
+                        return null;
+
+                    node = mappingNode.Children[key];
+                }
+
+                if (node is YamlScalarNode)
+                {
+                    return ((YamlScalarNode)node).Value;
+                }
+
+                return null;
+            }
+
+            public void SetValue(string value, params string[] keyPath)
+            {
+                YamlMappingNode node = this.Properties;
+                for (int i = 0; i < keyPath.Length - 1; i++)
+                {
+                    var childNode = node.Children.ContainsKey(keyPath[i]) ? node[keyPath[i]] as YamlMappingNode : null;
+                    if (childNode == null)
+                    {
+                        childNode = new YamlMappingNode();
+                        ((YamlMappingNode)node).Children.Add(keyPath[i], childNode);
+                    }
+                    node = childNode;
+                }
+
+                node.Children.Remove(keyPath[keyPath.Length - 1]);
+                node.Children.Add(keyPath[keyPath.Length - 1], new YamlScalarNode(value));
+            }
+        }
+    }
+}

--- a/src/Amazon.Lambda.Tools/TemplateProcessor/YamlTemplateParser.cs
+++ b/src/Amazon.Lambda.Tools/TemplateProcessor/YamlTemplateParser.cs
@@ -49,10 +49,14 @@ namespace Amazon.Lambda.Tools.TemplateProcessor
                 if (properties == null) continue;
                 if (type == null) continue;
 
-                var updatableResource = new UpdatableResource(resource.Key.ToString(), type.Value, new YamlUpdatableResourceDataSource(properties));
-                if (!updatableResource.IsUpdatable)
+                
+                UpdatableResourceDefinition updatableResourceDefinition;
+                if (!UpdatableResourceDefinition.ValidUpdatableResourceDefinitions.TryGetValue(type.Value,
+                    out updatableResourceDefinition))
                     continue;
-
+                
+                var updatableResource = new UpdatableResource(resource.Key.ToString(), updatableResourceDefinition, new YamlUpdatableResourceDataSource(properties));
+                
                 yield return updatableResource;
             }
 

--- a/src/Amazon.Lambda.Tools/TemplateProcessor/YamlTemplateParser.cs
+++ b/src/Amazon.Lambda.Tools/TemplateProcessor/YamlTemplateParser.cs
@@ -6,6 +6,9 @@ using YamlDotNet.RepresentationModel;
 
 namespace Amazon.Lambda.Tools.TemplateProcessor
 {
+    /// <summary>
+    /// JSON implementation of ITemplateParser
+    /// </summary>
     public class YamlTemplateParser : ITemplateParser
     {
         YamlStream Yaml { get; }
@@ -62,6 +65,9 @@ namespace Amazon.Lambda.Tools.TemplateProcessor
 
         }
 
+        /// <summary>
+        /// The JSON implementation of IUpdatableResourceDataSource
+        /// </summary>
         public class YamlUpdatableResourceDataSource : IUpdatableResourceDataSource
         {
             YamlMappingNode Properties { get; }

--- a/test/Amazon.Lambda.Tools.Test/Amazon.Lambda.Tools.Test.csproj
+++ b/test/Amazon.Lambda.Tools.Test/Amazon.Lambda.Tools.Test.csproj
@@ -52,9 +52,9 @@
     </Content>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="AWSSDK.CloudFormation" Version="3.3.11.5" />
-    <PackageReference Include="AWSSDK.Lambda" Version="3.3.15.1" />
-    <PackageReference Include="AWSSDK.SQS" Version="3.3.3.12" />
+    <PackageReference Include="AWSSDK.CloudFormation" Version="3.3.11.15" />
+    <PackageReference Include="AWSSDK.Lambda" Version="3.3.16.5" />
+    <PackageReference Include="AWSSDK.SQS" Version="3.3.3.22" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
     <PackageReference Include="System.IO.Compression.ZipFile" Version="4.0.1" />

--- a/test/Amazon.Lambda.Tools.Test/ConvertToMapOfFilesTests.cs
+++ b/test/Amazon.Lambda.Tools.Test/ConvertToMapOfFilesTests.cs
@@ -1,0 +1,52 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Runtime.InteropServices;
+using System.Text;
+
+using Xunit;
+
+namespace Amazon.Lambda.Tools.Test
+{
+    public class ConvertToMapOfFilesTests
+    {
+
+
+
+        [Theory]
+        [InlineData("app.js")]
+        [InlineData("./app.js")]
+        [InlineData("dir/app.js")]
+        [InlineData("./dir/app.js")]
+        public void FileCombinations(string file)
+        {
+            var files = LambdaPackager.ConvertToMapOfFiles(GetTestRoot(), new string[] { file });
+            Assert.Single(files);
+
+            Assert.True(files.ContainsKey(file));
+            Assert.Equal($"{GetTestRoot()}/{file}", files[file]);
+        }
+
+        [Theory]
+        [InlineData("app.js")]
+        [InlineData("./app.js")]
+        [InlineData("dir/app.js")]
+        [InlineData("./dir/app.js")]
+        public void RootPathWithTrailingSlash(string file)
+        {
+            var files = LambdaPackager.ConvertToMapOfFiles(GetTestRoot() + "/", new string[] { file });
+            Assert.Single(files);
+
+            Assert.True(files.ContainsKey(file));
+            Assert.Equal($"{GetTestRoot()}/{file}", files[file]);
+        }
+
+
+        public static string GetTestRoot()
+        {
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+                return @"c:/temp";
+
+            return "/home/norm/temp";
+        }
+    }
+}

--- a/test/Amazon.Lambda.Tools.Test/TemplateParserTests.cs
+++ b/test/Amazon.Lambda.Tools.Test/TemplateParserTests.cs
@@ -274,6 +274,94 @@ namespace Amazon.Lambda.Tools.Test
 
             Assert.Null(resource.Fields[0].GetLocalPath());
         }
+        
+        [Fact]
+        public void ApiGatewayApi_GetCurrentDirectoryForWithNullCode()
+        {
+            var dataSource = new FakeUpdatableResourceDataSource(
+                new Dictionary<string, string>
+                {
+                });
+            var resource = new UpdatableResource("TestResource", UpdatableResourceDefinition.DEF_SERVERLESS_API, dataSource);
+
+            Assert.Null(resource.Fields[0].GetLocalPath());
+        }
+        
+        [Theory]
+        [InlineData("/home/swagger.yml")]
+        public void ApiGatewayApi_GetLocalPathAndEmptyS3Bucket(string localPath)
+        {
+            var dataSource = new FakeUpdatableResourceDataSource(
+                new Dictionary<string, string>
+                {
+                    {"BodyS3Location/Key", localPath }
+                });
+            var resource = new UpdatableResource("TestResource", UpdatableResourceDefinition.DEF_APIGATEWAY_RESTAPI, dataSource);
+
+            Assert.Equal(localPath, resource.Fields[0].GetLocalPath());
+
+            resource.Fields[0].SetS3Location("my-bucket", localPath);
+            Assert.Equal("my-bucket", dataSource.GetValue("BodyS3Location/Bucket"));
+            Assert.Equal(localPath, dataSource.GetValue("BodyS3Location/Key"));
+        }
+        
+        [Fact]
+        public void AppSyncGraphQl_GetCurrentDirectoryForWithNullCode()
+        {
+            var dataSource = new FakeUpdatableResourceDataSource(
+                new Dictionary<string, string>
+                {
+                });
+            var resource = new UpdatableResource("TestResource", UpdatableResourceDefinition.DEF_APPSYNC_GRAPHQLSCHEMA, dataSource);
+
+            Assert.Null(resource.Fields[0].GetLocalPath());
+        }
+        
+        [Theory]
+        [InlineData("/home/swagger.yml")]
+        public void AppSyncGraphQl_GetLocalPathAndEmptyS3Bucket(string localPath)
+        {
+            var dataSource = new FakeUpdatableResourceDataSource(
+                new Dictionary<string, string>
+                {
+                    {"DefinitionS3Location", localPath }
+                });
+            var resource = new UpdatableResource("TestResource", UpdatableResourceDefinition.DEF_APPSYNC_GRAPHQLSCHEMA, dataSource);
+
+            Assert.Equal(localPath, resource.Fields[0].GetLocalPath());
+
+            resource.Fields[0].SetS3Location("my-bucket", "swagger.yml");
+            Assert.Equal("s3://my-bucket/swagger.yml", dataSource.GetValue("DefinitionS3Location"));
+        }
+        
+        [Fact]
+        public void ServerlessApi_GetCurrentDirectoryForWithNullCode()
+        {
+            var dataSource = new FakeUpdatableResourceDataSource(
+                new Dictionary<string, string>
+                {
+                });
+            var resource = new UpdatableResource("TestResource", UpdatableResourceDefinition.DEF_APIGATEWAY_RESTAPI, dataSource);
+
+            Assert.Null(resource.Fields[0].GetLocalPath());
+        }
+        
+        [Theory]
+        [InlineData("/home/swagger.yml")]
+        public void ServerlessApi_GetLocalPathAndEmptyS3Bucket(string localPath)
+        {
+            var dataSource = new FakeUpdatableResourceDataSource(
+                new Dictionary<string, string>
+                {
+                    {"DefinitionUri", localPath }
+                });
+            var resource = new UpdatableResource("TestResource", UpdatableResourceDefinition.DEF_SERVERLESS_API, dataSource);
+
+            Assert.Equal(localPath, resource.Fields[0].GetLocalPath());
+
+            resource.Fields[0].SetS3Location("my-bucket", "swagger.yml");
+            Assert.Equal("s3://my-bucket/swagger.yml", dataSource.GetValue("DefinitionUri"));
+        }
 
 
         public class FakeUpdatableResourceDataSource : IUpdatableResourceDataSource

--- a/test/Amazon.Lambda.Tools.Test/TemplateParserTests.cs
+++ b/test/Amazon.Lambda.Tools.Test/TemplateParserTests.cs
@@ -1,0 +1,313 @@
+﻿using System.Collections.Generic;
+using System.IO;
+using System.Reflection;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+using Xunit;
+
+using Amazon.Lambda.Tools.TemplateProcessor;
+using ThirdParty.Json.LitJson;
+using YamlDotNet.RepresentationModel;
+
+namespace Amazon.Lambda.Tools.Test
+{
+    public class TemplateParserTests
+    {
+        [Fact]
+        public void DetermineJsonReader()
+        {
+            Assert.IsType<JsonTemplateParser>(TemplateProcessorManager.CreateTemplateParser("{\"AWSTemplateFormatVersion\" : \"2010-09-09\"}"));
+            Assert.IsType<JsonTemplateParser>(TemplateProcessorManager.CreateTemplateParser("\t\t{\"AWSTemplateFormatVersion\" : \"2010-09-09\"}"));
+            Assert.IsType<JsonTemplateParser>(TemplateProcessorManager.CreateTemplateParser("\n{\"AWSTemplateFormatVersion\" : \"2010-09-09\"}"));
+        }
+
+        [Fact]
+        public void DetermineYamlReader()
+        {
+            Assert.IsType<YamlTemplateParser>(TemplateProcessorManager.CreateTemplateParser("AWSTemplateFormatVersion: \"2010-09-09\""));
+            Assert.IsType<YamlTemplateParser>(TemplateProcessorManager.CreateTemplateParser("-"));
+        }
+
+        [Theory]
+        [MemberData(nameof(GetAndSetValuesOnRootData))]
+        public void GetAndSetValuesOnRoot(IUpdatableResourceDataSource source)
+        {
+            Assert.Equal("/home/code", source.GetValue("CodeUri"));
+
+            source.SetValue("s3://my-bucket/my-key", "CodeUri");
+            Assert.Equal("s3://my-bucket/my-key", source.GetValue("CodeUri"));
+        }
+
+        public static IEnumerable<object[]> GetAndSetValuesOnRootData()
+        {
+            var list = new List<object[]>();
+            {
+                var rootData = new JsonData();
+                rootData["CodeUri"] = "/home/code";
+                var source = new JsonTemplateParser.JsonUpdatableResourceDataSource(rootData);
+                list.Add(new object[] { source });
+            }
+            {
+                var rootData = new YamlMappingNode();
+                rootData.Children.Add("CodeUri", new YamlScalarNode("/home/code"));
+
+                var source = new YamlTemplateParser.YamlUpdatableResourceDataSource(rootData);
+                list.Add(new object[] { source });
+            }
+
+            return list;
+        }
+
+
+        [Theory]
+        [MemberData(nameof(GetAndSetValuesOnChildOnObjectData))]
+        public void GetAndSetValuesOnChildOnObject(IUpdatableResourceDataSource source)
+        {
+            Assert.Equal("/currentProject", source.GetValue("Code", "S3Key"));
+
+            source.SetValue("my-key", "Code", "S3Key");
+            Assert.Equal("my-key", source.GetValue("Code", "S3Key"));
+        }
+
+        public static IEnumerable<object[]> GetAndSetValuesOnChildOnObjectData()
+        {
+            var list = new List<object[]>();
+            {
+                var codeData = new JsonData();
+                codeData["S3Bucket"] = "";
+                codeData["S3Key"] = "/currentProject";
+
+                var rootData = new JsonData();
+                rootData["Code"] = codeData;
+
+                var source = new JsonTemplateParser.JsonUpdatableResourceDataSource(rootData);
+                list.Add(new object[] { source });
+            }
+            {
+                var codeData = new YamlMappingNode();
+                codeData.Children.Add("S3Bucket", new YamlScalarNode(""));
+                codeData.Children.Add("S3Key", new YamlScalarNode("/currentProject"));
+
+                var rootData = new YamlMappingNode();
+                rootData.Children.Add("Code", codeData);
+
+                var source = new YamlTemplateParser.YamlUpdatableResourceDataSource(rootData);
+                list.Add(new object[] { source });
+            }
+
+            return list;
+        }
+
+        [Theory]
+        [MemberData(nameof(GetNullValueAndSetValuesOnRootOnObjectData))]
+        public void GetNullValueAndSetValuesOnRootOnObject(IUpdatableResourceDataSource source)
+        {
+            Assert.Null(source.GetValue("CodeUri"));
+
+            source.SetValue("my-key", "CodeUri");
+            Assert.Equal("my-key", source.GetValue("CodeUri"));
+        }
+
+        public static IEnumerable<object[]> GetNullValueAndSetValuesOnRootOnObjectData()
+        {
+            var list = new List<object[]>();
+            {
+                var rootData = new JsonData();
+
+                var source = new JsonTemplateParser.JsonUpdatableResourceDataSource(rootData);
+                list.Add(new object[] { source });
+            }
+            {
+                var rootData = new YamlMappingNode();
+
+                var source = new YamlTemplateParser.YamlUpdatableResourceDataSource(rootData);
+                list.Add(new object[] { source });
+            }
+
+            return list;
+        }
+
+        [Theory]
+        [MemberData(nameof(GetNullValueAndSetValuesOnChildOnObjectData))]
+        public void GetNullValueAndSetValuesOnChildOnObject(IUpdatableResourceDataSource source)
+        {
+            Assert.Null(source.GetValue("Code", "S3Key"));
+
+            source.SetValue("my-key", "Code", "S3Key");
+            Assert.Equal("my-key", source.GetValue("Code", "S3Key"));
+        }
+
+        public static IEnumerable<object[]> GetNullValueAndSetValuesOnChildOnObjectData()
+        {
+            var list = new List<object[]>();
+            {
+                var rootData = new JsonData();
+
+                var source = new JsonTemplateParser.JsonUpdatableResourceDataSource(rootData);
+                list.Add(new object[] { source });
+            }
+            {
+                var rootData = new YamlMappingNode();
+
+                var source = new YamlTemplateParser.YamlUpdatableResourceDataSource(rootData);
+                list.Add(new object[] { source });
+            }
+
+            return list;
+        }
+
+
+        [Fact]
+        public void ServerlessFunction_GetCurrentDirectoryForWithNullCodeUri()
+        {
+            var dataSource = new FakeUpdatableResourceDataSource(
+                                    new Dictionary<string, string>
+                                    {
+                                    });
+            var resource = new UpdatableResource("TestResource", TemplateProcessorManager.CF_TYPE_SERVERLESS_FUNCTION, dataSource);
+
+
+
+            Assert.True(resource.IsUpdatable);
+            Assert.Equal(".", resource.GetLocalPath());
+
+            resource.SetS3Location("my-bucket", "my.zip");
+            Assert.Equal("s3://my-bucket/my.zip", dataSource.GetValue("CodeUri"));
+        }
+
+        [Theory]
+        [InlineData(".")]
+        [InlineData("/home")]
+        public void ServerlessFunction_GetLocalPath(string localPath)
+        {
+            var dataSource = new FakeUpdatableResourceDataSource(
+                                    new Dictionary<string, string>
+                                    {
+                                        {"CodeUri", localPath }
+                                    });
+            var resource = new UpdatableResource("TestResource", TemplateProcessorManager.CF_TYPE_SERVERLESS_FUNCTION, dataSource);
+
+            Assert.True(resource.IsUpdatable);
+            Assert.Equal(localPath, resource.GetLocalPath());
+
+            resource.SetS3Location("my-bucket", "my.zip");
+            Assert.Equal("s3://my-bucket/my.zip", dataSource.GetValue("CodeUri"));
+        }
+
+        [Fact]
+        public void ServerlessFunction_NotUpdatableBecausePointAtAlreadyS3()
+        {
+            var dataSource = new FakeUpdatableResourceDataSource(
+                                    new Dictionary<string, string>
+                                    {
+                                        {"CodeUri", "s3://my-bucket/my.zip" }
+                                    });
+            var resource = new UpdatableResource("TestResource", TemplateProcessorManager.CF_TYPE_SERVERLESS_FUNCTION, dataSource);
+
+            Assert.False(resource.IsUpdatable);
+        }
+
+        [Fact]
+        public void LambdaFunction_GetCurrentDirectoryForWithNullCode()
+        {
+            var dataSource = new FakeUpdatableResourceDataSource(
+                                    new Dictionary<string, string>
+                                    {
+                                    });
+            var resource = new UpdatableResource("TestResource", TemplateProcessorManager.CF_TYPE_LAMBDA_FUNCTION, dataSource);
+
+            Assert.True(resource.IsUpdatable);
+            Assert.Equal(".", resource.GetLocalPath());
+
+            resource.SetS3Location("my-bucket", "my.zip");
+            Assert.Equal("my-bucket", dataSource.GetValue("Code/S3Bucket"));
+            Assert.Equal("my.zip", dataSource.GetValue("Code/S3Key"));
+        }
+
+        [Theory]
+        [InlineData(".")]
+        [InlineData("/home")]
+        public void LambdaFunction_GetLocalPath(string localPath)
+        {
+            var dataSource = new FakeUpdatableResourceDataSource(
+                                    new Dictionary<string, string>
+                                    {
+                                        {"Code/S3Key", localPath }
+                                    });
+            var resource = new UpdatableResource("TestResource", TemplateProcessorManager.CF_TYPE_LAMBDA_FUNCTION, dataSource);
+
+            Assert.True(resource.IsUpdatable);
+            Assert.Equal(localPath, resource.GetLocalPath());
+
+            resource.SetS3Location("my-bucket", "my.zip");
+            Assert.Equal("my-bucket", dataSource.GetValue("Code/S3Bucket"));
+            Assert.Equal("my.zip", dataSource.GetValue("Code/S3Key"));
+        }
+
+        [Theory]
+        [InlineData(".")]
+        [InlineData("/home")]
+        public void LambdaFunction_GetLocalPathAndEmptyS3Bucket(string localPath)
+        {
+            var dataSource = new FakeUpdatableResourceDataSource(
+                                    new Dictionary<string, string>
+                                    {
+                                        {"Code/S3Bucket", "" },
+                                        {"Code/S3Key", localPath }
+                                    });
+            var resource = new UpdatableResource("TestResource", TemplateProcessorManager.CF_TYPE_LAMBDA_FUNCTION, dataSource);
+
+            Assert.True(resource.IsUpdatable);
+            Assert.Equal(localPath, resource.GetLocalPath());
+
+            resource.SetS3Location("my-bucket", "my.zip");
+            Assert.Equal("my-bucket", dataSource.GetValue("Code/S3Bucket"));
+            Assert.Equal("my.zip", dataSource.GetValue("Code/S3Key"));
+        }
+
+        [Fact]
+        public void LambdaFunction_NotUpdatableBecausePointAtAlreadyS3()
+        {
+            var dataSource = new FakeUpdatableResourceDataSource(
+                                    new Dictionary<string, string>
+                                    {
+                                        {"Code/S3Bucket", "my-bucket" },
+                                        {"Code/S3Key", "my.zip" }
+                                    });
+            var resource = new UpdatableResource("TestResource", TemplateProcessorManager.CF_TYPE_LAMBDA_FUNCTION, dataSource);
+
+            Assert.False(resource.IsUpdatable);
+        }
+
+
+        public class FakeUpdatableResourceDataSource : IUpdatableResourceDataSource
+        {
+            IDictionary<string, string> Values { get; }
+
+            public FakeUpdatableResourceDataSource()
+            {
+                Values = new Dictionary<string, string>();
+            }
+
+            public FakeUpdatableResourceDataSource(IDictionary<string, string> values)
+            {
+                this.Values = values;
+            }
+
+            public string GetValue(params string[] keyPath)
+            {
+                var key = string.Join("/", keyPath);
+                if (Values.TryGetValue(key, out var value))
+                    return value;
+                return null;
+            }
+
+            public void SetValue(string value, params string[] keyPath)
+            {
+                var key = string.Join("/", keyPath);
+                Values[key] = value;
+            }
+        }
+    }
+}

--- a/test/Amazon.Lambda.Tools.Test/TemplateParserTests.cs
+++ b/test/Amazon.Lambda.Tools.Test/TemplateParserTests.cs
@@ -165,14 +165,13 @@ namespace Amazon.Lambda.Tools.Test
                                     new Dictionary<string, string>
                                     {
                                     });
-            var resource = new UpdatableResource("TestResource", TemplateProcessorManager.CF_TYPE_SERVERLESS_FUNCTION, dataSource);
+            var resource = new UpdatableResource("TestResource", UpdatableResourceDefinition.DEF_SERVERLESS_FUNCTION, dataSource);
 
 
 
-            Assert.True(resource.IsUpdatable);
-            Assert.Equal(".", resource.GetLocalPath());
+            Assert.Equal(".", resource.Fields[0].GetLocalPath());
 
-            resource.SetS3Location("my-bucket", "my.zip");
+            resource.Fields[0].SetS3Location("my-bucket", "my.zip");
             Assert.Equal("s3://my-bucket/my.zip", dataSource.GetValue("CodeUri"));
         }
 
@@ -186,12 +185,11 @@ namespace Amazon.Lambda.Tools.Test
                                     {
                                         {"CodeUri", localPath }
                                     });
-            var resource = new UpdatableResource("TestResource", TemplateProcessorManager.CF_TYPE_SERVERLESS_FUNCTION, dataSource);
+            var resource = new UpdatableResource("TestResource", UpdatableResourceDefinition.DEF_SERVERLESS_FUNCTION, dataSource);
 
-            Assert.True(resource.IsUpdatable);
-            Assert.Equal(localPath, resource.GetLocalPath());
+            Assert.Equal(localPath, resource.Fields[0].GetLocalPath());
 
-            resource.SetS3Location("my-bucket", "my.zip");
+            resource.Fields[0].SetS3Location("my-bucket", "my.zip");
             Assert.Equal("s3://my-bucket/my.zip", dataSource.GetValue("CodeUri"));
         }
 
@@ -203,9 +201,9 @@ namespace Amazon.Lambda.Tools.Test
                                     {
                                         {"CodeUri", "s3://my-bucket/my.zip" }
                                     });
-            var resource = new UpdatableResource("TestResource", TemplateProcessorManager.CF_TYPE_SERVERLESS_FUNCTION, dataSource);
+            var resource = new UpdatableResource("TestResource", UpdatableResourceDefinition.DEF_SERVERLESS_FUNCTION, dataSource);
 
-            Assert.False(resource.IsUpdatable);
+            Assert.Null(resource.Fields[0].GetLocalPath());
         }
 
         [Fact]
@@ -215,12 +213,11 @@ namespace Amazon.Lambda.Tools.Test
                                     new Dictionary<string, string>
                                     {
                                     });
-            var resource = new UpdatableResource("TestResource", TemplateProcessorManager.CF_TYPE_LAMBDA_FUNCTION, dataSource);
+            var resource = new UpdatableResource("TestResource", UpdatableResourceDefinition.DEF_LAMBDA_FUNCTION, dataSource);
 
-            Assert.True(resource.IsUpdatable);
-            Assert.Equal(".", resource.GetLocalPath());
+            Assert.Equal(".", resource.Fields[0].GetLocalPath());
 
-            resource.SetS3Location("my-bucket", "my.zip");
+            resource.Fields[0].SetS3Location("my-bucket", "my.zip");
             Assert.Equal("my-bucket", dataSource.GetValue("Code/S3Bucket"));
             Assert.Equal("my.zip", dataSource.GetValue("Code/S3Key"));
         }
@@ -235,12 +232,11 @@ namespace Amazon.Lambda.Tools.Test
                                     {
                                         {"Code/S3Key", localPath }
                                     });
-            var resource = new UpdatableResource("TestResource", TemplateProcessorManager.CF_TYPE_LAMBDA_FUNCTION, dataSource);
+            var resource = new UpdatableResource("TestResource", UpdatableResourceDefinition.DEF_LAMBDA_FUNCTION, dataSource);
 
-            Assert.True(resource.IsUpdatable);
-            Assert.Equal(localPath, resource.GetLocalPath());
+            Assert.Equal(localPath, resource.Fields[0].GetLocalPath());
 
-            resource.SetS3Location("my-bucket", "my.zip");
+            resource.Fields[0].SetS3Location("my-bucket", "my.zip");
             Assert.Equal("my-bucket", dataSource.GetValue("Code/S3Bucket"));
             Assert.Equal("my.zip", dataSource.GetValue("Code/S3Key"));
         }
@@ -256,12 +252,11 @@ namespace Amazon.Lambda.Tools.Test
                                         {"Code/S3Bucket", "" },
                                         {"Code/S3Key", localPath }
                                     });
-            var resource = new UpdatableResource("TestResource", TemplateProcessorManager.CF_TYPE_LAMBDA_FUNCTION, dataSource);
+            var resource = new UpdatableResource("TestResource", UpdatableResourceDefinition.DEF_LAMBDA_FUNCTION, dataSource);
 
-            Assert.True(resource.IsUpdatable);
-            Assert.Equal(localPath, resource.GetLocalPath());
+            Assert.Equal(localPath, resource.Fields[0].GetLocalPath());
 
-            resource.SetS3Location("my-bucket", "my.zip");
+            resource.Fields[0].SetS3Location("my-bucket", "my.zip");
             Assert.Equal("my-bucket", dataSource.GetValue("Code/S3Bucket"));
             Assert.Equal("my.zip", dataSource.GetValue("Code/S3Key"));
         }
@@ -275,9 +270,9 @@ namespace Amazon.Lambda.Tools.Test
                                         {"Code/S3Bucket", "my-bucket" },
                                         {"Code/S3Key", "my.zip" }
                                     });
-            var resource = new UpdatableResource("TestResource", TemplateProcessorManager.CF_TYPE_LAMBDA_FUNCTION, dataSource);
+            var resource = new UpdatableResource("TestResource", UpdatableResourceDefinition.DEF_LAMBDA_FUNCTION, dataSource);
 
-            Assert.False(resource.IsUpdatable);
+            Assert.Null(resource.Fields[0].GetLocalPath());
         }
 
 

--- a/testapps/MPDeployServerless/CurrentDirectoryTest/CurrentDirectoryTest.csproj
+++ b/testapps/MPDeployServerless/CurrentDirectoryTest/CurrentDirectoryTest.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
+    <AWSProjectType>Lambda</AWSProjectType>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Amazon.Lambda.Core" Version="1.0.0" />
+    <PackageReference Include="Amazon.Lambda.Serialization.Json" Version="1.4.0" />
+    <PackageReference Include="Amazon.Lambda.APIGatewayEvents" Version="1.1.3" />
+  </ItemGroup>
+
+</Project>

--- a/testapps/MPDeployServerless/CurrentDirectoryTest/Function.cs
+++ b/testapps/MPDeployServerless/CurrentDirectoryTest/Function.cs
@@ -1,0 +1,48 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Threading.Tasks;
+
+using Amazon.Lambda.Core;
+using Amazon.Lambda.APIGatewayEvents;
+
+// Assembly attribute to enable the Lambda function's JSON input to be converted into a .NET class.
+[assembly: LambdaSerializer(typeof(Amazon.Lambda.Serialization.Json.JsonSerializer))]
+
+namespace CurrentDirectoryTest
+{
+    public class Functions
+    {
+        /// <summary>
+        /// Default constructor that Lambda will invoke.
+        /// </summary>
+        public Functions()
+        {
+        }
+
+        public APIGatewayProxyResponse Get(APIGatewayProxyRequest request, ILambdaContext context)
+        {
+            var response = new APIGatewayProxyResponse
+            {
+                StatusCode = (int)HttpStatusCode.OK,
+                Body = "CurrentProjectTest",
+                Headers = new Dictionary<string, string> { { "Content-Type", "text/plain" } }
+            };
+
+            return response;
+        }
+
+        public APIGatewayProxyResponse Get2(APIGatewayProxyRequest request, ILambdaContext context)
+        {
+            var response = new APIGatewayProxyResponse
+            {
+                StatusCode = (int)HttpStatusCode.OK,
+                Body = "SecondCurrentProjectTest",
+                Headers = new Dictionary<string, string> { { "Content-Type", "text/plain" } }
+            };
+
+            return response;
+        }
+    }
+}

--- a/testapps/MPDeployServerless/CurrentDirectoryTest/Readme.md
+++ b/testapps/MPDeployServerless/CurrentDirectoryTest/Readme.md
@@ -1,0 +1,42 @@
+# Empty AWS Serverless Application Project
+
+This starter project consists of:
+* serverless.template - an AWS CloudFormation Serverless Application Model template file for declaring your Serverless functions and other AWS resources
+* Function.cs - class file containing the C# method mapped to the single function declared in the template file
+* aws-lambda-tools-defaults.json - default argument settings for use with Visual Studio and command line deployment tools for AWS
+
+You may also have a test project depending on the options selected.
+
+The generated project contains a Serverless template declaration for a single AWS Lambda function that will be exposed through Amazon API Gateway as a HTTP *Get* operation. Edit the template to customize the function or add more functions and other resources needed by your application, and edit the function code in Function.cs. You can then deploy your Serverless application.
+
+## Here are some steps to follow from Visual Studio:
+
+To deploy your Serverless application, right click the project in Solution Explorer and select *Publish to AWS Lambda*.
+
+To view your deployed application open the Stack View window by double-clicking the stack name shown beneath the AWS CloudFormation node in the AWS Explorer tree. The Stack View also displays the root URL to your published application.
+
+## Here are some steps to follow to get started from the command line:
+
+Once you have edited your template and code you can deploy your application using the [Amazon.Lambda.Tools Global Tool](https://github.com/aws/aws-extensions-for-dotnet-cli#aws-lambda-amazonlambdatools) from the command line.
+
+Install Amazon.Lambda.Tools Global Tools if not already installed.
+```
+    dotnet tool install -g Amazon.Lambda.Tools
+```
+
+If already installed check if new version is available.
+```
+    dotnet tool update -g Amazon.Lambda.Tools
+```
+
+Execute unit tests
+```
+    cd "CurrentDirectoryTest/test/CurrentDirectoryTest.Tests"
+    dotnet test
+```
+
+Deploy application
+```
+    cd "CurrentDirectoryTest/src/CurrentDirectoryTest"
+    dotnet lambda deploy-serverless
+```

--- a/testapps/MPDeployServerless/CurrentDirectoryTest/aws-lambda-tools-defaults.json
+++ b/testapps/MPDeployServerless/CurrentDirectoryTest/aws-lambda-tools-defaults.json
@@ -12,7 +12,5 @@
     "framework"     : "netcoreapp2.1",
     "s3-prefix"     : "CurrentDirectoryTest/",
     "template"      : "serverless.template",
-    "template-parameters" : "",
-    "s3-bucket"           : "normj-west2",
-    "stack-name"          : "NewCodeTest"
+    "template-parameters" : ""
 }

--- a/testapps/MPDeployServerless/CurrentDirectoryTest/aws-lambda-tools-defaults.json
+++ b/testapps/MPDeployServerless/CurrentDirectoryTest/aws-lambda-tools-defaults.json
@@ -7,7 +7,7 @@
         "All the command line options for the Lambda command can be specified in this file."
     ],
     "profile"     : "default",
-    "region"      : "us-west-2",
+    "region"      : "us-east-1",
     "configuration" : "Release",
     "framework"     : "netcoreapp2.1",
     "s3-prefix"     : "CurrentDirectoryTest/",

--- a/testapps/MPDeployServerless/CurrentDirectoryTest/aws-lambda-tools-defaults.json
+++ b/testapps/MPDeployServerless/CurrentDirectoryTest/aws-lambda-tools-defaults.json
@@ -1,0 +1,18 @@
+
+{
+    "Information" : [
+        "This file provides default values for the deployment wizard inside Visual Studio and the AWS Lambda commands added to the .NET Core CLI.",
+        "To learn more about the Lambda commands with the .NET Core CLI execute the following command at the command line in the project root directory.",
+        "dotnet lambda help",
+        "All the command line options for the Lambda command can be specified in this file."
+    ],
+    "profile"     : "default",
+    "region"      : "us-west-2",
+    "configuration" : "Release",
+    "framework"     : "netcoreapp2.1",
+    "s3-prefix"     : "CurrentDirectoryTest/",
+    "template"      : "serverless.template",
+    "template-parameters" : "",
+    "s3-bucket"           : "normj-west2",
+    "stack-name"          : "NewCodeTest"
+}

--- a/testapps/MPDeployServerless/CurrentDirectoryTest/serverless.template
+++ b/testapps/MPDeployServerless/CurrentDirectoryTest/serverless.template
@@ -1,0 +1,82 @@
+{
+  "AWSTemplateFormatVersion" : "2010-09-09",
+  "Transform" : "AWS::Serverless-2016-10-31",
+  "Description" : "An AWS Serverless Application.",
+
+  "Resources" : {
+
+    "CurrentProject" : {
+      "Type" : "AWS::Serverless::Function",
+      "Properties": {
+        "Handler": "CurrentDirectoryTest::CurrentDirectoryTest.Functions::Get",
+        "Runtime": "dotnetcore2.1",
+        "CodeUri": "",
+        "MemorySize": 256,
+        "Timeout": 30,
+        "Role": null,
+        "Policies": [ "AWSLambdaBasicExecutionRole" ],
+        "Events": {
+          "PutResource": {
+            "Type": "Api",
+            "Properties": {
+              "Path": "/current",
+              "Method": "GET"
+            }
+          }
+        }
+      }
+    },
+
+	"CurrentProject2" : {
+      "Type" : "AWS::Serverless::Function",
+      "Properties": {
+        "Handler": "CurrentDirectoryTest::CurrentDirectoryTest.Functions::Get2",
+        "Runtime": "dotnetcore2.1",
+        "CodeUri": "",
+        "MemorySize": 256,
+        "Timeout": 30,
+        "Role": null,
+        "Policies": [ "AWSLambdaBasicExecutionRole" ],
+        "Events": {
+          "PutResource": {
+            "Type": "Api",
+            "Properties": {
+              "Path": "/current2",
+              "Method": "GET"
+            }
+          }
+        }
+      }
+    },
+
+    "SiblingProject" : {
+      "Type" : "AWS::Serverless::Function",
+      "Properties": {
+        "Handler": "SiblingProjectTest::SiblingProjectTest.Function::Get",
+        "Runtime": "dotnetcore2.1",
+        "CodeUri": "../SiblingProjectTest",
+        "MemorySize": 256,
+        "Timeout": 30,
+        "Role": null,
+        "Policies": [ "AWSLambdaBasicExecutionRole" ],
+        "Events": {
+          "PutResource": {
+            "Type": "Api",
+            "Properties": {
+              "Path": "/sibling",
+              "Method": "GET"
+            }
+          }
+        }
+      }
+    }
+
+  },
+
+  "Outputs" : {
+    "ApiURL" : {
+        "Description" : "API endpoint URL for Prod environment",
+        "Value" : { "Fn::Sub" : "https://${ServerlessRestApi}.execute-api.${AWS::Region}.amazonaws.com/Prod/" }
+    }
+  }
+}

--- a/testapps/MPDeployServerless/CurrentDirectoryTest/serverless.template
+++ b/testapps/MPDeployServerless/CurrentDirectoryTest/serverless.template
@@ -69,6 +69,50 @@
           }
         }
       }
+    },
+
+    "SingleFileNodeFunction" : {
+      "Type" : "AWS::Serverless::Function",
+      "Properties": {
+        "Handler": "app.handler",
+        "Runtime": "nodejs8.10",
+        "CodeUri": "../SingleFileNodeFunction/app.js",
+        "MemorySize": 256,
+        "Timeout": 30,
+        "Role": null,
+        "Policies": [ "AWSLambdaBasicExecutionRole" ],
+        "Events": {
+          "PutResource": {
+            "Type": "Api",
+            "Properties": {
+              "Path": "/singlenode",
+              "Method": "GET"
+            }
+          }
+        }
+      }
+    },
+
+    "DirectoryNodeFunction" : {
+      "Type" : "AWS::Serverless::Function",
+      "Properties": {
+        "Handler": "app.handler",
+        "Runtime": "nodejs8.10",
+        "CodeUri": "../DirectoryNodeFunction",
+        "MemorySize": 256,
+        "Timeout": 30,
+        "Role": null,
+        "Policies": [ "AWSLambdaBasicExecutionRole" ],
+        "Events": {
+          "PutResource": {
+            "Type": "Api",
+            "Properties": {
+              "Path": "/directorynode",
+              "Method": "GET"
+            }
+          }
+        }
+      }
     }
 
   },

--- a/testapps/MPDeployServerless/DirectoryNodeFunction/DirectoryNodeFunction.njsproj
+++ b/testapps/MPDeployServerless/DirectoryNodeFunction/DirectoryNodeFunction.njsproj
@@ -1,0 +1,45 @@
+﻿<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">11.0</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+    <Name>DirectoryNodeFunction</Name>
+    <RootNamespace>DirectoryNodeFunction</RootNamespace>
+    <StartupFile>_testdriver.js</StartupFile>
+  </PropertyGroup>
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{99999999-9999-9999-9999-999999999999}</ProjectGuid>
+  </PropertyGroup>
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{49d8f6c3-001f-47a1-bbb1-0de9c07f265a}</ProjectGuid>
+    <ProjectHome>.</ProjectHome>
+    <StartWebBrowser>False</StartWebBrowser>
+    <SearchPath>
+    </SearchPath>
+    <WorkingDirectory>.</WorkingDirectory>
+    <OutputPath>.</OutputPath>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <ProjectTypeGuids>{3AF33F2E-1136-4D97-BBB7-1795711AC8B8};{9092AA53-FB77-4645-B42D-1CCCA6BD08BD}</ProjectTypeGuids>
+    <ProjectView>ShowAllFiles</ProjectView>
+    <StartWebBrowser>false</StartWebBrowser>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
+  </PropertyGroup>
+  <ItemGroup>
+    <None Include="datafile.txt" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="app.js" />
+    <Compile Include="_testdriver.js" />
+  </ItemGroup>
+  <ItemGroup>
+    <Content Include="_sampleEvent.json" />
+  </ItemGroup>
+  <Import Project="$(VSToolsPath)\Node.js Tools\Microsoft.NodejsTools.targets" />
+</Project>

--- a/testapps/MPDeployServerless/DirectoryNodeFunction/_sampleEvent.json
+++ b/testapps/MPDeployServerless/DirectoryNodeFunction/_sampleEvent.json
@@ -1,0 +1,35 @@
+﻿{
+  "Records": [
+    {
+      "eventVersion": "2.0",
+      "eventSource": "aws:s3",
+      "awsRegion": "us-west-2",
+      "eventTime": "2015-01-31T01:36:58.497Z",
+      "eventName": "s3:ObjectCreated:Put",
+      "userIdentity": {
+        "principalId": "AIDAJDPLRKLG7UEXAMPLE"
+      },
+      "requestParameters": {
+        "sourceIPAddress": "127.0.0.1"
+      },
+      "responseElements": {
+        "x-amz-request-id": "C3D13FE58DE4C810",
+        "x-amz-id-2": "FMyUVURIY8\/IgAtTv8xRjskZQpcIZ9KG4V5Wp6S7S\/JRWeUWerMUE5JgHvANOjpD"
+      },
+      "s3": {
+        "s3SchemaVersion": "1.0",
+        "configurationId": "testConfigRule",
+        "bucket": {
+          "name": "*** INSERT BUCKET NAME ***",
+          "ownerIdentity": {
+            "principalId": "A3NL1KOZZKExample"
+          },
+          "arn": "arn:aws:s3:::*** INSERT BUCKET NAME ***"
+        },
+        "object": {
+          "key": "*** INSERT OBJECT KEY ***"
+        }
+      }
+    }
+  ]
+}

--- a/testapps/MPDeployServerless/DirectoryNodeFunction/_testdriver.js
+++ b/testapps/MPDeployServerless/DirectoryNodeFunction/_testdriver.js
@@ -1,0 +1,27 @@
+﻿/*
+ * This is a utility file to help invoke and debug the lambda function. It is not included as part of the
+ * bundle upload to Lambda.
+ * 
+ * Credentials:
+ *  The AWS SDK for Node.js will look for credentials first in the AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY and then 
+ *  fall back to the shared credentials file. For further information about credentials read the AWS SDK for Node.js documentation
+ *  http://docs.aws.amazon.com/AWSJavaScriptSDK/guide/node-configuring.html#Credentials_from_the_Shared_Credentials_File_____aws_credentials_
+ * 
+ */
+
+// Set the region to the locations of the S3 buckets
+process.env['AWS_REGION'] = 'us-west-2'
+
+var fs = require('fs');
+var app = require('./app');
+
+// Load the sample event to be passed to Lambda. The _sampleEvent.json file can be modified to match
+// what you want Lambda to process on.
+var event = JSON.parse(fs.readFileSync('_sampleEvent.json', 'utf8').trim());
+
+var context = {};
+context.done = function () {
+    console.log("Lambda Function Complete");
+}
+
+app.handler(event, context);

--- a/testapps/MPDeployServerless/DirectoryNodeFunction/app.js
+++ b/testapps/MPDeployServerless/DirectoryNodeFunction/app.js
@@ -1,0 +1,16 @@
+﻿console.log('Loading');
+
+exports.handler = function (event, context) {
+
+    var fs = require('fs');
+
+    var contents = fs.readFileSync('datafile.txt', 'utf8');
+
+    var response = {};
+    response.statusCode = 200;
+    response.body = contents;
+    response.headers = {};
+    response.headers['Content-Type'] = "text/plain";
+
+    context.done(null, response);  // SUCCESS with message
+};

--- a/testapps/MPDeployServerless/DirectoryNodeFunction/datafile.txt
+++ b/testapps/MPDeployServerless/DirectoryNodeFunction/datafile.txt
@@ -1,0 +1,1 @@
+﻿DirectoryNodeFunction

--- a/testapps/MPDeployServerless/MPDeployServerless.sln
+++ b/testapps/MPDeployServerless/MPDeployServerless.sln
@@ -1,0 +1,31 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 15
+VisualStudioVersion = 15.0.28010.2036
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SiblingProjectTest", "SiblingProjectTest\SiblingProjectTest.csproj", "{A7012588-996C-40D3-936D-BA5FFDC3FC53}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CurrentDirectoryTest", "CurrentDirectoryTest\CurrentDirectoryTest.csproj", "{B6D70388-E3C7-4006-B833-455A54D27293}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{A7012588-996C-40D3-936D-BA5FFDC3FC53}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A7012588-996C-40D3-936D-BA5FFDC3FC53}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A7012588-996C-40D3-936D-BA5FFDC3FC53}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A7012588-996C-40D3-936D-BA5FFDC3FC53}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B6D70388-E3C7-4006-B833-455A54D27293}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B6D70388-E3C7-4006-B833-455A54D27293}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B6D70388-E3C7-4006-B833-455A54D27293}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B6D70388-E3C7-4006-B833-455A54D27293}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {ACE18719-BD94-45BC-97EA-562A865FB472}
+	EndGlobalSection
+EndGlobal

--- a/testapps/MPDeployServerless/MPDeployServerless.sln
+++ b/testapps/MPDeployServerless/MPDeployServerless.sln
@@ -7,6 +7,10 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SiblingProjectTest", "Sibli
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CurrentDirectoryTest", "CurrentDirectoryTest\CurrentDirectoryTest.csproj", "{B6D70388-E3C7-4006-B833-455A54D27293}"
 EndProject
+Project("{9092AA53-FB77-4645-B42D-1CCCA6BD08BD}") = "SingleFileNodeFunction", "SingleFileNodeFunction\SingleFileNodeFunction.njsproj", "{93A99353-34B5-47FA-87C9-63D274E18909}"
+EndProject
+Project("{9092AA53-FB77-4645-B42D-1CCCA6BD08BD}") = "DirectoryNodeFunction", "DirectoryNodeFunction\DirectoryNodeFunction.njsproj", "{49D8F6C3-001F-47A1-BBB1-0DE9C07F265A}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -21,6 +25,14 @@ Global
 		{B6D70388-E3C7-4006-B833-455A54D27293}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{B6D70388-E3C7-4006-B833-455A54D27293}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{B6D70388-E3C7-4006-B833-455A54D27293}.Release|Any CPU.Build.0 = Release|Any CPU
+		{93A99353-34B5-47FA-87C9-63D274E18909}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{93A99353-34B5-47FA-87C9-63D274E18909}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{93A99353-34B5-47FA-87C9-63D274E18909}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{93A99353-34B5-47FA-87C9-63D274E18909}.Release|Any CPU.Build.0 = Release|Any CPU
+		{49D8F6C3-001F-47A1-BBB1-0DE9C07F265A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{49D8F6C3-001F-47A1-BBB1-0DE9C07F265A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{49D8F6C3-001F-47A1-BBB1-0DE9C07F265A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{49D8F6C3-001F-47A1-BBB1-0DE9C07F265A}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/testapps/MPDeployServerless/SiblingProjectTest/Function.cs
+++ b/testapps/MPDeployServerless/SiblingProjectTest/Function.cs
@@ -1,0 +1,30 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Threading.Tasks;
+
+using Amazon.Lambda.Core;
+using Amazon.Lambda.APIGatewayEvents;
+
+// Assembly attribute to enable the Lambda function's JSON input to be converted into a .NET class.
+[assembly: LambdaSerializer(typeof(Amazon.Lambda.Serialization.Json.JsonSerializer))]
+
+namespace SiblingProjectTest
+{
+    public class Function
+    {
+
+        public APIGatewayProxyResponse Get(APIGatewayProxyRequest request, ILambdaContext context)
+        {
+            var response = new APIGatewayProxyResponse
+            {
+                StatusCode = (int)HttpStatusCode.OK,
+                Body = "SiblingProjectTest",
+                Headers = new Dictionary<string, string> { { "Content-Type", "text/plain" } }
+            };
+
+            return response;
+        }
+    }
+}

--- a/testapps/MPDeployServerless/SiblingProjectTest/Readme.md
+++ b/testapps/MPDeployServerless/SiblingProjectTest/Readme.md
@@ -1,0 +1,49 @@
+# AWS Lambda Empty Function Project
+
+This starter project consists of:
+* Function.cs - class file containing a class with a single function handler method
+* aws-lambda-tools-defaults.json - default argument settings for use with Visual Studio and command line deployment tools for AWS
+
+You may also have a test project depending on the options selected.
+
+The generated function handler is a simple method accepting a string argument that returns the uppercase equivalent of the input string. Replace the body of this method, and parameters, to suit your needs. 
+
+## Here are some steps to follow from Visual Studio:
+
+To deploy your function to AWS Lambda, right click the project in Solution Explorer and select *Publish to AWS Lambda*.
+
+To view your deployed function open its Function View window by double-clicking the function name shown beneath the AWS Lambda node in the AWS Explorer tree.
+
+To perform testing against your deployed function use the Test Invoke tab in the opened Function View window.
+
+To configure event sources for your deployed function, for example to have your function invoked when an object is created in an Amazon S3 bucket, use the Event Sources tab in the opened Function View window.
+
+To update the runtime configuration of your deployed function use the Configuration tab in the opened Function View window.
+
+To view execution logs of invocations of your function use the Logs tab in the opened Function View window.
+
+## Here are some steps to follow to get started from the command line:
+
+Once you have edited your template and code you can deploy your application using the [Amazon.Lambda.Tools Global Tool](https://github.com/aws/aws-extensions-for-dotnet-cli#aws-lambda-amazonlambdatools) from the command line.
+
+Install Amazon.Lambda.Tools Global Tools if not already installed.
+```
+    dotnet tool install -g Amazon.Lambda.Tools
+```
+
+If already installed check if new version is available.
+```
+    dotnet tool update -g Amazon.Lambda.Tools
+```
+
+Execute unit tests
+```
+    cd "SiblingProjectTest/test/SiblingProjectTest.Tests"
+    dotnet test
+```
+
+Deploy function to AWS Lambda
+```
+    cd "SiblingProjectTest/src/SiblingProjectTest"
+    dotnet lambda deploy-function
+```

--- a/testapps/MPDeployServerless/SiblingProjectTest/SiblingProjectTest.csproj
+++ b/testapps/MPDeployServerless/SiblingProjectTest/SiblingProjectTest.csproj
@@ -1,0 +1,15 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
+    <AWSProjectType>Lambda</AWSProjectType>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Amazon.Lambda.Core" Version="1.0.0" />
+    <PackageReference Include="Amazon.Lambda.Serialization.Json" Version="1.4.0" />
+    <PackageReference Include="Amazon.Lambda.APIGatewayEvents" Version="1.1.3" />
+  </ItemGroup>
+
+</Project>

--- a/testapps/MPDeployServerless/SiblingProjectTest/aws-lambda-tools-defaults.json
+++ b/testapps/MPDeployServerless/SiblingProjectTest/aws-lambda-tools-defaults.json
@@ -1,0 +1,19 @@
+{
+  "Information" : [
+    "This file provides default values for the deployment wizard inside Visual Studio and the AWS Lambda commands added to the .NET Core CLI.",
+    "To learn more about the Lambda commands with the .NET Core CLI execute the following command at the command line in the project root directory.",
+
+    "dotnet lambda help",
+
+    "All the command line options for the Lambda command can be specified in this file."
+  ],
+
+  "profile":"default",
+  "region" : "us-west-2",
+  "configuration" : "Release",
+  "framework" : "netcoreapp2.1",
+  "function-runtime":"dotnetcore2.1",
+  "function-memory-size" : 256,
+  "function-timeout" : 30,
+  "function-handler" : "SiblingProjectTest::SiblingProjectTest.Function::FunctionHandler"
+}

--- a/testapps/MPDeployServerless/SingleFileNodeFunction/ReadMe.txt
+++ b/testapps/MPDeployServerless/SingleFileNodeFunction/ReadMe.txt
@@ -1,0 +1,1 @@
+﻿To be completed - getting started text for the new project.

--- a/testapps/MPDeployServerless/SingleFileNodeFunction/ReadMe.txt
+++ b/testapps/MPDeployServerless/SingleFileNodeFunction/ReadMe.txt
@@ -1,1 +1,0 @@
-﻿To be completed - getting started text for the new project.

--- a/testapps/MPDeployServerless/SingleFileNodeFunction/SingleFileNodeFunction.njsproj
+++ b/testapps/MPDeployServerless/SingleFileNodeFunction/SingleFileNodeFunction.njsproj
@@ -1,0 +1,45 @@
+﻿<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">11.0</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+    <Name>SingleFileNodeFunction</Name>
+    <RootNamespace>SingleFileNodeFunction</RootNamespace>
+    <StartupFile>_testdriver.js</StartupFile>
+  </PropertyGroup>
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{99999999-9999-9999-9999-999999999999}</ProjectGuid>
+  </PropertyGroup>
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>93a99353-34b5-47fa-87c9-63d274e18909</ProjectGuid>
+    <ProjectHome>.</ProjectHome>
+    <StartWebBrowser>False</StartWebBrowser>
+    <SearchPath>
+    </SearchPath>
+    <WorkingDirectory>.</WorkingDirectory>
+    <OutputPath>.</OutputPath>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <ProjectTypeGuids>{3AF33F2E-1136-4D97-BBB7-1795711AC8B8};{9092AA53-FB77-4645-B42D-1CCCA6BD08BD}</ProjectTypeGuids>
+    <ProjectView>ShowAllFiles</ProjectView>
+    <StartWebBrowser>false</StartWebBrowser>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
+  </PropertyGroup>
+  <ItemGroup>
+    <None Include="ReadMe.txt" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="app.js" />
+    <Compile Include="_testdriver.js" />
+  </ItemGroup>
+  <ItemGroup>
+    <Content Include="_sampleEvent.json" />
+  </ItemGroup>
+  <Import Project="$(VSToolsPath)\Node.js Tools\Microsoft.NodejsTools.targets" />
+</Project>

--- a/testapps/MPDeployServerless/SingleFileNodeFunction/_sampleEvent.json
+++ b/testapps/MPDeployServerless/SingleFileNodeFunction/_sampleEvent.json
@@ -1,0 +1,35 @@
+﻿{
+  "Records": [
+    {
+      "eventVersion": "2.0",
+      "eventSource": "aws:s3",
+      "awsRegion": "us-west-2",
+      "eventTime": "2015-01-31T01:36:58.497Z",
+      "eventName": "s3:ObjectCreated:Put",
+      "userIdentity": {
+        "principalId": "AIDAJDPLRKLG7UEXAMPLE"
+      },
+      "requestParameters": {
+        "sourceIPAddress": "127.0.0.1"
+      },
+      "responseElements": {
+        "x-amz-request-id": "C3D13FE58DE4C810",
+        "x-amz-id-2": "FMyUVURIY8\/IgAtTv8xRjskZQpcIZ9KG4V5Wp6S7S\/JRWeUWerMUE5JgHvANOjpD"
+      },
+      "s3": {
+        "s3SchemaVersion": "1.0",
+        "configurationId": "testConfigRule",
+        "bucket": {
+          "name": "*** INSERT BUCKET NAME ***",
+          "ownerIdentity": {
+            "principalId": "A3NL1KOZZKExample"
+          },
+          "arn": "arn:aws:s3:::*** INSERT BUCKET NAME ***"
+        },
+        "object": {
+          "key": "*** INSERT OBJECT KEY ***"
+        }
+      }
+    }
+  ]
+}

--- a/testapps/MPDeployServerless/SingleFileNodeFunction/_testdriver.js
+++ b/testapps/MPDeployServerless/SingleFileNodeFunction/_testdriver.js
@@ -1,0 +1,27 @@
+﻿/*
+ * This is a utility file to help invoke and debug the lambda function. It is not included as part of the
+ * bundle upload to Lambda.
+ * 
+ * Credentials:
+ *  The AWS SDK for Node.js will look for credentials first in the AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY and then 
+ *  fall back to the shared credentials file. For further information about credentials read the AWS SDK for Node.js documentation
+ *  http://docs.aws.amazon.com/AWSJavaScriptSDK/guide/node-configuring.html#Credentials_from_the_Shared_Credentials_File_____aws_credentials_
+ * 
+ */
+
+// Set the region to the locations of the S3 buckets
+process.env['AWS_REGION'] = 'us-west-2'
+
+var fs = require('fs');
+var app = require('./app');
+
+// Load the sample event to be passed to Lambda. The _sampleEvent.json file can be modified to match
+// what you want Lambda to process on.
+var event = JSON.parse(fs.readFileSync('_sampleEvent.json', 'utf8').trim());
+
+var context = {};
+context.done = function () {
+    console.log("Lambda Function Complete");
+}
+
+app.handler(event, context);

--- a/testapps/MPDeployServerless/SingleFileNodeFunction/app.js
+++ b/testapps/MPDeployServerless/SingleFileNodeFunction/app.js
@@ -1,0 +1,20 @@
+﻿console.log('Loading');
+
+exports.handler = function (event, context) {
+
+    if (event != null) {
+        console.log('event = ' + JSON.stringify(event));
+    }
+    else {
+        console.log('No event object');
+
+    }
+
+    var response = {};
+    response.statusCode = 200;
+    response.body = 'SingleFileNodeFunction';
+    response.headers = {};
+    response.headers['Content-Type'] = "text/plain";
+
+    context.done(null, response);  // SUCCESS with message
+};


### PR DESCRIPTION
Now that Amazon.Lambda.Tools is a global tool and can be run outside of the context of a single project it is appropriate to support deploying multiple projects at the same time.

The current behavior is:
* Build .NET Core project
* Upload the built project as a zip archive to S3
* Read CloudFormation template and update the code location for any AWS::Lambda::Function or AWS::Serverless::Function resources.
* Deploy template.

The new behavior is to match the AWS CLI command [`aws cloudformation package`](https://docs.aws.amazon.com/cli/latest/reference/cloudformation/package.html) while maintaining compatiblity:
* Read the CloudFormation template
* Search of an CloudFormation resource that could point to a local file as listed on the `aws cloudformation package` help.
* If the resource is a AWS::Lambda::Function or AWS::Lambda::Serverless do
   * If Code location is blank assume the code is in the same directory as the template
   * If the Code properties are pointing to a directory
       *  If .NET Directory build project and upload it
       * Otherwise zip directory and upload. (Handle node.js functions)
   * If the Code location is pointing to a file
       * If the file is a zip file upload it
       * Otherwise zip file and upload it. (Handle pointing to a single JS file for node.js)
* For other AWS resources listed on the `aws cloudformation package` check to see if the code location is pointing to a local file and upload the file.
* If a file is uploaded then update the template to point to the new S3 location.

The new behavior also caches all local paths to S3 so if multiple Lambda point to the same local directory it is only built and uploaded once.