### PR TITLE
Fix issue related to yaml templates containing intrinsic functions in the short form

### DIFF
--- a/src/Amazon.Common.DotNetCli.Tools/IToolLogger.cs
+++ b/src/Amazon.Common.DotNetCli.Tools/IToolLogger.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Threading.Tasks;
 
@@ -25,11 +26,18 @@ namespace Amazon.Common.DotNetCli.Tools
         public void WriteLine(string message)
         {
             Console.WriteLine(message);
+#if DEBUG
+            Debugger.Log(0, "console", message + "\n");
+#endif
         }
 
         public void WriteLine(string message, params object[] args)
         {
-            Console.WriteLine(string.Format(message, args));
+            var str = string.Format(message, args);
+            Console.WriteLine(str);
+#if DEBUG
+            Debugger.Log(0, "console", str + "\n");
+#endif
         }
     }
 }

--- a/src/Amazon.Lambda.Tools/Amazon.Lambda.Tools.csproj
+++ b/src/Amazon.Lambda.Tools/Amazon.Lambda.Tools.csproj
@@ -33,7 +33,7 @@
     <PackageReference Include="AWSSDK.Lambda" Version="3.3.13.2" />
     <PackageReference Include="AWSSDK.IdentityManagement" Version="3.3.6.3" />
     <PackageReference Include="AWSSDK.S3" Version="3.3.18.2" />
-    <PackageReference Include="YamlDotNet.Signed" Version="5.0.1" />
+    <PackageReference Include="YamlDotNet.Signed" Version="5.2.1" />
   </ItemGroup>
   <PropertyGroup>
     <DefineConstants>$(DefineConstants);NETCORE</DefineConstants>

--- a/src/Amazon.Lambda.Tools/LambdaUtilities.cs
+++ b/src/Amazon.Lambda.Tools/LambdaUtilities.cs
@@ -477,7 +477,8 @@ namespace Amazon.Lambda.Tools
                 }
             }
             var myText = new StringWriter();
-            yaml.Save(myText, false);
+            //keep the yaml human readable, don't assign anchors
+            yaml.Save(myText, assignAnchors:false);
 
             return myText.ToString();
         }

--- a/test/Amazon.Lambda.Tools.Test/Amazon.Lambda.Tools.Test.csproj
+++ b/test/Amazon.Lambda.Tools.Test/Amazon.Lambda.Tools.Test.csproj
@@ -59,7 +59,7 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
     <PackageReference Include="System.IO.Compression.ZipFile" Version="4.0.1" />
     <PackageReference Include="xunit" Version="2.2.0" />
-    <PackageReference Include="YamlDotNet.Signed" Version="5.0.1" />
+    <PackageReference Include="YamlDotNet.Signed" Version="5.2.1" />
   </ItemGroup>
   <ItemGroup>
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />

--- a/test/Amazon.Lambda.Tools.Test/TemplateCodeUpdateYamlTest.cs
+++ b/test/Amazon.Lambda.Tools.Test/TemplateCodeUpdateYamlTest.cs
@@ -138,6 +138,8 @@ Resources:
 
             //Does not throw an error when parsing template
             var updateTemplateBody = LambdaUtilities.UpdateCodeLocationInYamlTemplate(template, S3_BUCKET, S3_OBJECT);
+            //validate that functions survive the template update
+            Assert.Contains("DevStack: !Equals [!Ref 'AWS::StackName', dev]", updateTemplateBody);
         }
     }
 }

--- a/test/Amazon.Lambda.Tools.Test/TestFiles/testtemplate.yaml
+++ b/test/Amazon.Lambda.Tools.Test/TestFiles/testtemplate.yaml
@@ -2,8 +2,7 @@ AWSTemplateFormatVersion : 2010-09-09
 Transform : AWS::Serverless-2016-10-31
 Description : An AWS Serverless Application.
 Conditions:
-  DevStack: 
-    !Equals [!Ref 'AWS::StackName', dev ]
+  DevStack: !Equals [!Ref 'AWS::StackName', dev ]
 Resources : 
   RestApi : 
     Type: AWS::Serverless::Api


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/aws-extensions-for-dotnet-cli/issues/32
*Description of changes:*
I'm fixing the above issue by taking the latest YamlDotNet package that fixes this issue.

I've added a new unit test to ensure that this bug stays fixed.
I've also improved debuggability by logging to debugger in debug builds.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
