### PR TITLE
Fixing wrong directory separator used while zipping on windows syst…

### DIFF
--- a/src/Amazon.Common.DotNetCli.Tools/Utilities.cs
+++ b/src/Amazon.Common.DotNetCli.Tools/Utilities.cs
@@ -298,12 +298,15 @@ namespace Amazon.Common.DotNetCli.Tools
         /// <returns></returns>
         private static IDictionary<string, string> GetFilesToIncludeInArchive(string publishLocation)
         {
+            const char uniformDirectorySeparator = '/';
             var includedFiles = new Dictionary<string, string>();
             var allFiles = Directory.GetFiles(publishLocation, "*.*", SearchOption.AllDirectories);
             foreach (var file in allFiles)
             {
-                var relativePath = file.Substring(publishLocation.Length);
-                if (relativePath[0] == Path.DirectorySeparatorChar)
+                var relativePath = file.Substring(publishLocation.Length)
+                    .Replace(Path.DirectorySeparatorChar.ToString(), uniformDirectorySeparator.ToString());
+                
+                if (relativePath[0] == uniformDirectorySeparator)
                     relativePath = relativePath.Substring(1);
 
                 includedFiles[relativePath] = file;


### PR DESCRIPTION
I've found a problem with directory separators that are used in zipping process. When `aws eb deploy-environment` command is called on windows system everything goes smooth untill EBS wants to unzip it on Linux environment ("Docker running on 64bit Amazon Linux/2.12.4"). Then this:

`warning:  /opt/elasticbeanstalk/deploy/appsource/source_bundle appears to use backslashes as path separators`

And this:

`Failed to unzip source bundle, abort deployment (ElasticBeanstalk::ExternalInvocationError)`

is poping out.

This commit is fixing this up. Switching to '/' is unharmful because windows is accepting paths with it without any problems.

I've tested this on both EBS configurations:

- Docker running on 64bit Amazon Linux/2.12.4
- IIS 10.0 running on 64bit Windows Server 2016/1.2.0

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
