### PR TITLE
Make Target Framework Optional

### DIFF
--- a/src/Amazon.Common.DotNetCli.Tools/Utilities.cs
+++ b/src/Amazon.Common.DotNetCli.Tools/Utilities.cs
@@ -149,14 +149,29 @@ namespace Amazon.Common.DotNetCli.Tools
 
         public static string LookupTargetFrameworkFromProjectFile(string projectLocation)
         {
-            var files = Directory.GetFiles(projectLocation, "*.csproj", SearchOption.TopDirectoryOnly);
-            if (files.Length != 1)
-                return null;
+            var projectFile = FindProjectFileInDirectory(projectLocation);
 
-            var xdoc = XDocument.Load(files[0]);
+            var xdoc = XDocument.Load(projectFile);
 
             var element = xdoc.XPathSelectElement("//PropertyGroup/TargetFramework");
             return element?.Value;
+        }
+
+        public static string FindProjectFileInDirectory(string directory)
+        {
+            if (File.Exists(directory))
+                return directory;
+            
+            foreach (var ext in new [] { "*.csproj", "*.fsproj", "*.vbproj" })
+            {
+                var files = Directory.GetFiles(directory, ext, SearchOption.TopDirectoryOnly);
+                if (files.Length == 1)
+                {
+                    return files[0];
+                }
+            }
+
+            return null;
         }
 
         /// <summary>

--- a/src/Amazon.Lambda.Tools/Amazon.Lambda.Tools.csproj
+++ b/src/Amazon.Lambda.Tools/Amazon.Lambda.Tools.csproj
@@ -9,13 +9,13 @@
     <PackageId>Amazon.Lambda.Tools</PackageId>
     <PackageTags>AWS;Amazon;Lambda</PackageTags>
     <PackAsTool>true</PackAsTool>
-	<ToolCommandName>dotnet-lambda</ToolCommandName>
-	<GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+	  <ToolCommandName>dotnet-lambda</ToolCommandName>
+	  <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Company>Amazon.com, Inc</Company>
     <Copyright>Copyright 2009-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.</Copyright>
     <Product>AWS Lambda Tools for .NET CLI</Product>
     <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
-    <Version>3.1.3</Version>
+    <Version>3.1.4</Version>
   </PropertyGroup>
   <ItemGroup>
     <Content Include="Resources\build-lambda-zip.exe">

--- a/src/Amazon.Lambda.Tools/Commands/DeployFunctionCommand.cs
+++ b/src/Amazon.Lambda.Tools/Commands/DeployFunctionCommand.cs
@@ -127,10 +127,14 @@ namespace Amazon.Lambda.Tools.Commands
                 // Release will be the default configuration if nothing set.
                 string configuration = this.GetStringValueOrDefault(this.Configuration, CommonDefinedCommandOptions.ARGUMENT_CONFIGURATION, false);
 
-                string targetFramework = this.GetStringValueOrDefault(this.TargetFramework, CommonDefinedCommandOptions.ARGUMENT_FRAMEWORK, true);
+                var targetFramework = this.GetStringValueOrDefault(this.TargetFramework, CommonDefinedCommandOptions.ARGUMENT_FRAMEWORK, false);
+                if (string.IsNullOrEmpty(targetFramework))
+                {
+                    targetFramework = Utilities.LookupTargetFrameworkFromProjectFile(Utilities.DetermineProjectLocation(this.WorkingDirectory, projectLocation));
+                }
                 string msbuildParameters = this.GetStringValueOrDefault(this.MSBuildParameters, CommonDefinedCommandOptions.ARGUMENT_MSBUILD_PARAMETERS, false);
 
-                ValidateTargetFrameworkAndLambdaRuntime();
+                ValidateTargetFrameworkAndLambdaRuntime(targetFramework);
 
                 bool disableVersionCheck = this.GetBoolValueOrDefault(this.DisableVersionCheck, LambdaDefinedCommandOptions.ARGUMENT_DISABLE_VERSION_CHECK, false).GetValueOrDefault();
                 string publishLocation;
@@ -289,11 +293,10 @@ namespace Amazon.Lambda.Tools.Commands
             return true;
         }
 
-        private void ValidateTargetFrameworkAndLambdaRuntime()
+        private void ValidateTargetFrameworkAndLambdaRuntime(string targetFramework)
         {
             string runtimeName = this.GetStringValueOrDefault(this.Runtime, LambdaDefinedCommandOptions.ARGUMENT_FUNCTION_RUNTIME, true);
-            string frameworkName = this.GetStringValueOrDefault(this.TargetFramework, CommonDefinedCommandOptions.ARGUMENT_FRAMEWORK, true);
-            LambdaUtilities.ValidateTargetFrameworkAndLambdaRuntime(runtimeName, frameworkName);
+            LambdaUtilities.ValidateTargetFrameworkAndLambdaRuntime(runtimeName, targetFramework);
         }
 
         protected override void SaveConfigFile(JsonData data)

--- a/src/Amazon.Lambda.Tools/Commands/PackageCommand.cs
+++ b/src/Amazon.Lambda.Tools/Commands/PackageCommand.cs
@@ -89,11 +89,17 @@ namespace Amazon.Lambda.Tools.Commands
 
             return Task.Run(() =>
             {
+                var projectLocation = this.GetStringValueOrDefault(this.ProjectLocation, CommonDefinedCommandOptions.ARGUMENT_PROJECT_LOCATION, false);
+
                 // Release will be the default configuration if nothing set.
                 var configuration = this.GetStringValueOrDefault(this.Configuration, CommonDefinedCommandOptions.ARGUMENT_CONFIGURATION, false);
 
-                var targetFramework = this.GetStringValueOrDefault(this.TargetFramework, CommonDefinedCommandOptions.ARGUMENT_FRAMEWORK, true);
-                var projectLocation = this.GetStringValueOrDefault(this.ProjectLocation, CommonDefinedCommandOptions.ARGUMENT_PROJECT_LOCATION, false);
+                var targetFramework = this.GetStringValueOrDefault(this.TargetFramework, CommonDefinedCommandOptions.ARGUMENT_FRAMEWORK, false);
+                if(string.IsNullOrEmpty(targetFramework))
+                {
+                    targetFramework = Utilities.LookupTargetFrameworkFromProjectFile(Utilities.DetermineProjectLocation(this.WorkingDirectory, projectLocation));
+                }
+
                 var msbuildParameters = this.GetStringValueOrDefault(this.MSBuildParameters, CommonDefinedCommandOptions.ARGUMENT_MSBUILD_PARAMETERS, false);
                 var disableVersionCheck = this.GetBoolValueOrDefault(this.DisableVersionCheck, LambdaDefinedCommandOptions.ARGUMENT_DISABLE_VERSION_CHECK, false).GetValueOrDefault();
 

--- a/src/Amazon.Lambda.Tools/LambdaUtilities.cs
+++ b/src/Amazon.Lambda.Tools/LambdaUtilities.cs
@@ -10,6 +10,7 @@ using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using ThirdParty.Json.LitJson;
 using System.Xml.Linq;
+using System.Xml.Linq;
 using Amazon.Common.DotNetCli.Tools;
 
 namespace Amazon.Lambda.Tools
@@ -25,13 +26,14 @@ namespace Amazon.Lambda.Tools
             {Amazon.Lambda.Runtime.Dotnetcore10.Value, "netcoreapp1.0"}
         };
 
-        public static string DetermineTargetFrameworkFromLambdaRuntime(string lambdaRuntime)
+        public static string DetermineTargetFrameworkFromLambdaRuntime(string lambdaRuntime, string projectLocation)
         {
             string runtime;
             if (_lambdaRuntimeToDotnetFramework.TryGetValue(lambdaRuntime, out runtime))
                 return runtime;
 
-            return null;
+            var framework = Utilities.LookupTargetFrameworkFromProjectFile(projectLocation);
+            return framework;
         }
         
         /// <summary>

--- a/src/Amazon.Lambda.Tools/TemplateProcessor/TemplateProcessorManager.cs
+++ b/src/Amazon.Lambda.Tools/TemplateProcessor/TemplateProcessorManager.cs
@@ -200,7 +200,7 @@ namespace Amazon.Lambda.Tools.TemplateProcessor
             var outputPackage = GenerateOutputZipFilename(field);
             command.OutputPackageFileName = outputPackage;
             command.TargetFramework =
-                LambdaUtilities.DetermineTargetFrameworkFromLambdaRuntime(field.Resource.LambdaRuntime);
+                LambdaUtilities.DetermineTargetFrameworkFromLambdaRuntime(field.Resource.LambdaRuntime, location);
 
             // If the project is in the same directory as the CloudFormation template then use any parameters
             // there were specified on the command to build the project.

--- a/test/Amazon.Common.DotNetCli.Tools.Test/UtilitesTests.cs
+++ b/test/Amazon.Common.DotNetCli.Tools.Test/UtilitesTests.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Reflection;
+using System.Text;
+
+using Xunit;
+
+namespace Amazon.Common.DotNetCli.Tools.Test
+{
+    public class UtilitesTests
+    {
+        [Theory]
+        [InlineData("../../../../../testapps/TestFunction", "netcoreapp1.0")]
+        [InlineData("../../../../../testapps/ServerlessWithYamlFunction", "netcoreapp2.0")]
+        [InlineData("../../../../../testapps/TestBeanstalkWebApp", "netcoreapp2.1")]
+        public void CheckFramework(string projectPath, string expectedFramework)
+        {
+            var assembly = this.GetType().GetTypeInfo().Assembly;
+            var fullPath = Path.GetFullPath(Path.GetDirectoryName(assembly.Location) + projectPath);
+            var determinedFramework = Utilities.LookupTargetFrameworkFromProjectFile(projectPath);
+            Assert.Equal(expectedFramework, determinedFramework);
+        }
+    }
+}

--- a/test/Amazon.Lambda.Tools.Test/DeployTest.cs
+++ b/test/Amazon.Lambda.Tools.Test/DeployTest.cs
@@ -117,7 +117,6 @@ namespace Amazon.Lambda.Tools.Test
             command.Timeout = 10;
             command.Role = this._roleArn;
             command.Configuration = "Release";
-            command.TargetFramework = "netcoreapp1.0";
             command.Runtime = "dotnetcore1.0";
             command.DisableInteractive = true;
 
@@ -160,7 +159,6 @@ namespace Amazon.Lambda.Tools.Test
             var packageCommand = new PackageCommand(new ConsoleToolLogger(), fullPath, new string[0]);
             packageCommand.OutputPackageFileName = packageZip;
             packageCommand.Configuration = "Release";
-            packageCommand.TargetFramework = "netcoreapp1.0";
 
             await packageCommand.ExecuteAsync();
 


### PR DESCRIPTION
Update commands using `--target-framework` to have the switch be optional. If it is not set then determine the target framework from the project.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
