### PR TITLE
Add .NET Core 2.0 deprecation message.

### DIFF
--- a/src/Amazon.Lambda.Tools/LambdaPackager.cs
+++ b/src/Amazon.Lambda.Tools/LambdaPackager.cs
@@ -47,7 +47,9 @@ namespace Amazon.Lambda.Tools
             string projectLocation, string configuration, string targetFramework, string msbuildParameters, bool disableVersionCheck,
             out string publishLocation, ref string zipArchivePath)
         {
-            if(string.IsNullOrEmpty(configuration))
+            LogDotNetCore20DeprecationMessageIfNecessary(logger, targetFramework);
+
+            if (string.IsNullOrEmpty(configuration))
                 configuration = LambdaConstants.DEFAULT_BUILD_CONFIGURATION;
             
             string lambdaRuntimePackageStoreManifestContent = null;
@@ -659,6 +661,37 @@ namespace Amazon.Lambda.Tools
                 {
                     logger?.WriteLine(string.Format("Created publish archive ({0}).", zipArchivePath));
                 }
+            }
+        }
+
+        internal static void LogDotNetCore20DeprecationMessageIfNecessary(IToolLogger logger, string targetFramework)
+        {
+            if (targetFramework == "netcoreapp2.0" && logger != null)
+            {
+                logger.WriteLine("--------------------------------------------------------------------------------");
+                logger.WriteLine(".NET Core 2.0 Lambda Function Deprecation Notice");
+                logger.WriteLine("--------------------------------------------------------------------------------");
+                logger.WriteLine("Support for .NET Core 2.0 Lambda functions will soon be deprecated.");
+                logger.WriteLine("");
+                logger.WriteLine("Support for .NET Core 2.0 was discontinued by Microsoft in October 2018.  This");
+                logger.WriteLine("version of the runtime is no longer receiving bug fixes or security updates from");
+                logger.WriteLine("Microsoft.  AWS Lambda has discontinued updates to this runtime as well.");
+                logger.WriteLine("");
+                logger.WriteLine("You can find Lambda's runtime support policy here:");
+                logger.WriteLine("https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html");
+                logger.WriteLine("");
+                logger.WriteLine("You will notice an initial change 30 days prior to the deprecation.");
+                logger.WriteLine("During the 30 day grace period you will be able to update existing .NET Core 2.0");
+                logger.WriteLine("Lambda functions but you will not be able to create new ones.  After the");
+                logger.WriteLine("deprecation has been finalized you will be unable to create or update .NET Core");
+                logger.WriteLine("2.0 functions.");
+                logger.WriteLine("");
+                logger.WriteLine("However, both during and after the grace period you WILL be able to invoke .NET ");
+                logger.WriteLine("Core 2.0 functions.  Existing .NET Core 2.0 function invocation will continue to");
+                logger.WriteLine("be available, subject to Lambda's runtime support policy.");
+                logger.WriteLine("");
+                logger.WriteLine("--------------------------------------------------------------------------------");
+
             }
         }
     }

--- a/src/Amazon.Lambda.Tools/LambdaPackager.cs
+++ b/src/Amazon.Lambda.Tools/LambdaPackager.cs
@@ -47,7 +47,7 @@ namespace Amazon.Lambda.Tools
             string projectLocation, string configuration, string targetFramework, string msbuildParameters, bool disableVersionCheck,
             out string publishLocation, ref string zipArchivePath)
         {
-            LogDotNetCore20DeprecationMessageIfNecessary(logger, targetFramework);
+            LogDeprecationMessagesIfNecessary(logger, targetFramework);
 
             if (string.IsNullOrEmpty(configuration))
                 configuration = LambdaConstants.DEFAULT_BUILD_CONFIGURATION;
@@ -664,7 +664,7 @@ namespace Amazon.Lambda.Tools
             }
         }
 
-        internal static void LogDotNetCore20DeprecationMessageIfNecessary(IToolLogger logger, string targetFramework)
+        internal static void LogDeprecationMessagesIfNecessary(IToolLogger logger, string targetFramework)
         {
             if (targetFramework == "netcoreapp2.0" && logger != null)
             {


### PR DESCRIPTION
Show a message about the upcoming .NET Core 2.0 deprecation in Lambda if the function being packaged uses .NET Core 2.0.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
