### PR TITLE
Fixed issue of not handling embedded node.js or python code

### DIFF
--- a/src/Amazon.Lambda.Tools/TemplateProcessor/UpdatableResource.cs
+++ b/src/Amazon.Lambda.Tools/TemplateProcessor/UpdatableResource.cs
@@ -90,7 +90,23 @@ namespace Amazon.Lambda.Tools.TemplateProcessor
 
             public string Name => this.Field.Name;
 
-            public bool IsCode => this.Field.IsCode;
+            public bool IsCode
+            {
+                get
+                {
+                    if (!this.Field.IsCode)
+                    {
+                        return false;
+                    }
+                    if(!string.IsNullOrEmpty(this._resource.DataSource.GetValue("Code", "ZipFile")))
+                    {
+                        // The template contains embedded code.
+                        return false;
+                    }                     
+
+                    return true;
+                }
+            }
 
             public string GetLocalPath()
             {

--- a/test/Amazon.Lambda.Tools.Test/TemplateParserTests.cs
+++ b/test/Amazon.Lambda.Tools.Test/TemplateParserTests.cs
@@ -452,7 +452,7 @@ namespace Amazon.Lambda.Tools.Test
 
         public static IEnumerable<object[]> IgnoreResourceWithInlineCodeData()
         {
-            const string InclineCode = @"{ 'Fn::Join': ['', [
+            const string InlineCode = @"{ 'Fn::Join': ['', [
   'var response = require('cfn-response');',
   'exports.handler = function(event, context) {',
   '  var input = parseInt(event.ResourceProperties.Input);',
@@ -463,7 +463,7 @@ namespace Amazon.Lambda.Tools.Test
             var list = new List<object[]>();
             {
                 var codeData = new JsonData();
-                codeData["ZipFile"] = InclineCode;
+                codeData["ZipFile"] = InlineCode;
 
                 var rootData = new JsonData();
                 rootData["Code"] = codeData;
@@ -473,7 +473,7 @@ namespace Amazon.Lambda.Tools.Test
             }
             {
                 var codeData = new YamlMappingNode();
-                codeData.Children.Add("ZipFile", new YamlScalarNode(InclineCode));
+                codeData.Children.Add("ZipFile", new YamlScalarNode(InlineCode));
 
                 var rootData = new YamlMappingNode();
                 rootData.Children.Add("Code", codeData);

--- a/test/Amazon.Lambda.Tools.Test/TemplateParserTests.cs
+++ b/test/Amazon.Lambda.Tools.Test/TemplateParserTests.cs
@@ -440,7 +440,51 @@ namespace Amazon.Lambda.Tools.Test
 
             Assert.Null(resource.Fields[0].GetLocalPath());
         }
-        
+
+        [Theory]
+        [MemberData(nameof(IgnoreResourceWithInlineCodeData))]
+        public void IgnoreResourceWithInlineCode(IUpdatableResourceDataSource source)
+        {
+            var resource = new UpdatableResource("TestResource", UpdatableResourceDefinition.DEF_LAMBDA_FUNCTION, source);
+            Assert.False(resource.Fields[0].IsCode);
+        }
+
+
+        public static IEnumerable<object[]> IgnoreResourceWithInlineCodeData()
+        {
+            const string InclineCode = @"{ 'Fn::Join': ['', [
+  'var response = require('cfn-response');',
+  'exports.handler = function(event, context) {',
+  '  var input = parseInt(event.ResourceProperties.Input);',
+  '  var responseData = {Value: input * 5};',
+  '  response.send(event, context, response.SUCCESS, responseData);',
+  '};'
+]]}";
+            var list = new List<object[]>();
+            {
+                var codeData = new JsonData();
+                codeData["ZipFile"] = InclineCode;
+
+                var rootData = new JsonData();
+                rootData["Code"] = codeData;
+
+                var source = new JsonTemplateParser.JsonUpdatableResourceDataSource(null, rootData);
+                list.Add(new object[] { source });
+            }
+            {
+                var codeData = new YamlMappingNode();
+                codeData.Children.Add("ZipFile", new YamlScalarNode(InclineCode));
+
+                var rootData = new YamlMappingNode();
+                rootData.Children.Add("Code", codeData);
+
+                var source = new YamlTemplateParser.YamlUpdatableResourceDataSource(null, rootData);
+                list.Add(new object[] { source });
+            }
+
+            return list;
+        }
+
         [Theory]
         [InlineData("/home/infra.template")]
         public void CloudFormationStack_GetLocalPathAndEmptyS3Bucket(string localPath)


### PR DESCRIPTION
*Description of changes:*
It is possible to embed Node.js or Python code inside CloudFormation template. This PR updates the template parser to not attempt to build the current directory if the code is embedded.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
