### PR TITLE
Switch --runtime value to linux-x64

### DIFF
--- a/src/Amazon.Lambda.Tools/LambdaConstants.cs
+++ b/src/Amazon.Lambda.Tools/LambdaConstants.cs
@@ -34,7 +34,7 @@ namespace Amazon.Lambda.Tools
         internal const string RUNTIME_HIERARCHY = "netcore.runtime.hierarchy.json";
 
         // The closest match to Amazon Linux
-        internal const string RUNTIME_HIERARCHY_STARTING_POINT = "rhel.7.2-x64";
+        internal const string LEGACY_RUNTIME_HIERARCHY_STARTING_POINT = "rhel.7.2-x64";
 
 
         public const string AWS_LAMBDA_MANAGED_POLICY_PREFIX = "AWSLambda";

--- a/src/Amazon.Lambda.Tools/LambdaConstants.cs
+++ b/src/Amazon.Lambda.Tools/LambdaConstants.cs
@@ -33,7 +33,7 @@ namespace Amazon.Lambda.Tools
         // https://github.com/dotnet/corefx/blob/release/1.0.0/pkg/Microsoft.NETCore.Platforms/runtime.json
         internal const string RUNTIME_HIERARCHY = "netcore.runtime.hierarchy.json";
 
-        // The closest match to Amazon Linux
+        // The runtime identifier used for older Lambda runtimes running on Amazon Linux 1.
         internal const string LEGACY_RUNTIME_HIERARCHY_STARTING_POINT = "rhel.7.2-x64";
 
 

--- a/src/Amazon.Lambda.Tools/LambdaPackager.cs
+++ b/src/Amazon.Lambda.Tools/LambdaPackager.cs
@@ -427,7 +427,7 @@ namespace Amazon.Lambda.Tools
 
                 // Use a queue to do a breadth first search through the list of runtimes.
                 var queue = new Queue<string>();
-                queue.Enqueue(LambdaConstants.RUNTIME_HIERARCHY_STARTING_POINT);
+                queue.Enqueue(LambdaConstants.LEGACY_RUNTIME_HIERARCHY_STARTING_POINT);
 
                 while(queue.Count > 0)
                 {

--- a/src/Amazon.Lambda.Tools/LambdaUtilities.cs
+++ b/src/Amazon.Lambda.Tools/LambdaUtilities.cs
@@ -673,6 +673,27 @@ namespace Amazon.Lambda.Tools
             var updatedContent = updatedDoc.ToString();
             
             return new ConvertManifestContentToSdkManifestResult(true, updatedContent);
-        }                
+        }
+
+        /// <summary>
+        /// Determines what runtime identifier (RID) to use when running a dotnet CLI command. For the
+        /// older .NET Lambda runtimes that are not running on Amazon Linux 2 keep using the existing rhel.7.2-x64
+        /// RID. For all other runtimes that are running on Amazon Linux 2 use the newer linux-x64 RID which did
+        /// not exist when this tool was first created.
+        /// </summary>
+        /// <param name="targetFramework"></param>
+        /// <returns></returns>
+        public static string DetermineRuntimeParameter(string targetFramework)
+        {
+            switch (targetFramework)
+            {
+                case "netcoreapp1.0":
+                case "netcoreapp2.0":
+                case "netcoreapp2.1":
+                    return LambdaConstants.LEGACY_RUNTIME_HIERARCHY_STARTING_POINT;
+                default:
+                    return "linux-x64";
+            }
+        }
     }
 }

--- a/test/Amazon.Common.DotNetCli.Tools.Test/UtilitesTests.cs
+++ b/test/Amazon.Common.DotNetCli.Tools.Test/UtilitesTests.cs
@@ -11,7 +11,7 @@ namespace Amazon.Common.DotNetCli.Tools.Test
     public class UtilitesTests
     {
         [Theory]
-        [InlineData("../../../../../testapps/TestFunction", "netcoreapp1.0")]
+        [InlineData("../../../../../testapps/TestFunction", "netcoreapp2.1")]
         [InlineData("../../../../../testapps/ServerlessWithYamlFunction", "netcoreapp2.1")]
         [InlineData("../../../../../testapps/TestBeanstalkWebApp", "netcoreapp2.1")]
         public void CheckFramework(string projectPath, string expectedFramework)

--- a/test/Amazon.Lambda.Tools.Test/UtilitiesTests.cs
+++ b/test/Amazon.Lambda.Tools.Test/UtilitiesTests.cs
@@ -32,5 +32,20 @@ namespace Amazon.Lambda.Tools.Test
             var value = LambdaUtilities.DetermineListDisplayLayerDescription(fullLayer, maxLength);
             Assert.Equal(displayLayer, value);
         }
+
+        [Theory]
+        [InlineData("netcoreapp1.0", "rhel.7.2-x64")]
+        [InlineData("netcoreapp1.1", "linux-x64")]
+        [InlineData("netcoreapp2.0", "rhel.7.2-x64")]
+        [InlineData("netcoreapp2.1", "rhel.7.2-x64")]
+        [InlineData("netcoreapp2.2", "linux-x64")]
+        [InlineData("netcoreapp3.0", "linux-x64")]
+        [InlineData("netcoreapp3.1", "linux-x64")]
+        [InlineData("netcoreapp6.0", "linux-x64")]
+        public void TestDetermineRuntimeParameter(string targetFramework, string expectedValue)
+        {
+            var runtime = LambdaUtilities.DetermineRuntimeParameter(targetFramework);
+            Assert.Equal(expectedValue, runtime);
+        }
     }
 }


### PR DESCRIPTION
*Description of changes:*

Change what the value set --runtime when calling dotnet CLI commands for runtimes using Amazon Linux 2.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
