### PR TITLE
Disable creation of .NET Core 3.1 Lambda layers due to a issue in the…

### DIFF
--- a/src/Amazon.Lambda.Tools/Commands/PublishLayerCommand.cs
+++ b/src/Amazon.Lambda.Tools/Commands/PublishLayerCommand.cs
@@ -154,6 +154,14 @@ namespace Amazon.Lambda.Tools.Commands
             var projectLocation = this.GetStringValueOrDefault(this.ProjectLocation, CommonDefinedCommandOptions.ARGUMENT_PROJECT_LOCATION, false);
             var enableOptimization = this.GetBoolValueOrDefault(this.EnablePackageOptimization, LambdaDefinedCommandOptions.ARGUMENT_ENABLE_PACKAGE_OPTIMIZATION, false).GetValueOrDefault();
 
+            if(string.Equals(targetFramework, "netcoreapp3.1"))
+            {
+                var message = "Publishing runtime package store layers targeting .NET Core 3.1 is currently disabled due to an issue with the dotnet cli's 'store' command " +
+                              "used to create the runtime package store. For further information see the following GitHub issue.\n" +
+                              "https://github.com/dotnet/sdk/issues/10973";
+                throw new LambdaToolsException(message, LambdaToolsException.LambdaErrorCode.DisabledSupportForNET31Layers);
+            }
+
 #if NETCORE
             if (enableOptimization)
             {

--- a/src/Amazon.Lambda.Tools/Exceptions.cs
+++ b/src/Amazon.Lambda.Tools/Exceptions.cs
@@ -64,7 +64,9 @@ namespace Amazon.Lambda.Tools
 
             FailedToFindZipProgram,
             FailedToDetectSdkVersion,
-            LayerNetSdkVersionMismatch
+            LayerNetSdkVersionMismatch,
+
+            DisabledSupportForNET31Layers
         }
 
         public LambdaToolsException(string message, LambdaErrorCode code) : base(message, code.ToString(), null)


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/dotnet/sdk/issues/10973
https://github.com/aws/aws-extensions-for-dotnet-cli/issues/113

*Description of changes:*
Since the `dotnet store` is currently not working correctly for .NET Core 3.1 we are going disable the attempt of creating a .NET Core 3.1 layer to avoid users getting confusing error messages. When the issue on the **dotnet/sdk** repo is resolved we will hopefully re-enable the feature.


Here is a screen showing first correctly creating a .NET Core 2.1 layer and then failing to create a .NET Core 3.1 layer.

![image](https://user-images.githubusercontent.com/1653751/77694901-118da980-6f68-11ea-953e-069dbbd09b47.png)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
