### PR TITLE
Echo Dotnet Publish

### DIFF
--- a/RELEASE.CHANGELOG.md
+++ b/RELEASE.CHANGELOG.md
@@ -1,3 +1,7 @@
+### Release Unreleased
+* **Amazon.Lambda.Tools**
+  * Echo the full `dotnet publish` command using during lambda deployment
+
 ### Release 2020-03-31
 * **Amazon.Lambda.Tools (4.0.0)**
   * Added support to deploy to .NET Core 3.1 Lambda runtime

--- a/src/Amazon.Lambda.Tools/LambdaDotNetCLIWrapper.cs
+++ b/src/Amazon.Lambda.Tools/LambdaDotNetCLIWrapper.cs
@@ -264,6 +264,9 @@ namespace Amazon.Lambda.Tools
                 }
             }
 
+            // echo the full dotnet command for debug
+            _logger?.WriteLine($"... dotnet {arguments}");
+
             var psi = new ProcessStartInfo
             {
                 FileName = dotnetCLI,


### PR DESCRIPTION
*Issue*
I had an issue with lambda deployment caused by the failure of `dotnet publish`. However, I was unable to replicate the problem by calling `dotnet publish` manually. In order to debug the issue, I added an additional log statement to output the publish args being used internally by the lambda tool. In my case, it was nuget package resolution issues that only showed when the `--runtime linux-x64` arg was used.

I think my change would be a useful addition for others in order to help debug publish failures.

*Changes*
- Added additional log statement to `LambdaDotNetCLIWrapper.Publish`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
