### PR TITLE
Work around packaging issue with Microsoft.PowerShell.SDK

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,4 +23,5 @@
 
 **/.vscode
 **/.idea
+**/.ionide
 *.userprefs

--- a/RELEASE.CHANGELOG.md
+++ b/RELEASE.CHANGELOG.md
@@ -1,3 +1,9 @@
+### Release 2020-06-23
+* **Amazon.ElasticBeanstalk.Tools (4.0.0)**
+  * Added support to to deploy to the new Beanstalk ".NET Core for Linux" platform.
+  * Added ability to enable sticky sessions.
+  * Added switch to do a self contained publish
+
 ### Release 2020-03-31
 * **Amazon.Lambda.Tools (4.0.0)**
   * Added support to deploy to .NET Core 3.1 Lambda runtime

--- a/aws-extensions-for-dotnet-cli.sln
+++ b/aws-extensions-for-dotnet-cli.sln
@@ -69,6 +69,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TestLayerServerless", "test
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TestLayerAspNetCore", "testapps\TestLayerAspNetCore\TestLayerAspNetCore.csproj", "{D9C49D8B-0162-4C6B-9CAD-FBF8E246CDC9}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TestPowerShellParallelTest", "testapps\TestPowerShellParallelTest\TestPowerShellParallelTest.csproj", "{71926012-0E0D-4A46-B6C0-6A421645CA06}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -171,6 +173,10 @@ Global
 		{D9C49D8B-0162-4C6B-9CAD-FBF8E246CDC9}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{D9C49D8B-0162-4C6B-9CAD-FBF8E246CDC9}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{D9C49D8B-0162-4C6B-9CAD-FBF8E246CDC9}.Release|Any CPU.Build.0 = Release|Any CPU
+		{71926012-0E0D-4A46-B6C0-6A421645CA06}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{71926012-0E0D-4A46-B6C0-6A421645CA06}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{71926012-0E0D-4A46-B6C0-6A421645CA06}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{71926012-0E0D-4A46-B6C0-6A421645CA06}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -203,6 +209,7 @@ Global
 		{AC3E127E-F157-404C-BCCC-CFF1BFF3A777} = {BB3CF729-8213-4DDD-85AE-A5E7754F3944}
 		{1B90F7DE-9E8D-4F2B-A417-23263925429A} = {BB3CF729-8213-4DDD-85AE-A5E7754F3944}
 		{D9C49D8B-0162-4C6B-9CAD-FBF8E246CDC9} = {BB3CF729-8213-4DDD-85AE-A5E7754F3944}
+		{71926012-0E0D-4A46-B6C0-6A421645CA06} = {BB3CF729-8213-4DDD-85AE-A5E7754F3944}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {DBFC70D6-49A2-40A1-AB08-5D9504AB7112}

--- a/src/Amazon.Common.DotNetCli.Tools/Commands/BaseCommand.cs
+++ b/src/Amazon.Common.DotNetCli.Tools/Commands/BaseCommand.cs
@@ -773,6 +773,7 @@ namespace Amazon.Common.DotNetCli.Tools.Commands
 
                     var config = new AmazonS3Config();
                     config.RegionEndpoint = DetermineAWSRegion();
+                    config.Timeout = TimeSpan.FromHours(1);
 
                     this._s3Client = new AmazonS3Client(DetermineAWSCredentials(), config);
                 }

--- a/src/Amazon.Common.DotNetCli.Tools/Utilities.cs
+++ b/src/Amazon.Common.DotNetCli.Tools/Utilities.cs
@@ -723,5 +723,44 @@ namespace Amazon.Common.DotNetCli.Tools
             }
             return code.ToString().Trim();
         }
+        
+        
+        public static void CopyDirectory(string sourceDirectory, string destinationDirectory, bool copySubDirectories)
+        {
+            // Get the subdirectories for the specified directory.
+            DirectoryInfo dir = new DirectoryInfo(sourceDirectory);
+
+            if (!dir.Exists)
+            {
+                throw new DirectoryNotFoundException(
+                    "Source directory does not exist or could not be found: "
+                    + sourceDirectory);
+            }
+
+            DirectoryInfo[] dirs = dir.GetDirectories();
+            // If the destination directory doesn't exist, create it.
+            if (!Directory.Exists(destinationDirectory))
+            {
+                Directory.CreateDirectory(destinationDirectory);
+            }
+
+            // Get the files in the directory and copy them to the new location.
+            FileInfo[] files = dir.GetFiles();
+            foreach (FileInfo file in files)
+            {
+                string tempPath = Path.Combine(destinationDirectory, file.Name);
+                file.CopyTo(tempPath, false);
+            }
+
+            // If copying subdirectories, copy them and their contents to new location.
+            if (copySubDirectories)
+            {
+                foreach (DirectoryInfo subdirectory in dirs)
+                {
+                    string temppath = Path.Combine(destinationDirectory, subdirectory.Name);
+                    CopyDirectory(subdirectory.FullName, temppath, copySubDirectories);
+                }
+            }
+        }
     }
 }

--- a/src/Amazon.Common.DotNetCli.Tools/Utilities.cs
+++ b/src/Amazon.Common.DotNetCli.Tools/Utilities.cs
@@ -755,8 +755,7 @@ namespace Amazon.Common.DotNetCli.Tools
                     "Source directory does not exist or could not be found: "
                     + sourceDirectory);
             }
-
-            DirectoryInfo[] dirs = dir.GetDirectories();
+            
             // If the destination directory doesn't exist, create it.
             if (!Directory.Exists(destinationDirectory))
             {
@@ -774,6 +773,7 @@ namespace Amazon.Common.DotNetCli.Tools
             // If copying subdirectories, copy them and their contents to new location.
             if (copySubDirectories)
             {
+                DirectoryInfo[] dirs = dir.GetDirectories();
                 foreach (DirectoryInfo subdirectory in dirs)
                 {
                     string temppath = Path.Combine(destinationDirectory, subdirectory.Name);

--- a/test/Amazon.Lambda.Tools.Test/DeployTest.cs
+++ b/test/Amazon.Lambda.Tools.Test/DeployTest.cs
@@ -356,7 +356,7 @@ namespace Amazon.Lambda.Tools.Test
             try
             {
 
-                var logger = new TestToolLogger();
+                var logger = new TestToolLogger(_testOutputHelper);
                 var assembly = this.GetType().GetTypeInfo().Assembly;
 
                 var fullPath = Path.GetFullPath(Path.GetDirectoryName(assembly.Location) + "../../../../../../testapps/TemplateSubstitutionTestProjects/StateMachineDefinitionStringTest");

--- a/test/Amazon.Lambda.Tools.Test/DeployTest.cs
+++ b/test/Amazon.Lambda.Tools.Test/DeployTest.cs
@@ -82,6 +82,51 @@ namespace Amazon.Lambda.Tools.Test
                 }
             }
         }
+        
+        [Fact]
+        public async Task TestPowerShellLambdaParallelTestCommand()
+        {
+            var assembly = this.GetType().GetTypeInfo().Assembly;
+
+            var fullPath = Path.GetFullPath(Path.GetDirectoryName(assembly.Location) + "../../../../../../testapps/TestPowerShellParallelTest");
+            var command = new DeployFunctionCommand(new TestToolLogger(_testOutputHelper), fullPath, new string[0]);
+            command.FunctionName = "test-function-" + DateTime.Now.Ticks;
+            command.Timeout = 10;
+            command.MemorySize = 512;
+            command.Role = TestHelper.GetTestRoleArn();
+            command.Configuration = "Release";
+            command.S3Bucket = this._testFixture.Bucket;
+            command.S3Prefix = "TestPowerShellParallelTest/";
+            command.Region = "us-east-1";
+            command.DisableInteractive = true;
+
+            var created = await command.ExecuteAsync();
+            try
+            {
+                Assert.True(created);
+
+                var invokeRequest = new InvokeRequest
+                {
+                    FunctionName = command.FunctionName,
+                    LogType = LogType.Tail,
+                    Payload = "{}"
+                };
+                var response = await command.LambdaClient.InvokeAsync(invokeRequest);
+
+                var logTail = Encoding.UTF8.GetString(Convert.FromBase64String(response.LogResult));
+                
+                Assert.Equal(200, response.StatusCode);
+                Assert.Contains("Running against: 1 for SharedVariable: Hello Shared Variable", logTail);
+                Assert.Contains("Running against: 10 for SharedVariable: Hello Shared Variable", logTail);
+            }
+            finally
+            {
+                if (created)
+                {
+                    await command.LambdaClient.DeleteFunctionAsync(command.FunctionName);
+                }
+            }
+        }        
 
         [Fact]
         public async Task RunDeployCommandWithCustomConfigAndProjectLocation()

--- a/testapps/TestPowerShellParallelTest/Bootstrap.cs
+++ b/testapps/TestPowerShellParallelTest/Bootstrap.cs
@@ -1,0 +1,11 @@
+using Amazon.Lambda.PowerShellHost;
+
+namespace TestPowerShellParallelTest
+{
+    public class Bootstrap : PowerShellFunctionHost
+    {
+        public Bootstrap() : base("TestPowerShellParallelTest.ps1")
+        {
+        }
+    }
+}

--- a/testapps/TestPowerShellParallelTest/TestPowerShellParallelTest.csproj
+++ b/testapps/TestPowerShellParallelTest/TestPowerShellParallelTest.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+    <PropertyGroup>
+        <TargetFramework>netcoreapp3.1</TargetFramework>
+        <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <Content Include="TestPowerShellParallelTest.ps1">
+            <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+        </Content>
+        <Content Include="./Modules/**">
+            <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+        </Content>
+    </ItemGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Microsoft.PowerShell.SDK" Version="7.0.0" />
+
+        <PackageReference Include="Amazon.Lambda.Core" Version="1.1.0" />
+        <PackageReference Include="Amazon.Lambda.PowerShellHost" Version="2.0.0" />
+    </ItemGroup>
+</Project>

--- a/testapps/TestPowerShellParallelTest/TestPowerShellParallelTest.ps1
+++ b/testapps/TestPowerShellParallelTest/TestPowerShellParallelTest.ps1
@@ -1,0 +1,5 @@
+$SharedVariable = "Hello Shared Variable"
+@(1..10) | ForEach-Object -Parallel { 
+    $i = $_
+    Write-Host "Running against: $i for SharedVariable: $($using:SharedVariable)"
+}

--- a/testapps/TestPowerShellParallelTest/aws-lambda-tools-defaults.json
+++ b/testapps/TestPowerShellParallelTest/aws-lambda-tools-defaults.json
@@ -1,0 +1,15 @@
+{
+    "profile"     : "",
+    "region"      : "",
+    "configuration" : "Release",
+    "framework"     : "netcoreapp3.1",
+    "function-runtime" : "dotnetcore3.1",
+    "function-memory-size" : 512,
+    "function-timeout"     : 90,
+    "function-handler"     : "TestPowerShellParallelTest::TestPowerShellParallelTest.Bootstrap::ExecuteFunction",
+    "function-name"        : "",
+    "function-role"        : "",
+    "tracing-mode"         : "",
+    "environment-variables" : "",
+    "apply-defaults"        : true
+}


### PR DESCRIPTION
*Description of changes:*
This PR is fixing PowerShell Lambda functions that use PowerShell 7 `-Parallel` feature which are currently failing because the new runspaces created fail to find the default Modules that should be loaded into.

The reason this is happening is the Lambda bundle is created using the `--runtime linux-x64` switch to reduce bundle size to what is just needed for Linux. This flatten the assemblies in the deployment bundle but the Module files under the runtime folder are still in their original location and so are failed to be found. To work around this issue the publishing tool checks to see if the Microsoft.PowerShell.SDK package is being used and if so move the Modules folder up to the root like the assemblies happened when the package was flatten.

The issue for Microsoft.PowerShell.SDK has been reported on the PowerShell repo which this work around was suggested.
https://github.com/PowerShell/PowerShell/issues/13132

Also noticed time out issues uploading large deployment bundles to S3. Increased the timeout out and switched to use TransferUtility to do multipart uploads.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
