### PR TITLE
Enable MSBuild Parameters for `package-ci` and `deploy-serverless`

### DIFF
--- a/src/Amazon.Lambda.Tools/TemplateProcessor/TemplateProcessorManager.cs
+++ b/src/Amazon.Lambda.Tools/TemplateProcessor/TemplateProcessorManager.cs
@@ -224,18 +224,12 @@ namespace Amazon.Lambda.Tools.TemplateProcessor
                 LambdaUtilities.DetermineTargetFrameworkFromLambdaRuntime(field.Resource.LambdaRuntime, location);
 
             command.LayerVersionArns = field.Resource.LambdaLayers;
+            if (!string.IsNullOrEmpty(this.DefaultOptions.TargetFramework))
+                command.TargetFramework = this.DefaultOptions.TargetFramework;
 
-            // If the project is in the same directory as the CloudFormation template then use any parameters
-            // there were specified on the command to build the project.
-            if (IsCurrentDirectory(field.GetLocalPath()))
-            {
-                if (!string.IsNullOrEmpty(this.DefaultOptions.TargetFramework))
-                    command.TargetFramework = this.DefaultOptions.TargetFramework;
-                
-                command.Configuration = this.DefaultOptions.Configuration;
-                command.DisableVersionCheck = this.DefaultOptions.DisableVersionCheck;
-                command.MSBuildParameters = this.DefaultOptions.MSBuildParameters;
-            }
+            command.Configuration = this.DefaultOptions.Configuration;
+            command.DisableVersionCheck = this.DefaultOptions.DisableVersionCheck;
+            command.MSBuildParameters = this.DefaultOptions.MSBuildParameters;
                         
             if(!await command.ExecuteAsync())
             {


### PR DESCRIPTION
These commands accept MSBuild parameters, but ignore them later on.

This also enables the configuration and the verison check disabling.
Not for any deep reason, but only because they were in the same `if`
block. I'm happy to put either of them back in the block if I
misunderstand the purpose.

Closes: #122

*Issue #, if available:*

#122 

*Description of changes:*

The parameters for configuration, version check disabling, and MSBuild parameters were not being passed to the package command when those parameters were supplied to the commands `package-ci` or `deploy-serverless` when that command was called from the root of a project. This removes the locality requirement.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
