### PR TITLE
Fix: Publish optimization uses a hardcoded runtime linux-x64 again.

### DIFF
--- a/src/Amazon.Lambda.Tools/LambdaConstants.cs
+++ b/src/Amazon.Lambda.Tools/LambdaConstants.cs
@@ -38,10 +38,9 @@ namespace Amazon.Lambda.Tools
         internal const string PRUNE_LIST_SDK_XML = "publish-layer-31sdk-prunelist.xml";
         
         internal const string PRUNE_LIST_SDKWEB_XML = "publish-layer-31sdkweb-prunelist.xml";
-
-        // The runtime identifier used for older Lambda runtimes running on Amazon Linux 1.
-        internal const string LEGACY_RUNTIME_HIERARCHY_STARTING_POINT = "rhel.7.2-x64";
-
+        
+        // The runtime identifier provides the most compatibility with Amazon Linux as most of the plain linux-x64 runtimes in reality target ubuntu/debian distros.
+        internal const string RUNTIME_HIERARCHY_STARTING_POINT = "rhel.7.2-x64";
 
         public const string AWS_LAMBDA_MANAGED_POLICY_PREFIX = "AWSLambda";
 

--- a/src/Amazon.Lambda.Tools/LambdaDotNetCLIWrapper.cs
+++ b/src/Amazon.Lambda.Tools/LambdaDotNetCLIWrapper.cs
@@ -84,7 +84,7 @@ namespace Amazon.Lambda.Tools
             arguments.Append($" --manifest \"{fullPackageManifest}\"");
 
 
-            arguments.Append($" --runtime {LambdaUtilities.DetermineRuntimeParameter(targetFramework)}");
+            arguments.Append($" --runtime {LambdaConstants.RUNTIME_HIERARCHY_STARTING_POINT}");
 
             if(!enableOptimization)
             {
@@ -216,7 +216,7 @@ namespace Amazon.Lambda.Tools
                     if (msbuildParameters == null ||
                         msbuildParameters.IndexOf("--runtime", StringComparison.InvariantCultureIgnoreCase) == -1)
                     {
-                        arguments.Append($" --runtime {LambdaUtilities.DetermineRuntimeParameter(targetFramework)}");
+                        arguments.Append($" --runtime {LambdaConstants.RUNTIME_HIERARCHY_STARTING_POINT}");
                     }
 
                     if (msbuildParameters == null ||

--- a/src/Amazon.Lambda.Tools/LambdaPackager.cs
+++ b/src/Amazon.Lambda.Tools/LambdaPackager.cs
@@ -448,7 +448,7 @@ namespace Amazon.Lambda.Tools
 
                 // Use a queue to do a breadth first search through the list of runtimes.
                 var queue = new Queue<string>();
-                queue.Enqueue(LambdaConstants.LEGACY_RUNTIME_HIERARCHY_STARTING_POINT);
+                queue.Enqueue(LambdaConstants.RUNTIME_HIERARCHY_STARTING_POINT);
 
                 while(queue.Count > 0)
                 {

--- a/src/Amazon.Lambda.Tools/LambdaUtilities.cs
+++ b/src/Amazon.Lambda.Tools/LambdaUtilities.cs
@@ -740,27 +740,6 @@ namespace Amazon.Lambda.Tools
             return new ConvertManifestContentToSdkManifestResult(true, updatedContent);
         }
 
-        /// <summary>
-        /// Determines what runtime identifier (RID) to use when running a dotnet CLI command. For the
-        /// older .NET Lambda runtimes that are not running on Amazon Linux 2 keep using the existing rhel.7.2-x64
-        /// RID. For all other runtimes that are running on Amazon Linux 2 use the newer linux-x64 RID which did
-        /// not exist when this tool was first created.
-        /// </summary>
-        /// <param name="targetFramework"></param>
-        /// <returns></returns>
-        public static string DetermineRuntimeParameter(string targetFramework)
-        {
-            switch (targetFramework)
-            {
-                case "netcoreapp1.0":
-                case "netcoreapp2.0":
-                case "netcoreapp2.1":
-                    return LambdaConstants.LEGACY_RUNTIME_HIERARCHY_STARTING_POINT;
-                default:
-                    return "linux-x64";
-            }
-        }
-
         public static async Task WaitTillFunctionAvailableAsync(IToolLogger logger, IAmazonLambda lambdaClient, string functionName)
         {
             const int POLL_INTERVAL = 3000;

--- a/test/Amazon.Lambda.Tools.Test/FlattenDependencyTests.cs
+++ b/test/Amazon.Lambda.Tools.Test/FlattenDependencyTests.cs
@@ -124,14 +124,16 @@ namespace Amazon.Lambda.Tools.Test
             }
         }
 
-        [Fact]
-        public async Task NativeDependency2Example()
+        [Theory]
+        [InlineData("netcoreapp2.1")]
+        [InlineData("netcoreapp3.1")]
+        public async Task NativeDependency2Example(string targetFramework)
         {
             var fullPath = GetTestProjectPath("NativeDependencyExample2");
             var command = new PackageCommand(new TestToolLogger(_testOutputHelper), fullPath, new string[0]);
             command.DisableInteractive = true;
             command.Configuration = "Release";
-            command.TargetFramework = "netcoreapp2.1";
+            command.TargetFramework = targetFramework;
 
             command.OutputPackageFileName = Path.GetTempFileName() + ".zip";
 

--- a/test/Amazon.Lambda.Tools.Test/UtilitiesTests.cs
+++ b/test/Amazon.Lambda.Tools.Test/UtilitiesTests.cs
@@ -35,21 +35,6 @@ namespace Amazon.Lambda.Tools.Test
         }
 
         [Theory]
-        [InlineData("netcoreapp1.0", "rhel.7.2-x64")]
-        [InlineData("netcoreapp1.1", "linux-x64")]
-        [InlineData("netcoreapp2.0", "rhel.7.2-x64")]
-        [InlineData("netcoreapp2.1", "rhel.7.2-x64")]
-        [InlineData("netcoreapp2.2", "linux-x64")]
-        [InlineData("netcoreapp3.0", "linux-x64")]
-        [InlineData("netcoreapp3.1", "linux-x64")]
-        [InlineData("netcoreapp6.0", "linux-x64")]
-        public void TestDetermineRuntimeParameter(string targetFramework, string expectedValue)
-        {
-            var runtime = LambdaUtilities.DetermineRuntimeParameter(targetFramework);
-            Assert.Equal(expectedValue, runtime);
-        }
-
-        [Theory]
         [InlineData("repo:old", "repo", "old")]
         [InlineData("repo", "repo", "latest")]
         [InlineData("repo:", "repo", "latest")]

--- a/testapps/FlattenDependencyTestProjects/NativeDependencyExample2/NativeDependencyExample2.csproj
+++ b/testapps/FlattenDependencyTestProjects/NativeDependencyExample2/NativeDependencyExample2.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
     <AssemblyName>NativeDependencyExample2</AssemblyName>
     <PackageId>NativeDependencyExample2</PackageId>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
@@ -10,7 +10,7 @@
     <WarningsAsErrors />
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Amazon.Lambda.Serialization.Json" Version="1.1.0" />
+    <PackageReference Include="Amazon.Lambda.Serialization.Json" Version="1.7.0" />
     <PackageReference Include="LibGit2Sharp.NativeBinaries" Version="1.0.226" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
*Issue #, if available:* #136

*Description of changes:*
* Make the tests check two runtime targets instead of one
* Always use the RHEL moniker


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
