### PR TITLE
Update AWS SDK for .NET dependencies.

### DIFF
--- a/src/Amazon.Common.DotNetCli.Tools/Amazon.Common.DotNetCli.Tools.csproj
+++ b/src/Amazon.Common.DotNetCli.Tools/Amazon.Common.DotNetCli.Tools.csproj
@@ -6,10 +6,10 @@
     <FileVersion>3.0.0.0</FileVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="AWSSDK.Core" Version="3.3.29.12" />
-    <PackageReference Include="AWSSDK.IdentityManagement" Version="3.3.8.1" />
-    <PackageReference Include="AWSSDK.S3" Version="3.3.30" />
-    <PackageReference Include="AWSSDK.SecurityToken" Version="3.3.4.34" />
+    <PackageReference Include="AWSSDK.Core" Version="3.5.1.20" />
+    <PackageReference Include="AWSSDK.IdentityManagement" Version="3.5.0.22" />
+    <PackageReference Include="AWSSDK.S3" Version="3.5.2" />
+    <PackageReference Include="AWSSDK.SecurityToken" Version="3.5.1.2" />
   </ItemGroup>
   <PropertyGroup Condition="'$(TargetFramework)' == 'netcoreapp2.1' ">
     <DefineConstants>$(DefineConstants);NETCORE</DefineConstants>

--- a/src/Amazon.ECS.Tools/Amazon.ECS.Tools.csproj
+++ b/src/Amazon.ECS.Tools/Amazon.ECS.Tools.csproj
@@ -20,14 +20,14 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AWSSDK.CloudWatchEvents" Version="3.3.8" />
-    <PackageReference Include="AWSSDK.CloudWatchLogs" Version="3.3.7" />
-    <PackageReference Include="AWSSDK.Core" Version="3.3.29.12" />
-    <PackageReference Include="AWSSDK.EC2" Version="3.3.75" />
-    <PackageReference Include="AWSSDK.ECR" Version="3.3.3.39" />
-    <PackageReference Include="AWSSDK.ECS" Version="3.3.21" />
-    <PackageReference Include="AWSSDK.IdentityManagement" Version="3.3.8.1" />
-    <PackageReference Include="AWSSDK.S3" Version="3.3.30" />
+    <PackageReference Include="AWSSDK.CloudWatchEvents" Version="3.5.1.4" />
+    <PackageReference Include="AWSSDK.CloudWatchLogs" Version="3.5.0.22" />
+    <PackageReference Include="AWSSDK.Core" Version="3.5.1.20" />
+    <PackageReference Include="AWSSDK.EC2" Version="3.5.7.2" />
+    <PackageReference Include="AWSSDK.ECR" Version="3.5.0.22" />
+    <PackageReference Include="AWSSDK.ECS" Version="3.5.0.22" />
+    <PackageReference Include="AWSSDK.IdentityManagement" Version="3.5.0.22" />
+    <PackageReference Include="AWSSDK.S3" Version="3.5.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Amazon.ElasticBeanstalk.Tools/Amazon.ElasticBeanstalk.Tools.csproj
+++ b/src/Amazon.ElasticBeanstalk.Tools/Amazon.ElasticBeanstalk.Tools.csproj
@@ -25,9 +25,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="AWSSDK.ElasticBeanstalk" Version="3.3.11.14" />
-    <PackageReference Include="AWSSDK.IdentityManagement" Version="3.3.8.1" />
-    <PackageReference Include="AWSSDK.S3" Version="3.3.30" />
+    <PackageReference Include="AWSSDK.ElasticBeanstalk" Version="3.5.0.22" />
+    <PackageReference Include="AWSSDK.IdentityManagement" Version="3.5.0.22" />
+    <PackageReference Include="AWSSDK.S3" Version="3.5.2" />
   </ItemGroup>
 
   <PropertyGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.1' ">

--- a/src/Amazon.Lambda.Tools/Amazon.Lambda.Tools.csproj
+++ b/src/Amazon.Lambda.Tools/Amazon.Lambda.Tools.csproj
@@ -31,12 +31,11 @@
     <EmbeddedResource Include="Resources\netcore.runtime.hierarchy.json" Exclude="bin\**;obj\**;**\*.xproj;packages\**;@(EmbeddedResource)" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
-    <PackageReference Include="System.Runtime.Loader" Version="4.0.0" />
-    <PackageReference Include="AWSSDK.CloudFormation" Version="3.3.13" />
-    <PackageReference Include="AWSSDK.Lambda" Version="3.3.19" />
-    <PackageReference Include="AWSSDK.IdentityManagement" Version="3.3.8.1" />
-    <PackageReference Include="AWSSDK.S3" Version="3.3.30" />
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+    <PackageReference Include="AWSSDK.CloudFormation" Version="3.5.0.22" />
+    <PackageReference Include="AWSSDK.Lambda" Version="3.5.0.22" />
+    <PackageReference Include="AWSSDK.IdentityManagement" Version="3.5.0.22" />
+    <PackageReference Include="AWSSDK.S3" Version="3.5.2" />
     <PackageReference Include="YamlDotNet.Signed" Version="5.2.1" />
   </ItemGroup>
   <PropertyGroup>

--- a/test/Amazon.Common.DotNetCli.Tools.Test/UtilitiesTests.cs
+++ b/test/Amazon.Common.DotNetCli.Tools.Test/UtilitiesTests.cs
@@ -13,7 +13,7 @@ namespace Amazon.Common.DotNetCli.Tools.Test
         {
             var result = Utilities.ExecuteShellCommand(null, FindDotnetProcess(), "--info");
             Assert.Equal(0, result.ExitCode);
-            Assert.Contains(".NET Core SDKs installed", result.Stdout);
+            Assert.Contains("SDKs installed", result.Stdout);
         }
         
         [Fact]

--- a/test/Amazon.ElasticBeanstalk.Tools.Test/Amazon.ElasticBeanstalk.Tools.Test.csproj
+++ b/test/Amazon.ElasticBeanstalk.Tools.Test/Amazon.ElasticBeanstalk.Tools.Test.csproj
@@ -7,10 +7,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AWSSDK.ElasticBeanstalk" Version="3.3.12.18" />
+    <PackageReference Include="AWSSDK.ElasticBeanstalk" Version="3.5.0.22" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0-preview-20170810-02" />
     <PackageReference Include="Moq" Version="4.10.1" />
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="xunit" Version="2.2.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
   </ItemGroup>

--- a/test/Amazon.Lambda.Tools.Test/Amazon.Lambda.Tools.Test.csproj
+++ b/test/Amazon.Lambda.Tools.Test/Amazon.Lambda.Tools.Test.csproj
@@ -55,9 +55,9 @@
     </Content>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="AWSSDK.CloudFormation" Version="3.3.13" />
-    <PackageReference Include="AWSSDK.Lambda" Version="3.3.19" />
-    <PackageReference Include="AWSSDK.SQS" Version="3.3.3.38" />
+    <PackageReference Include="AWSSDK.CloudFormation" Version="3.5.0.22" />
+    <PackageReference Include="AWSSDK.Lambda" Version="3.5.0.22" />
+    <PackageReference Include="AWSSDK.SQS" Version="3.5.0.22" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
     <PackageReference Include="System.IO.Compression.ZipFile" Version="4.0.1" />


### PR DESCRIPTION


*Issue #, if available:*
https://github.com/aws/aws-extensions-for-dotnet-cli/issues/117

*Description of changes:*
This was done specifically to address https://github.com/aws/aws-extensions-for-dotnet-cli/issues/117 which was already fixed in the SDK

The test case was tweaked because the output of dotnet --info has changed for .NET 5

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
