### PR TITLE
Prompt user for target framework when the tool is unable to determine target framework

### DIFF
--- a/src/Amazon.Common.DotNetCli.Tools/Options/CommonDefinedCommandOptions.cs
+++ b/src/Amazon.Common.DotNetCli.Tools/Options/CommonDefinedCommandOptions.cs
@@ -23,7 +23,7 @@ namespace Amazon.Common.DotNetCli.Tools.Options
                 ShortSwitch = "-f",
                 Switch = "--framework",
                 ValueType = CommandOption.CommandOptionValueType.StringValue,
-                Description = "Target framework to compile, for example netcoreapp2.1.",
+                Description = "Target framework to compile, for example netcoreapp3.1.",
             };
         public static readonly CommandOption ARGUMENT_SELF_CONTAINED =
             new CommandOption

--- a/src/Amazon.Lambda.Tools/Commands/DeployFunctionCommand.cs
+++ b/src/Amazon.Lambda.Tools/Commands/DeployFunctionCommand.cs
@@ -192,6 +192,13 @@ namespace Amazon.Lambda.Tools.Commands
                     if (string.IsNullOrEmpty(targetFramework))
                     {
                         targetFramework = Utilities.LookupTargetFrameworkFromProjectFile(Utilities.DetermineProjectLocation(this.WorkingDirectory, projectLocation));
+
+                        // If we still don't know what the target framework is ask the user what targetframework to use.
+                        // This is common when a project is using multi targeting.
+                        if(string.IsNullOrEmpty(targetFramework))
+                        {
+                            targetFramework = this.GetStringValueOrDefault(this.TargetFramework, CommonDefinedCommandOptions.ARGUMENT_FRAMEWORK, true);
+                        }
                     }
                     string msbuildParameters = this.GetStringValueOrDefault(this.MSBuildParameters, CommonDefinedCommandOptions.ARGUMENT_MSBUILD_PARAMETERS, false);
 

--- a/src/Amazon.Lambda.Tools/Commands/PackageCommand.cs
+++ b/src/Amazon.Lambda.Tools/Commands/PackageCommand.cs
@@ -194,6 +194,13 @@ namespace Amazon.Lambda.Tools.Commands
                 if (string.IsNullOrEmpty(targetFramework))
                 {
                     targetFramework = Utilities.LookupTargetFrameworkFromProjectFile(Utilities.DetermineProjectLocation(this.WorkingDirectory, projectLocation));
+
+                    // If we still don't know what the target framework is ask the user what targetframework to use.
+                    // This is common when a project is using multi targeting.
+                    if (string.IsNullOrEmpty(targetFramework))
+                    {
+                        targetFramework = this.GetStringValueOrDefault(this.TargetFramework, CommonDefinedCommandOptions.ARGUMENT_FRAMEWORK, true);
+                    }
                 }
 
                 var msbuildParameters = this.GetStringValueOrDefault(this.MSBuildParameters, CommonDefinedCommandOptions.ARGUMENT_MSBUILD_PARAMETERS, false);


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/aws-extensions-for-dotnet-cli/issues/150
*Description of changes:*
If the target framework can not determined by the tool then prompt the user for the framework to use.

![PromptForTargetFramework](https://user-images.githubusercontent.com/1653751/101969762-07d1d200-3bdb-11eb-8c80-00d228194b72.gif)




By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
