### PR TITLE
Pass OriginalCommandLineArguments to Command constructor

### DIFF
--- a/src/Amazon.Lambda.Tools/Commands/DeployServerlessCommand.cs
+++ b/src/Amazon.Lambda.Tools/Commands/DeployServerlessCommand.cs
@@ -164,7 +164,7 @@ namespace Amazon.Lambda.Tools.Commands
             };
             
             var templateProcessor = new TemplateProcessorManager(this, s3Bucket, s3Prefix, options);
-            templateBody = await templateProcessor.TransformTemplateAsync(templatePath, templateBody);
+            templateBody = await templateProcessor.TransformTemplateAsync(templatePath, templateBody, OriginalCommandLineArguments);
 
             // Upload the template to S3 instead of sending it straight to CloudFormation to avoid the size limitation
             string s3KeyTemplate;

--- a/src/Amazon.Lambda.Tools/Commands/PackageCICommand.cs
+++ b/src/Amazon.Lambda.Tools/Commands/PackageCICommand.cs
@@ -128,7 +128,7 @@ namespace Amazon.Lambda.Tools.Commands
             };
             
             var templateProcessor = new TemplateProcessorManager(this, s3Bucket, s3Prefix, options);
-            templateBody = await templateProcessor.TransformTemplateAsync(templatePath, templateBody);            
+            templateBody = await templateProcessor.TransformTemplateAsync(templatePath, templateBody, OriginalCommandLineArguments);
             
             this.Logger.WriteLine($"Writing updated template: {outputTemplatePath}");
             File.WriteAllText(outputTemplatePath, templateBody);


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/aws-extensions-for-dotnet-cli/issues/122
Please see my comment https://github.com/aws/aws-extensions-for-dotnet-cli/issues/122#issuecomment-752185888

The command line arguments are not passed to the command objects that are created internally. For example, `deploy-serverless` passes null/empty for the `args` constructor parameter when it creates `PackageCommand` (package-ci) or `PushDockerImageCommand` (push-image).

*Description of changes:*
Added a `string[] args` parameter to the methods in `TemplateProcessorManager` to allow passing the original `args` to `PackageCommand` and `PushDockerImageCommand`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
