### PR TITLE
Update AWSSDK.Core reference to 3.5.2 which supports AWS SSO based Credential Profiles.

### DIFF
--- a/src/Amazon.Common.DotNetCli.Tools/Amazon.Common.DotNetCli.Tools.csproj
+++ b/src/Amazon.Common.DotNetCli.Tools/Amazon.Common.DotNetCli.Tools.csproj
@@ -6,7 +6,7 @@
     <FileVersion>3.0.0.0</FileVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="AWSSDK.Core" Version="3.5.1.20" />
+    <PackageReference Include="AWSSDK.Core" Version="3.5.2" />
 	<PackageReference Include="AWSSDK.ECR" Version="3.5.0.22" />
     <PackageReference Include="AWSSDK.IdentityManagement" Version="3.5.0.22" />
     <PackageReference Include="AWSSDK.S3" Version="3.5.2" />

--- a/src/Amazon.ECS.Tools/Amazon.ECS.Tools.csproj
+++ b/src/Amazon.ECS.Tools/Amazon.ECS.Tools.csproj
@@ -22,7 +22,7 @@
   <ItemGroup>
     <PackageReference Include="AWSSDK.CloudWatchEvents" Version="3.5.1.4" />
     <PackageReference Include="AWSSDK.CloudWatchLogs" Version="3.5.0.22" />
-    <PackageReference Include="AWSSDK.Core" Version="3.5.1.20" />
+    <PackageReference Include="AWSSDK.Core" Version="3.5.2" />
     <PackageReference Include="AWSSDK.EC2" Version="3.5.7.2" />
     <PackageReference Include="AWSSDK.ECS" Version="3.5.0.22" />
     <PackageReference Include="AWSSDK.IdentityManagement" Version="3.5.0.22" />

--- a/src/Amazon.ECS.Tools/Amazon.ECS.Tools.csproj
+++ b/src/Amazon.ECS.Tools/Amazon.ECS.Tools.csproj
@@ -10,7 +10,7 @@
     <PackAsTool>true</PackAsTool>
 	<ToolCommandName>dotnet-ecs</ToolCommandName>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Version>3.3.0</Version>
+    <Version>3.3.1</Version>
     <AssemblyName>dotnet-ecs</AssemblyName>
     <Company>Amazon.com, Inc</Company>
     <Authors>Amazon Web Services</Authors>

--- a/src/Amazon.ElasticBeanstalk.Tools/Amazon.ElasticBeanstalk.Tools.csproj
+++ b/src/Amazon.ElasticBeanstalk.Tools/Amazon.ElasticBeanstalk.Tools.csproj
@@ -10,7 +10,7 @@
     <PackAsTool>true</PackAsTool>
 	<ToolCommandName>dotnet-eb</ToolCommandName>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Version>4.1.0</Version>
+    <Version>4.1.1</Version>
     <AssemblyName>dotnet-eb</AssemblyName>
     <Authors>Amazon Web Services</Authors>
     <Copyright>Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.</Copyright>

--- a/src/Amazon.Lambda.Tools/Amazon.Lambda.Tools.csproj
+++ b/src/Amazon.Lambda.Tools/Amazon.Lambda.Tools.csproj
@@ -15,7 +15,7 @@
     <Copyright>Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.</Copyright>
     <Product>AWS Lambda Tools for .NET CLI</Product>
     <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
-    <Version>5.0.1</Version>
+    <Version>5.0.2</Version>
   </PropertyGroup>
   <ItemGroup>
     <Content Include="Resources\build-lambda-zip.exe">


### PR DESCRIPTION
*Issue #:* #154 

*Description of changes:*
Update AWSSDK.Core reference to 3.5.2 which supports AWS SSO based Credential Profiles.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
