### PR TITLE
Fixed random manifest names causing zip package hash refresh on every build

### DIFF
--- a/src/Amazon.Lambda.Tools/LambdaUtilities.cs
+++ b/src/Amazon.Lambda.Tools/LambdaUtilities.cs
@@ -478,7 +478,17 @@ namespace Amazon.Lambda.Tools
                         continue;
                     }
 
-                    string filePath = Path.GetTempFileName();
+                    string GetLastArnComponent(string input)
+                    {
+                        return input.Substring(input.LastIndexOf(':') + 1);
+                    }
+
+                    var layerName = GetLastArnComponent(getLayerResponse.LayerArn);
+                    var layerVers = GetLastArnComponent(getLayerResponse.LayerVersionArn);
+
+                    var tempPath = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), Path.GetRandomFileName()));
+                    var filePath = Path.Combine(tempPath.FullName, $"{layerName}-v{layerVers}.xml");
+
                     using (var getResponse = await s3Client.GetObjectAsync(manifest.Buc, manifest.Key))
                     using (var reader = new StreamReader(getResponse.ResponseStream))
                     {


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/aws-extensions-for-dotnet-cli/issues/162

*Description of changes:*
I changed use of temporary filename for layer manifest to be directory name instead. All layers of the project will have their filename built from layer name and version number, located under the new temp directory. This stops hash of zip package to change across executions of package-ci and deploy-serverless commands when no other content changes are introduced.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
