### PR TITLE
Update AWS SDK Dependencies to 3.7 and Replace Deprecated Lambda Policy

### DIFF
--- a/src/Amazon.Common.DotNetCli.Tools/Amazon.Common.DotNetCli.Tools.csproj
+++ b/src/Amazon.Common.DotNetCli.Tools/Amazon.Common.DotNetCli.Tools.csproj
@@ -2,15 +2,15 @@
   <Import Project="..\..\buildtools\common.props" />
   <PropertyGroup>
     <TargetFrameworks>netcoreapp2.1</TargetFrameworks>
-    <AssemblyVersion>3.0.0.0</AssemblyVersion>
-    <FileVersion>3.0.0.0</FileVersion>
+    <AssemblyVersion>3.1.0.0</AssemblyVersion>
+    <FileVersion>3.1.0.0</FileVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="AWSSDK.Core" Version="3.5.2" />
-	<PackageReference Include="AWSSDK.ECR" Version="3.5.0.22" />
-    <PackageReference Include="AWSSDK.IdentityManagement" Version="3.5.0.22" />
-    <PackageReference Include="AWSSDK.S3" Version="3.5.2" />
-    <PackageReference Include="AWSSDK.SecurityToken" Version="3.5.1.2" />
+    <PackageReference Include="AWSSDK.Core" Version="3.7.0.3" />
+    <PackageReference Include="AWSSDK.ECR" Version="3.7.0.2" />
+    <PackageReference Include="AWSSDK.IdentityManagement" Version="3.7.1" />
+    <PackageReference Include="AWSSDK.S3" Version="3.7.0.3" />
+    <PackageReference Include="AWSSDK.SecurityToken" Version="3.7.0.2" />
   </ItemGroup>
   <PropertyGroup Condition="'$(TargetFramework)' == 'netcoreapp2.1' ">
     <DefineConstants>$(DefineConstants);NETCORE</DefineConstants>

--- a/src/Amazon.ECS.Tools/Amazon.ECS.Tools.csproj
+++ b/src/Amazon.ECS.Tools/Amazon.ECS.Tools.csproj
@@ -8,9 +8,9 @@
     <PackageId>Amazon.ECS.Tools</PackageId>
     <PackageTags>AWS;Amazon;Docker;ECS</PackageTags>
     <PackAsTool>true</PackAsTool>
-	<ToolCommandName>dotnet-ecs</ToolCommandName>
+    <ToolCommandName>dotnet-ecs</ToolCommandName>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Version>3.3.1</Version>
+    <Version>3.4.0</Version>
     <AssemblyName>dotnet-ecs</AssemblyName>
     <Company>Amazon.com, Inc</Company>
     <Authors>Amazon Web Services</Authors>
@@ -20,13 +20,13 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AWSSDK.CloudWatchEvents" Version="3.5.1.4" />
-    <PackageReference Include="AWSSDK.CloudWatchLogs" Version="3.5.0.22" />
-    <PackageReference Include="AWSSDK.Core" Version="3.5.2" />
-    <PackageReference Include="AWSSDK.EC2" Version="3.5.7.2" />
-    <PackageReference Include="AWSSDK.ECS" Version="3.5.0.22" />
-    <PackageReference Include="AWSSDK.IdentityManagement" Version="3.5.0.22" />
-    <PackageReference Include="AWSSDK.S3" Version="3.5.2" />
+    <PackageReference Include="AWSSDK.CloudWatchEvents" Version="3.7.1.1" />
+    <PackageReference Include="AWSSDK.CloudWatchLogs" Version="3.7.0.2" />
+    <PackageReference Include="AWSSDK.Core" Version="3.7.0.3" />
+    <PackageReference Include="AWSSDK.EC2" Version="3.7.0.2" />
+    <PackageReference Include="AWSSDK.ECS" Version="3.7.0.2" />
+    <PackageReference Include="AWSSDK.IdentityManagement" Version="3.7.1" />
+    <PackageReference Include="AWSSDK.S3" Version="3.7.0.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Amazon.ElasticBeanstalk.Tools/Amazon.ElasticBeanstalk.Tools.csproj
+++ b/src/Amazon.ElasticBeanstalk.Tools/Amazon.ElasticBeanstalk.Tools.csproj
@@ -8,9 +8,9 @@
     <PackageId>Amazon.ElasticBeanstalk.Tools</PackageId>
     <PackageTags>AWS;Amazon;Beanstalk</PackageTags>
     <PackAsTool>true</PackAsTool>
-	<ToolCommandName>dotnet-eb</ToolCommandName>
+    <ToolCommandName>dotnet-eb</ToolCommandName>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Version>4.1.1</Version>
+    <Version>4.2.0</Version>
     <AssemblyName>dotnet-eb</AssemblyName>
     <Authors>Amazon Web Services</Authors>
     <Copyright>Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.</Copyright>
@@ -25,9 +25,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="AWSSDK.ElasticBeanstalk" Version="3.5.0.22" />
-    <PackageReference Include="AWSSDK.IdentityManagement" Version="3.5.0.22" />
-    <PackageReference Include="AWSSDK.S3" Version="3.5.2" />
+    <PackageReference Include="AWSSDK.ElasticBeanstalk" Version="3.7.0.2" />
+    <PackageReference Include="AWSSDK.IdentityManagement" Version="3.7.1" />
+    <PackageReference Include="AWSSDK.S3" Version="3.7.0.3" />
   </ItemGroup>
 
   <PropertyGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.1' ">

--- a/src/Amazon.Lambda.Tools/Amazon.Lambda.Tools.csproj
+++ b/src/Amazon.Lambda.Tools/Amazon.Lambda.Tools.csproj
@@ -9,13 +9,13 @@
     <PackageId>Amazon.Lambda.Tools</PackageId>
     <PackageTags>AWS;Amazon;Lambda</PackageTags>
     <PackAsTool>true</PackAsTool>
-	<ToolCommandName>dotnet-lambda</ToolCommandName>
-	<GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <ToolCommandName>dotnet-lambda</ToolCommandName>
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Company>Amazon.com, Inc</Company>
     <Copyright>Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.</Copyright>
     <Product>AWS Lambda Tools for .NET CLI</Product>
     <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
-    <Version>5.0.2</Version>
+    <Version>5.1.0</Version>
   </PropertyGroup>
   <ItemGroup>
     <Content Include="Resources\build-lambda-zip.exe">
@@ -36,10 +36,10 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
-    <PackageReference Include="AWSSDK.CloudFormation" Version="3.5.0.22" />
-    <PackageReference Include="AWSSDK.Lambda" Version="3.5.4" />
-    <PackageReference Include="AWSSDK.IdentityManagement" Version="3.5.0.22" />
-    <PackageReference Include="AWSSDK.S3" Version="3.5.2" />
+    <PackageReference Include="AWSSDK.CloudFormation" Version="3.7.0.2" />
+    <PackageReference Include="AWSSDK.Lambda" Version="3.7.0.2" />
+    <PackageReference Include="AWSSDK.IdentityManagement" Version="3.7.1" />
+    <PackageReference Include="AWSSDK.S3" Version="3.7.0.3" />
     <PackageReference Include="YamlDotNet.Signed" Version="5.2.1" />
   </ItemGroup>
   <PropertyGroup>

--- a/src/Amazon.Lambda.Tools/LambdaConstants.cs
+++ b/src/Amazon.Lambda.Tools/LambdaConstants.cs
@@ -60,7 +60,11 @@ namespace Amazon.Lambda.Tools
             {"arn:aws:iam::aws:policy/service-role/AWSCodeDeployRoleForLambda","Provides CodeDeploy service access to perform a Lambda deployment on your behalf."},
             {"arn:aws:iam::aws:policy/service-role/AWSLambdaENIManagementAccess","Provides minimum permissions for a Lambda function to manage ENIs (create, describe, delete) used by a VPC-enabled Lambda Function."},
             {"arn:aws:iam::aws:policy/AWSDeepLensLambdaFunctionAccessPolicy","This policy specifies permissions required by DeepLens Administrative lambda functions that run on a DeepLens device"},
-            {"arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole","Provides minimum permissions for a Lambda function to execute while accessing a resource within a VPC"}
+            {"arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole","Provides minimum permissions for a Lambda function to execute while accessing a resource within a VPC"},
+            {"arn:aws:iam::aws:policy/aws-service-role/AWSLambdaReplicator","Grants Lambda Replicator necessary permissions to replicate functions across regions "},
+            {"arn:aws:iam::aws:policy/service-role/AWSLambdaMSKExecutionRole","Provides permissions required to access MSK Cluster within a VPC, manage ENIs (create, describe, delete) in the VPC and write permissions to CloudWatch Logs."},
+            {"arn:aws:iam::aws:policy/AWSLambda_ReadOnlyAccess","Grants read-only access to AWS Lambda service, AWS Lambda console features, and other related AWS services."},
+            {"arn:aws:iam::aws:policy/AWSLambda_FullAccess","Grants full access to AWS Lambda service, AWS Lambda console features, and other related AWS services."}
         };
 
 

--- a/test/Amazon.ElasticBeanstalk.Tools.Test/Amazon.ElasticBeanstalk.Tools.Test.csproj
+++ b/test/Amazon.ElasticBeanstalk.Tools.Test/Amazon.ElasticBeanstalk.Tools.Test.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AWSSDK.ElasticBeanstalk" Version="3.5.0.22" />
+    <PackageReference Include="AWSSDK.ElasticBeanstalk" Version="3.7.0.2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0-preview-20170810-02" />
     <PackageReference Include="Moq" Version="4.10.1" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />

--- a/test/Amazon.Lambda.Tools.Test/Amazon.Lambda.Tools.Test.csproj
+++ b/test/Amazon.Lambda.Tools.Test/Amazon.Lambda.Tools.Test.csproj
@@ -55,15 +55,15 @@
     </Content>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="AWSSDK.CloudFormation" Version="3.5.0.22" />
-    <PackageReference Include="AWSSDK.Lambda" Version="3.5.4" />
-    <PackageReference Include="AWSSDK.SQS" Version="3.5.0.22" />
+    <PackageReference Include="AWSSDK.CloudFormation" Version="3.7.0.2" />
+    <PackageReference Include="AWSSDK.Lambda" Version="3.7.0.2" />
+    <PackageReference Include="AWSSDK.SQS" Version="3.7.0.3" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
     <PackageReference Include="System.IO.Compression.ZipFile" Version="4.3.0" />
     <PackageReference Include="xunit" Version="2.2.0" />
     <PackageReference Include="YamlDotNet.Signed" Version="5.2.1" />
-	<PackageReference Include="Moq" Version="4.14.7"/>
+	<PackageReference Include="Moq" Version="4.14.7" />
   </ItemGroup>
   <ItemGroup>
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />

--- a/testapps/TestLayerAspNetCore/fake.template
+++ b/testapps/TestLayerAspNetCore/fake.template
@@ -17,7 +17,7 @@
 				"MemorySize": 256,
 				"Timeout": 30,
 				"Role": null,
-				"Policies": [ "AWSLambdaFullAccess" ],
+				"Policies": [ "AWSLambda_FullAccess" ],
 				"Layers" : [ "LAYER_ARN_PLACEHOLDER" ],
 				"Environment" : {
 				},

--- a/testapps/TestServerlessWebApp/large-serverless.template
+++ b/testapps/TestServerlessWebApp/large-serverless.template
@@ -27,7 +27,7 @@
         "MemorySize": 256,
         "Timeout": 30,
         "Role": null,
-        "Policies": [ "AWSLambdaFullAccess" ],
+        "Policies": [ "AWSLambda_FullAccess" ],
         "Events": {
           "PutResource": {
             "Type": "Api",

--- a/testapps/TestServerlessWebApp/serverless.template
+++ b/testapps/TestServerlessWebApp/serverless.template
@@ -15,7 +15,7 @@
         "MemorySize": 256,
         "Timeout": 30,
         "Role": null,
-        "Policies": [ "AWSLambdaFullAccess" ],
+        "Policies": [ "AWSLambda_FullAccess" ],
         "Events": {
           "PutResource": {
             "Type": "Api",


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
1. Update AWS SDK dependencies to 3.7, and perform a minor version update to packages where I did so.
2. Replace `AWSLambdaFullAccess` with `AWSLambda_FullAccess` where it was used in test projects. The former was deprecated on 3/1/21 per [Lambda docs](https://docs.aws.amazon.com/lambda/latest/dg/access-control-identity-based.html), which was causing `TestDeployLargeServerless` to fail.
    * Also updated `KNOWN_MANAGED_POLICY_DESCRIPTIONS` which should fill in the missing descriptions when guiding the user through creating a new role. This is the before state:

![image](https://user-images.githubusercontent.com/1170880/113222546-44dad680-9255-11eb-99df-af6df4535638.png)




By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
