### PR TITLE
Lambda Tool: Fix update issue for runtime and handler

### DIFF
--- a/src/Amazon.Lambda.Tools/Commands/UpdateFunctionConfigCommand.cs
+++ b/src/Amazon.Lambda.Tools/Commands/UpdateFunctionConfigCommand.cs
@@ -401,8 +401,8 @@ namespace Amazon.Lambda.Tools.Commands
                 different = true;
             }
 
-            var packageType = this.GetStringValueOrDefault(this.PackageType, LambdaDefinedCommandOptions.ARGUMENT_PACKAGE_TYPE, false);
-            if (string.Equals(packageType, Lambda.PackageType.Zip.Value, StringComparison.OrdinalIgnoreCase))
+            var packageType = DeterminePackageType();
+            if (packageType == Lambda.PackageType.Zip)
             {
                 var handler = this.GetStringValueOrDefault(this.Handler, LambdaDefinedCommandOptions.ARGUMENT_FUNCTION_HANDLER, false);
                 if (!string.IsNullOrEmpty(handler) && !string.Equals(handler, existingConfiguration.Handler, StringComparison.Ordinal))
@@ -418,7 +418,7 @@ namespace Amazon.Lambda.Tools.Commands
                     different = true;
                 }
             }
-            else if (string.Equals(packageType, Lambda.PackageType.Image.Value, StringComparison.OrdinalIgnoreCase))
+            else if (packageType == Lambda.PackageType.Image)
             {
                 {
                     var imageEntryPoints = this.GetStringValuesOrDefault(this.ImageEntryPoint, LambdaDefinedCommandOptions.ARGUMENT_IMAGE_ENTRYPOINT, false);
@@ -476,6 +476,12 @@ namespace Amazon.Lambda.Tools.Commands
                 return null;
 
             return request;
+        }
+
+        private Lambda.PackageType DeterminePackageType()
+        {
+            var strPackageType = this.GetStringValueOrDefault(this.PackageType, LambdaDefinedCommandOptions.ARGUMENT_PACKAGE_TYPE, false);
+            return LambdaUtilities.DeterminePackageType(strPackageType);
         }
 
         public Dictionary<string, string> GetEnvironmentVariables(Dictionary<string, string> existingEnvironmentVariables)

--- a/src/Amazon.Lambda.Tools/Commands/UpdateFunctionConfigCommand.cs
+++ b/src/Amazon.Lambda.Tools/Commands/UpdateFunctionConfigCommand.cs
@@ -28,8 +28,6 @@ namespace Amazon.Lambda.Tools.Commands
         {
             LambdaDefinedCommandOptions.ARGUMENT_FUNCTION_NAME,
             LambdaDefinedCommandOptions.ARGUMENT_FUNCTION_DESCRIPTION,
-            LambdaDefinedCommandOptions.ARGUMENT_PACKAGE_TYPE,
-
             LambdaDefinedCommandOptions.ARGUMENT_FUNCTION_PUBLISH,
             LambdaDefinedCommandOptions.ARGUMENT_FUNCTION_MEMORY_SIZE,
             LambdaDefinedCommandOptions.ARGUMENT_FUNCTION_ROLE,
@@ -107,8 +105,6 @@ namespace Amazon.Lambda.Tools.Commands
                 this.FunctionName = tuple.Item2.StringValue;
             if ((tuple = values.FindCommandOption(LambdaDefinedCommandOptions.ARGUMENT_FUNCTION_DESCRIPTION.Switch)) != null)
                 this.Description = tuple.Item2.StringValue;
-            if ((tuple = values.FindCommandOption(LambdaDefinedCommandOptions.ARGUMENT_PACKAGE_TYPE.Switch)) != null)
-                this.PackageType = tuple.Item2.StringValue;
             if ((tuple = values.FindCommandOption(LambdaDefinedCommandOptions.ARGUMENT_FUNCTION_PUBLISH.Switch)) != null)
                 this.Publish = tuple.Item2.BoolValue;
             if ((tuple = values.FindCommandOption(LambdaDefinedCommandOptions.ARGUMENT_FUNCTION_HANDLER.Switch)) != null)

--- a/src/Amazon.Lambda.Tools/Commands/UpdateFunctionConfigCommand.cs
+++ b/src/Amazon.Lambda.Tools/Commands/UpdateFunctionConfigCommand.cs
@@ -401,8 +401,7 @@ namespace Amazon.Lambda.Tools.Commands
                 different = true;
             }
 
-            var packageType = DeterminePackageType();
-            if (packageType == Lambda.PackageType.Zip)
+            if (existingConfiguration.PackageType == Lambda.PackageType.Zip)
             {
                 var handler = this.GetStringValueOrDefault(this.Handler, LambdaDefinedCommandOptions.ARGUMENT_FUNCTION_HANDLER, false);
                 if (!string.IsNullOrEmpty(handler) && !string.Equals(handler, existingConfiguration.Handler, StringComparison.Ordinal))
@@ -418,7 +417,7 @@ namespace Amazon.Lambda.Tools.Commands
                     different = true;
                 }
             }
-            else if (packageType == Lambda.PackageType.Image)
+            else if (existingConfiguration.PackageType == Lambda.PackageType.Image)
             {
                 {
                     var imageEntryPoints = this.GetStringValuesOrDefault(this.ImageEntryPoint, LambdaDefinedCommandOptions.ARGUMENT_IMAGE_ENTRYPOINT, false);
@@ -476,12 +475,6 @@ namespace Amazon.Lambda.Tools.Commands
                 return null;
 
             return request;
-        }
-
-        private Lambda.PackageType DeterminePackageType()
-        {
-            var strPackageType = this.GetStringValueOrDefault(this.PackageType, LambdaDefinedCommandOptions.ARGUMENT_PACKAGE_TYPE, false);
-            return LambdaUtilities.DeterminePackageType(strPackageType);
         }
 
         public Dictionary<string, string> GetEnvironmentVariables(Dictionary<string, string> existingEnvironmentVariables)

--- a/src/Amazon.Lambda.Tools/Commands/UpdateFunctionConfigCommand.cs
+++ b/src/Amazon.Lambda.Tools/Commands/UpdateFunctionConfigCommand.cs
@@ -28,6 +28,8 @@ namespace Amazon.Lambda.Tools.Commands
         {
             LambdaDefinedCommandOptions.ARGUMENT_FUNCTION_NAME,
             LambdaDefinedCommandOptions.ARGUMENT_FUNCTION_DESCRIPTION,
+            LambdaDefinedCommandOptions.ARGUMENT_PACKAGE_TYPE,
+
             LambdaDefinedCommandOptions.ARGUMENT_FUNCTION_PUBLISH,
             LambdaDefinedCommandOptions.ARGUMENT_FUNCTION_MEMORY_SIZE,
             LambdaDefinedCommandOptions.ARGUMENT_FUNCTION_ROLE,
@@ -105,6 +107,8 @@ namespace Amazon.Lambda.Tools.Commands
                 this.FunctionName = tuple.Item2.StringValue;
             if ((tuple = values.FindCommandOption(LambdaDefinedCommandOptions.ARGUMENT_FUNCTION_DESCRIPTION.Switch)) != null)
                 this.Description = tuple.Item2.StringValue;
+            if ((tuple = values.FindCommandOption(LambdaDefinedCommandOptions.ARGUMENT_PACKAGE_TYPE.Switch)) != null)
+                this.PackageType = tuple.Item2.StringValue;
             if ((tuple = values.FindCommandOption(LambdaDefinedCommandOptions.ARGUMENT_FUNCTION_PUBLISH.Switch)) != null)
                 this.Publish = tuple.Item2.BoolValue;
             if ((tuple = values.FindCommandOption(LambdaDefinedCommandOptions.ARGUMENT_FUNCTION_HANDLER.Switch)) != null)


### PR DESCRIPTION
*Issue #, if available:*
#149 

*Description of changes:*
When `package-type` is missing from the `aws-lambda-tools-defaults.json` file, any change to runtime or handler is not applied. The change here is to check the existing lambdas package type instead of the defaults file when applying an update.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
