### PR TITLE
Lambda Tool: Should not trigger update if vpc config has not changed

### DIFF
--- a/src/Amazon.Lambda.Tools/Commands/UpdateFunctionConfigCommand.cs
+++ b/src/Amazon.Lambda.Tools/Commands/UpdateFunctionConfigCommand.cs
@@ -312,7 +312,7 @@ namespace Amazon.Lambda.Tools.Commands
             var subnetIds = this.GetStringValuesOrDefault(this.SubnetIds, LambdaDefinedCommandOptions.ARGUMENT_FUNCTION_SUBNETS, false);
             if (subnetIds != null)
             {
-                if(request.VpcConfig == null)
+                if(existingConfiguration.VpcConfig == null)
                 {
                     request.VpcConfig = new VpcConfig
                     {
@@ -320,7 +320,7 @@ namespace Amazon.Lambda.Tools.Commands
                     };
                     different = true;
                 }
-                else if(AreDifferent(subnetIds, request.VpcConfig.SubnetIds))
+                else if(AreDifferent(subnetIds, existingConfiguration.VpcConfig.SubnetIds))
                 {
                     request.VpcConfig.SubnetIds = subnetIds.ToList();
                     different = true;
@@ -330,7 +330,7 @@ namespace Amazon.Lambda.Tools.Commands
             var securityGroupIds = this.GetStringValuesOrDefault(this.SecurityGroupIds, LambdaDefinedCommandOptions.ARGUMENT_FUNCTION_SECURITY_GROUPS, false);
             if (securityGroupIds != null)
             {
-                if (request.VpcConfig == null)
+                if (existingConfiguration.VpcConfig == null)
                 {
                     request.VpcConfig = new VpcConfig
                     {
@@ -338,7 +338,7 @@ namespace Amazon.Lambda.Tools.Commands
                     };
                     different = true;
                 }
-                else if (AreDifferent(securityGroupIds, request.VpcConfig.SecurityGroupIds))
+                else if (AreDifferent(securityGroupIds, existingConfiguration.VpcConfig.SecurityGroupIds))
                 {
                     request.VpcConfig.SecurityGroupIds = securityGroupIds.ToList();
                     different = true;

--- a/src/Amazon.Lambda.Tools/Commands/UpdateFunctionConfigCommand.cs
+++ b/src/Amazon.Lambda.Tools/Commands/UpdateFunctionConfigCommand.cs
@@ -314,19 +314,12 @@ namespace Amazon.Lambda.Tools.Commands
             {
                 if (request.VpcConfig == null)
                 {
-                    request.VpcConfig = new VpcConfig
-                    {
-                        SubnetIds = subnetIds.ToList()
-                    };
+                    request.VpcConfig = new VpcConfig();
                 }
 
-                if (existingConfiguration.VpcConfig == null)
+                request.VpcConfig.SubnetIds = subnetIds.ToList();
+                if (existingConfiguration.VpcConfig == null || AreDifferent(subnetIds, existingConfiguration.VpcConfig.SubnetIds))
                 {
-                    different = true;
-                }
-                else if (AreDifferent(subnetIds, existingConfiguration.VpcConfig.SubnetIds))
-                {
-                    request.VpcConfig.SubnetIds = subnetIds.ToList();
                     different = true;
                 }
             }
@@ -336,19 +329,12 @@ namespace Amazon.Lambda.Tools.Commands
             {
                 if (request.VpcConfig == null)
                 {
-                    request.VpcConfig = new VpcConfig
-                    {
-                        SecurityGroupIds = securityGroupIds.ToList()
-                    };
+                    request.VpcConfig = new VpcConfig();
                 }
 
-                if (existingConfiguration.VpcConfig == null)
+                request.VpcConfig.SecurityGroupIds = securityGroupIds.ToList();
+                if (existingConfiguration.VpcConfig == null || AreDifferent(securityGroupIds, existingConfiguration.VpcConfig.SecurityGroupIds))
                 {
-                    different = true;
-                }
-                else if (AreDifferent(securityGroupIds, existingConfiguration.VpcConfig.SecurityGroupIds))
-                {
-                    request.VpcConfig.SecurityGroupIds = securityGroupIds.ToList();
                     different = true;
                 }
             }

--- a/src/Amazon.Lambda.Tools/Commands/UpdateFunctionConfigCommand.cs
+++ b/src/Amazon.Lambda.Tools/Commands/UpdateFunctionConfigCommand.cs
@@ -312,15 +312,19 @@ namespace Amazon.Lambda.Tools.Commands
             var subnetIds = this.GetStringValuesOrDefault(this.SubnetIds, LambdaDefinedCommandOptions.ARGUMENT_FUNCTION_SUBNETS, false);
             if (subnetIds != null)
             {
-                if(existingConfiguration.VpcConfig == null)
+                if (request.VpcConfig == null)
                 {
                     request.VpcConfig = new VpcConfig
                     {
                         SubnetIds = subnetIds.ToList()
                     };
+                }
+
+                if (existingConfiguration.VpcConfig == null)
+                {
                     different = true;
                 }
-                else if(AreDifferent(subnetIds, existingConfiguration.VpcConfig.SubnetIds))
+                else if (AreDifferent(subnetIds, existingConfiguration.VpcConfig.SubnetIds))
                 {
                     request.VpcConfig.SubnetIds = subnetIds.ToList();
                     different = true;
@@ -330,12 +334,16 @@ namespace Amazon.Lambda.Tools.Commands
             var securityGroupIds = this.GetStringValuesOrDefault(this.SecurityGroupIds, LambdaDefinedCommandOptions.ARGUMENT_FUNCTION_SECURITY_GROUPS, false);
             if (securityGroupIds != null)
             {
-                if (existingConfiguration.VpcConfig == null)
+                if (request.VpcConfig == null)
                 {
                     request.VpcConfig = new VpcConfig
                     {
                         SecurityGroupIds = securityGroupIds.ToList()
                     };
+                }
+
+                if (existingConfiguration.VpcConfig == null)
+                {
                     different = true;
                 }
                 else if (AreDifferent(securityGroupIds, existingConfiguration.VpcConfig.SecurityGroupIds))


### PR DESCRIPTION
*Issue #, if available:*
Seems small enough that I didn't open an issue for it, but happy to do so if needed.

*Description of changes:*

Small changes, but reduces unnecessary updates.

When working on #169 I noticed that when a function's `aws-lambda-tools-defaults.json` contains subnets and security groups, it always triggers an update.
It seems the `CreateConfigurationRequestIfDifferent` does not compare the subnets and sg ids with the existing ones so it always triggers. This PR changes it to compare with the existing configuration.



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
