### PR TITLE
Propagate Beanstalk publishing changes made in the AWS Toolkit repo

### DIFF
--- a/src/Amazon.ElasticBeanstalk.Tools/Commands/DeployEnvironmentCommand.cs
+++ b/src/Amazon.ElasticBeanstalk.Tools/Commands/DeployEnvironmentCommand.cs
@@ -1,7 +1,6 @@
 ﻿using Amazon.Common.DotNetCli.Tools;
 using Amazon.Common.DotNetCli.Tools.Options;
 using Amazon.ElasticBeanstalk.Model;
-using Amazon.S3.Transfer;
 using System;
 using System.Collections.Generic;
 using System.Globalization;

--- a/src/Amazon.ElasticBeanstalk.Tools/Commands/DeployEnvironmentCommand.cs
+++ b/src/Amazon.ElasticBeanstalk.Tools/Commands/DeployEnvironmentCommand.cs
@@ -131,7 +131,6 @@ namespace Amazon.ElasticBeanstalk.Tools.Commands
 
                 string configuration = this.GetStringValueOrDefault(this.DeployEnvironmentOptions.Configuration, CommonDefinedCommandOptions.ARGUMENT_CONFIGURATION, false) ?? "Release";
                 string targetFramework = this.GetStringValueOrDefault(this.DeployEnvironmentOptions.TargetFramework, CommonDefinedCommandOptions.ARGUMENT_FRAMEWORK, false);
-                string publishOptions = this.GetStringValueOrDefault(this.DeployEnvironmentOptions.PublishOptions, CommonDefinedCommandOptions.ARGUMENT_PUBLISH_OPTIONS, false);
 
                 if (string.IsNullOrEmpty(targetFramework))
                 {
@@ -147,19 +146,7 @@ namespace Amazon.ElasticBeanstalk.Tools.Commands
                 var publishLocation = Utilities.DeterminePublishLocation(null, projectLocation, configuration, targetFramework);
                 this.Logger?.WriteLine("Determine publish location: " + publishLocation);
 
-                if (!isWindowsEnvironment)
-                {
-                    
-                    if(publishOptions == null || !publishOptions.Contains("-r ") && !publishOptions.Contains("--runtime "))
-                    {
-                        publishOptions += " --runtime linux-x64";
-                    }
-                    if(publishOptions == null || !publishOptions.Contains("--self-contained"))
-                    {
-                        var selfContained = this.GetBoolValueOrDefault(this.DeployEnvironmentOptions.SelfContained, CommonDefinedCommandOptions.ARGUMENT_SELF_CONTAINED, false);
-                        publishOptions += $" --self-contained {selfContained.GetValueOrDefault().ToString(CultureInfo.InvariantCulture).ToLowerInvariant()}"; 
-                    }
-                }
+                var publishOptions = GetPublishOptions(isWindowsEnvironment);
 
                 this.Logger?.WriteLine("Executing publish command");
                 if (dotnetCli.Publish(projectLocation, publishLocation, targetFramework, configuration, publishOptions) != 0)
@@ -290,6 +277,13 @@ namespace Amazon.ElasticBeanstalk.Tools.Commands
             }
 
             return true;
+        }
+
+        public string GetPublishOptions(bool isWindowsEnvironment)
+        {
+            var initialOptions = this.GetStringValueOrDefault(this.DeployEnvironmentOptions.PublishOptions, CommonDefinedCommandOptions.ARGUMENT_PUBLISH_OPTIONS, false);
+            var selfContained = this.GetBoolValueOrDefault(this.DeployEnvironmentOptions.SelfContained, CommonDefinedCommandOptions.ARGUMENT_SELF_CONTAINED, false) ?? false;
+            return new PublishOptions(initialOptions, isWindowsEnvironment, selfContained).ToCliString();
         }
 
         private async Task CreateEBApplicationIfNotExist(string application, bool doesApplicationExist)

--- a/src/Amazon.ElasticBeanstalk.Tools/Commands/DeployEnvironmentCommand.cs
+++ b/src/Amazon.ElasticBeanstalk.Tools/Commands/DeployEnvironmentCommand.cs
@@ -392,7 +392,7 @@ namespace Amazon.ElasticBeanstalk.Tools.Commands
             }
 
             var serviceRole = this.GetServiceRoleOrCreateIt(this.DeployEnvironmentOptions.ServiceRole, EBDefinedCommandOptions.ARGUMENT_SERVICE_ROLE, 
-                "aws-elasticbeanstalk-service-role", Constants.ELASTICBEANSTALK_ASSUME_ROLE_POLICY, null, "AWSElasticBeanstalkService", "AWSElasticBeanstalkEnhancedHealth");
+                "aws-elasticbeanstalk-service-role", Constants.ELASTICBEANSTALK_ASSUME_ROLE_POLICY, null, "AWSElasticBeanstalkManagedUpdatesCustomerRolePolicy", "AWSElasticBeanstalkEnhancedHealth");
             if (!string.IsNullOrEmpty(serviceRole))
             {
                 int pos = serviceRole.LastIndexOf('/');

--- a/src/Amazon.ElasticBeanstalk.Tools/EBUtilities.cs
+++ b/src/Amazon.ElasticBeanstalk.Tools/EBUtilities.cs
@@ -90,7 +90,17 @@ namespace Amazon.ElasticBeanstalk.Tools
 
         public static bool IsSolutionStackLinuxNETCore(string solutionStackName)
         {
-            return solutionStackName.StartsWith("64bit Amazon Linux 2") && (solutionStackName.Contains(".NET Core") || solutionStackName.Contains("DotNetCore"));
+            return IsSolutionStackLinux(solutionStackName) && IsSolutionStackNETCore(solutionStackName);
+        }
+
+        public static bool IsSolutionStackLinux(string solutionStackName)
+        {
+            return solutionStackName.StartsWith("64bit Amazon Linux 2");
+        }
+
+        public static bool IsSolutionStackNETCore(string solutionStackName)
+        {
+            return solutionStackName.Contains(".NET Core") || solutionStackName.Contains("DotNetCore");
         }
 
         public static bool IsLoadBalancedEnvironmentType(string environmentType)

--- a/src/Amazon.ElasticBeanstalk.Tools/PublishOptions.cs
+++ b/src/Amazon.ElasticBeanstalk.Tools/PublishOptions.cs
@@ -1,0 +1,44 @@
+﻿using System.Globalization;
+using System.Text;
+
+namespace Amazon.ElasticBeanstalk.Tools
+{
+    public class PublishOptions
+    {
+        private readonly string _initialOptions;
+        private readonly bool _isWindowsEnvironment;
+        private readonly bool _selfContained;
+
+        public PublishOptions(string initialOptions, bool isWindowsEnvironment, bool selfContained)
+        {
+            _initialOptions = initialOptions ?? "";
+            _isWindowsEnvironment = isWindowsEnvironment;
+            _selfContained = selfContained;
+        }
+
+        public string ToCliString()
+        {
+            var publishOptionsBuilder = new StringBuilder(_initialOptions);
+
+            if (DoesNotContainRuntime())
+            {
+                publishOptionsBuilder.Append($" --runtime {GetRuntimeString()}");
+            } 
+
+            if (DoesNotContainSelfContained())
+            {
+                publishOptionsBuilder.Append($" --self-contained {ConvertBoolToString(_selfContained)}");
+            }
+
+            return publishOptionsBuilder.ToString();
+        }
+
+        private bool DoesNotContainRuntime() => !_initialOptions.Contains("-r ") && !_initialOptions.Contains("--runtime ");
+
+        private string GetRuntimeString() => _isWindowsEnvironment ? "win-x64" : "linux-x64";
+
+        private bool DoesNotContainSelfContained() => !_initialOptions.Contains("--self-contained");
+
+        private string ConvertBoolToString(bool boolean) => boolean.ToString(CultureInfo.InvariantCulture).ToLowerInvariant();
+    }
+}


### PR DESCRIPTION

*Description of changes:*

This change synchronizes the Beanstalk deployment code with the code used in the AWS Toolkit for Visual Studio, because there were some changes that had not been propagated back to this repo:

* Replace older `AWSElasticBeanstalkService` managed service role policy with `AWSElasticBeanstalkManagedUpdatesCustomerRolePolicy` - see https://docs.aws.amazon.com/elasticbeanstalk/latest/dg/iam-servicerole.html for details
* Allow Windows runtimes to make self-contained builds (previously, only Linux could use self-contained builds).
  * This change was made to support publishing .NET 6 applications to Windows compute
  * Code was moved to a new class (`PublishOptions`) to encapsulate converting publish options to command line arguments
* General cleanup

The changes have been made as separate commits, but are being PR'd together.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
