### PR TITLE
Add ability to enable function url and configure EphemeralStorageSize

### DIFF
--- a/aws-extensions-for-dotnet-cli.sln
+++ b/aws-extensions-for-dotnet-cli.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.30608.117
+# Visual Studio Version 17
+VisualStudioVersion = 17.1.32228.430
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{A5EA2C7D-846F-4266-8423-EFC4BA0FE4B6}"
 EndProject
@@ -59,7 +59,9 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "ImageBasedProjects", "Image
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TestSimpleImageProject", "testapps\ImageBasedProjects\TestSimpleImageProject\TestSimpleImageProject.csproj", "{4FA5B55F-BE55-42F7-A2DE-1924B10296A2}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Amazon.Lambda.Tools.Integ.Tests", "test\Amazon.Lambda.Tools.Integ.Tests\Amazon.Lambda.Tools.Integ.Tests.csproj", "{7B2AE176-8AB5-4050-8E22-A2A80E88BB92}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Amazon.Lambda.Tools.Integ.Tests", "test\Amazon.Lambda.Tools.Integ.Tests\Amazon.Lambda.Tools.Integ.Tests.csproj", "{7B2AE176-8AB5-4050-8E22-A2A80E88BB92}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TestHttpFunction", "testapps\TestHttpFunction\TestHttpFunction.csproj", "{AD31D053-97C5-4262-B187-EC42BFD51A9F}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -151,6 +153,10 @@ Global
 		{7B2AE176-8AB5-4050-8E22-A2A80E88BB92}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{7B2AE176-8AB5-4050-8E22-A2A80E88BB92}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{7B2AE176-8AB5-4050-8E22-A2A80E88BB92}.Release|Any CPU.Build.0 = Release|Any CPU
+		{AD31D053-97C5-4262-B187-EC42BFD51A9F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{AD31D053-97C5-4262-B187-EC42BFD51A9F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{AD31D053-97C5-4262-B187-EC42BFD51A9F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{AD31D053-97C5-4262-B187-EC42BFD51A9F}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -179,6 +185,7 @@ Global
 		{7C227173-0F21-44DD-93A7-5D3693240271} = {BB3CF729-8213-4DDD-85AE-A5E7754F3944}
 		{4FA5B55F-BE55-42F7-A2DE-1924B10296A2} = {7C227173-0F21-44DD-93A7-5D3693240271}
 		{7B2AE176-8AB5-4050-8E22-A2A80E88BB92} = {BB0A8314-3127-4159-8B6A-64F97FEF9474}
+		{AD31D053-97C5-4262-B187-EC42BFD51A9F} = {BB3CF729-8213-4DDD-85AE-A5E7754F3944}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {DBFC70D6-49A2-40A1-AB08-5D9504AB7112}

--- a/src/Amazon.Common.DotNetCli.Tools/Amazon.Common.DotNetCli.Tools.csproj
+++ b/src/Amazon.Common.DotNetCli.Tools/Amazon.Common.DotNetCli.Tools.csproj
@@ -6,13 +6,13 @@
     <FileVersion>3.1.0.0</FileVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="AWSSDK.Core" Version="3.7.0.27" />
-    <PackageReference Include="AWSSDK.ECR" Version="3.7.0.2" />
-    <PackageReference Include="AWSSDK.IdentityManagement" Version="3.7.1" />
-    <PackageReference Include="AWSSDK.S3" Version="3.7.0.3" />
-    <PackageReference Include="AWSSDK.SecurityToken" Version="3.7.1.15" />
-    <PackageReference Include="AWSSDK.SSO" Version="3.7.0.26" />
-    <PackageReference Include="AWSSDK.SSOOIDC" Version="3.7.0.26" />
+    <PackageReference Include="AWSSDK.Core" Version="3.7.10.8" />
+    <PackageReference Include="AWSSDK.ECR" Version="3.7.4.10" />
+    <PackageReference Include="AWSSDK.IdentityManagement" Version="3.7.2.128" />
+    <PackageReference Include="AWSSDK.S3" Version="3.7.8.20" />
+    <PackageReference Include="AWSSDK.SecurityToken" Version="3.7.1.140" />
+    <PackageReference Include="AWSSDK.SSO" Version="3.7.0.148" />
+    <PackageReference Include="AWSSDK.SSOOIDC" Version="3.7.0.148" />
   </ItemGroup>
   <PropertyGroup>
     <NoWarn>1701;1702;1705;1591</NoWarn>

--- a/src/Amazon.ECS.Tools/Amazon.ECS.Tools.csproj
+++ b/src/Amazon.ECS.Tools/Amazon.ECS.Tools.csproj
@@ -20,13 +20,13 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AWSSDK.CloudWatchEvents" Version="3.7.1.1" />
-    <PackageReference Include="AWSSDK.CloudWatchLogs" Version="3.7.0.2" />
-    <PackageReference Include="AWSSDK.Core" Version="3.7.0.27" />
-    <PackageReference Include="AWSSDK.EC2" Version="3.7.0.2" />
-    <PackageReference Include="AWSSDK.ECS" Version="3.7.0.2" />
-    <PackageReference Include="AWSSDK.IdentityManagement" Version="3.7.1" />
-    <PackageReference Include="AWSSDK.S3" Version="3.7.0.3" />
+    <PackageReference Include="AWSSDK.CloudWatchEvents" Version="3.7.4.93" />
+    <PackageReference Include="AWSSDK.CloudWatchLogs" Version="3.7.2.42" />
+    <PackageReference Include="AWSSDK.Core" Version="3.7.10.8" />
+    <PackageReference Include="AWSSDK.EC2" Version="3.7.64.1" />
+    <PackageReference Include="AWSSDK.ECS" Version="3.7.5.18" />
+    <PackageReference Include="AWSSDK.IdentityManagement" Version="3.7.2.128" />
+    <PackageReference Include="AWSSDK.S3" Version="3.7.8.20" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Amazon.ElasticBeanstalk.Tools/Amazon.ElasticBeanstalk.Tools.csproj
+++ b/src/Amazon.ElasticBeanstalk.Tools/Amazon.ElasticBeanstalk.Tools.csproj
@@ -25,9 +25,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="AWSSDK.ElasticBeanstalk" Version="3.7.0.2" />
-    <PackageReference Include="AWSSDK.IdentityManagement" Version="3.7.1" />
-    <PackageReference Include="AWSSDK.S3" Version="3.7.0.3" />
+    <PackageReference Include="AWSSDK.ElasticBeanstalk" Version="3.7.0.148" />
+    <PackageReference Include="AWSSDK.IdentityManagement" Version="3.7.2.128" />
+    <PackageReference Include="AWSSDK.S3" Version="3.7.8.20" />
   </ItemGroup>
   
   <PropertyGroup>

--- a/src/Amazon.Lambda.Tools/Amazon.Lambda.Tools.csproj
+++ b/src/Amazon.Lambda.Tools/Amazon.Lambda.Tools.csproj
@@ -15,7 +15,7 @@
     <Copyright>Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.</Copyright>
     <Product>AWS Lambda Tools for .NET CLI</Product>
     <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
-    <Version>5.3.0</Version>
+    <Version>5.4.0</Version>
   </PropertyGroup>
   <ItemGroup>
     <Content Include="Resources\build-lambda-zip.exe">
@@ -36,10 +36,10 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
-    <PackageReference Include="AWSSDK.CloudFormation" Version="3.7.0.2" />
-    <PackageReference Include="AWSSDK.Lambda" Version="3.7.4" />
-    <PackageReference Include="AWSSDK.IdentityManagement" Version="3.7.1" />
-    <PackageReference Include="AWSSDK.S3" Version="3.7.0.3" />
+    <PackageReference Include="AWSSDK.CloudFormation" Version="3.7.9.26" />
+    <PackageReference Include="AWSSDK.Lambda" Version="3.7.12.4" />
+    <PackageReference Include="AWSSDK.IdentityManagement" Version="3.7.2.128" />
+    <PackageReference Include="AWSSDK.S3" Version="3.7.8.20" />
     <PackageReference Include="YamlDotNet.Signed" Version="5.2.1" />
   </ItemGroup>
   <PropertyGroup>

--- a/src/Amazon.Lambda.Tools/Exceptions.cs
+++ b/src/Amazon.Lambda.Tools/Exceptions.cs
@@ -31,6 +31,10 @@ namespace Amazon.Lambda.Tools
             IAMCreateRole,
             IAMGetRole,
 
+            LambdaFunctionUrlGet,
+            LambdaFunctionUrlCreate,
+            LambdaFunctionUrlUpdate,
+            LambdaFunctionUrlDelete,
 
             LambdaCreateFunction,
             LambdaDeleteFunction,

--- a/src/Amazon.Lambda.Tools/LambdaConstants.cs
+++ b/src/Amazon.Lambda.Tools/LambdaConstants.cs
@@ -48,6 +48,9 @@ namespace Amazon.Lambda.Tools
         public const string ARCHITECTURE_X86_64 = "x86_64";
         public const string ARCHITECTURE_ARM64 = "arm64";
 
+        // This is the same value the console is using.
+        public const string FUNCTION_URL_PUBLIC_PERMISSION_STATEMENT_ID = "FunctionURLAllowPublicAccess";
+
 
         public const string AWS_LAMBDA_MANAGED_POLICY_PREFIX = "AWSLambda";
 

--- a/src/Amazon.Lambda.Tools/LambdaDefinedCommandOptions.cs
+++ b/src/Amazon.Lambda.Tools/LambdaDefinedCommandOptions.cs
@@ -417,5 +417,29 @@ namespace Amazon.Lambda.Tools
                 ValueType = CommandOption.CommandOptionValueType.StringValue,
                 Description = "Docker image name and tag in the 'name:tag' format."
             };
+        public static readonly CommandOption ARGUMENT_EPHEMERAL_STORAGE_SIZE =
+            new CommandOption
+            {
+                Name = "Ephemerals Storage Size",
+                Switch = "--ephemerals-storage-size",
+                ValueType = CommandOption.CommandOptionValueType.IntValue,
+                Description = "The size of the function's /tmp directory in MB. The default value is 512, but can be any whole number between 512 and 10240 MB"
+            };
+        public static readonly CommandOption ARGUMENT_FUNCTION_URL_ENABLE =
+            new CommandOption
+            {
+                Name = "Function Url Enable",
+                Switch = "--function-url-enable",
+                ValueType = CommandOption.CommandOptionValueType.BoolValue,
+                Description = "Enable function URL. A function URL is a dedicated HTTP(S) endpoint for your Lambda function."
+            };
+        public static readonly CommandOption ARGUMENT_FUNCTION_URL_AUTH =
+            new CommandOption
+            {
+                Name = "Function Url Auth Type",
+                Switch = "--function-url-auth",
+                ValueType = CommandOption.CommandOptionValueType.StringValue,
+                Description = $"The type of authentication that your function URL uses, default value is NONE. Valid values: {FunctionUrlAuthType.NONE} or {FunctionUrlAuthType.AWS_IAM}"
+            };
     }
 }

--- a/test/Amazon.ElasticBeanstalk.Tools.Test/Amazon.ElasticBeanstalk.Tools.Test.csproj
+++ b/test/Amazon.ElasticBeanstalk.Tools.Test/Amazon.ElasticBeanstalk.Tools.Test.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AWSSDK.ElasticBeanstalk" Version="3.7.0.2" />
+    <PackageReference Include="AWSSDK.ElasticBeanstalk" Version="3.7.0.148" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
     <PackageReference Include="Moq" Version="4.16.1" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />

--- a/test/Amazon.Lambda.Tools.Test/Amazon.Lambda.Tools.Test.csproj
+++ b/test/Amazon.Lambda.Tools.Test/Amazon.Lambda.Tools.Test.csproj
@@ -55,9 +55,9 @@
     </Content>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="AWSSDK.CloudFormation" Version="3.7.0.2" />
-    <PackageReference Include="AWSSDK.Lambda" Version="3.7.4" />
-    <PackageReference Include="AWSSDK.SQS" Version="3.7.0.3" />
+    <PackageReference Include="AWSSDK.CloudFormation" Version="3.7.9.26" />
+    <PackageReference Include="AWSSDK.Lambda" Version="3.7.12.4" />
+    <PackageReference Include="AWSSDK.SQS" Version="3.7.2.45" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
     <PackageReference Include="System.IO.Compression.ZipFile" Version="4.3.0" />

--- a/testapps/TestHttpFunction/Function.cs
+++ b/testapps/TestHttpFunction/Function.cs
@@ -1,0 +1,24 @@
+using Amazon.Lambda.Core;
+using Amazon.Lambda.APIGatewayEvents;
+using System.Net;
+
+// Assembly attribute to enable the Lambda function's JSON input to be converted into a .NET class.
+[assembly: LambdaSerializer(typeof(Amazon.Lambda.Serialization.SystemTextJson.DefaultLambdaJsonSerializer))]
+
+namespace TestHttpFunction;
+
+public class Function
+{
+
+    public APIGatewayHttpApiV2ProxyResponse FunctionHandler(APIGatewayProxyRequest request, ILambdaContext context)
+    {
+        var response = new APIGatewayHttpApiV2ProxyResponse
+        {
+            StatusCode = (int)HttpStatusCode.OK,
+            Body = "Making HTTP Calls",
+            Headers = new Dictionary<string, string> { { "Content-Type", "text/plain" } }
+        };
+
+        return response;
+    }
+}

--- a/testapps/TestHttpFunction/TestHttpFunction.csproj
+++ b/testapps/TestHttpFunction/TestHttpFunction.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
+    <AWSProjectType>Lambda</AWSProjectType>
+    <!-- This property makes the build directory similar to a publish directory and helps the AWS .NET Lambda Mock Test Tool find project dependencies. -->
+    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
+  </PropertyGroup>
+  <ItemGroup>
+	<PackageReference Include="Amazon.Lambda.Core" Version="2.1.0" />
+	<PackageReference Include="Amazon.Lambda.APIGatewayEvents" Version="2.4.0" />
+	<PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.3.0" />
+  </ItemGroup>
+
+</Project>

--- a/testapps/TestHttpFunction/aws-lambda-tools-defaults.json
+++ b/testapps/TestHttpFunction/aws-lambda-tools-defaults.json
@@ -1,0 +1,7 @@
+{
+  "configuration": "Release",
+  "function-runtime": "dotnet6",
+  "function-memory-size": 256,
+  "function-timeout": 30,
+  "function-handler": "TestHttpFunction::TestHttpFunction.Function::FunctionHandler"
+}


### PR DESCRIPTION
*Description of changes:*
This PR adds following new switches for deploying and updating Lambda functions. They are used to configure function url and the size of the ephemeral storage size.

* `--function-url-enable`
* `--function-url-auth`
* `--ephemerals-storage-size`

The `get-function-config` command was updated to show the new fields.
```
> dotnet lambda get-function-config
Amazon Lambda Tools for .NET Core applications (5.4.0)
Project Home: https://github.com/aws/aws-extensions-for-dotnet-cli, https://github.com/aws/aws-lambda-dotnet

Name:                         TestNewLambdaTool
Arn:                          arn:aws:lambda:us-west-2:123412341234:function:TestNewLambdaTool
Package Type:                 Zip
Runtime:                      dotnet6
Function Handler:             TestNewLambdaTool::TestNewLambdaTool.Functions::Get
Last Modified:                2022-04-20T07:16:20.000+0000
Memory Size:                  256
Ephemeral Storage Size:       512
Role:                         arn:aws:iam::123412341234:role/LambdaDemoRole
Timeout:                      30
Version:                      $LATEST
State:                        Active
Last Update Status:           Successful
KMS Key ARN:                  (default) aws/lambda
Function Url Config
   Url:                       https://3ykyyrgkrbu6t3bovu5eqe2txi0kzbra.lambda-url.us-west-2.on.aws/
   Auth:                      NONE
```

To configure a Lambda Function Url you have to make separate calls CRUD API calls to managed the function url config. If the function auth is set to `NONE` which is the default then permissions need to be added to the function to allow public invoke of the function. This PR manages adding the statement to the function's resource policy when a url config is enabled with `NONE` auth type. It will also remove the statement if the auth type changes to `AWS_IAM` or the function url disabled.


## Bug Fix
Also included in this PR is a fix to on collection properties to for the update function config to be able to clear out the values. That is the reason for the `IsXXXSet` properties set to `true` being added to the `CreateConfigurationRequestIfDifferent` method.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
