### PR TITLE
Added ability to use DockerBuildArgs in Amazon.Lambda.Tools serverless template.

### DIFF
--- a/src/Amazon.Lambda.Tools/Amazon.Lambda.Tools.csproj
+++ b/src/Amazon.Lambda.Tools/Amazon.Lambda.Tools.csproj
@@ -15,7 +15,7 @@
     <Copyright>Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.</Copyright>
     <Product>AWS Lambda Tools for .NET CLI</Product>
     <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
-    <Version>5.4.2</Version>
+    <Version>5.4.3</Version>
   </PropertyGroup>
   <ItemGroup>
     <Content Include="Resources\build-lambda-zip.exe">

--- a/src/Amazon.Lambda.Tools/TemplateProcessor/ITemplateParser.cs
+++ b/src/Amazon.Lambda.Tools/TemplateProcessor/ITemplateParser.cs
@@ -128,6 +128,12 @@ namespace Amazon.Lambda.Tools.TemplateProcessor
         /// </summary>
         /// <returns></returns>
         string GetMetadataDockerTag();
+
+        /// <summary>
+        /// Gets the Docker build args specified for an AWS::Serverless::Function
+        /// </summary>
+        /// <returns></returns>
+        Dictionary<string, string> GetMetadataDockerBuildArgs();
     }
 
     /// <summary>
@@ -176,6 +182,7 @@ namespace Amazon.Lambda.Tools.TemplateProcessor
         /// <param name="keyPath"></param>
         /// <returns></returns>
         string[] GetValueList(params string[] keyPath);
-        
+
+        Dictionary<string, string> GetValueDictionaryFromResource(params string[] keyPath);
     }
 }

--- a/src/Amazon.Lambda.Tools/TemplateProcessor/JsonTemplateParser.cs
+++ b/src/Amazon.Lambda.Tools/TemplateProcessor/JsonTemplateParser.cs
@@ -110,6 +110,11 @@ namespace Amazon.Lambda.Tools.TemplateProcessor
                 return GetValueList(this.Properties, keyPath);
             }
 
+            public Dictionary<string, string> GetValueDictionaryFromResource(params string[] keyPath)
+            {
+                return GetValueDictionaryFromResource(this.Resource, keyPath);
+            }
+
             private static string[] GetValueList(JsonData node, params string[] keyPath)
             {
                 foreach (var key in keyPath)
@@ -147,6 +152,35 @@ namespace Amazon.Lambda.Tools.TemplateProcessor
                 }
 
                 node[keyPath[keyPath.Length - 1]] = value;
+            }
+
+            private static Dictionary<string, string> GetValueDictionaryFromResource(JsonData node, params string[] keyPath)
+            {
+                foreach (var key in keyPath)
+                {
+                    if (node == null)
+                        return null;
+
+                    node = node[key];
+                }
+
+                if (node == null || !node.IsObject || node.Count == 0)
+                    return null;
+
+                var dictionary = new Dictionary<string, string>(node.Count);
+                foreach (string key in node.PropertyNames)
+                {
+                    if (dictionary.ContainsKey(key))
+                    {
+                        dictionary[key] = node[key]?.ToString();
+                    }
+                    else
+                    {
+                        dictionary.Add(key, node[key]?.ToString());
+                    }
+                }
+
+                return dictionary;
             }
         }
     }

--- a/src/Amazon.Lambda.Tools/TemplateProcessor/UpdatableResource.cs
+++ b/src/Amazon.Lambda.Tools/TemplateProcessor/UpdatableResource.cs
@@ -174,6 +174,11 @@ namespace Amazon.Lambda.Tools.TemplateProcessor
             {
                 return this.DataSource.GetValueFromResource("Metadata", "DockerTag");
             }
+
+            public Dictionary<string, string> GetMetadataDockerBuildArgs()
+            {
+                return this.DataSource.GetValueDictionaryFromResource("Metadata", "DockerBuildArgs");
+            }
         }
     }
 }

--- a/src/Amazon.Lambda.Tools/TemplateProcessor/YamlTemplateParser.cs
+++ b/src/Amazon.Lambda.Tools/TemplateProcessor/YamlTemplateParser.cs
@@ -133,6 +133,11 @@ namespace Amazon.Lambda.Tools.TemplateProcessor
                 return GetValueList(this.Properties, keyPath);
             }
 
+            public Dictionary<string, string> GetValueDictionaryFromResource(params string[] keyPath)
+            {
+                return GetValueDictionaryFromResource(this.Resource, keyPath);
+            }
+
             private static string[] GetValueList(YamlNode node, params string[] keyPath)
             {
                 foreach (var key in keyPath)
@@ -179,6 +184,46 @@ namespace Amazon.Lambda.Tools.TemplateProcessor
 
                 node.Children.Remove(keyPath[keyPath.Length - 1]);
                 node.Children.Add(keyPath[keyPath.Length - 1], new YamlScalarNode(value));
+            }
+
+            private static Dictionary<string, string> GetValueDictionaryFromResource(YamlNode node, params string[] keyPath)
+            {
+                foreach (var key in keyPath)
+                {
+                    if (node == null || !(node is YamlMappingNode))
+                        return null;
+
+                    var mappingNode = ((YamlMappingNode)node);
+                    if (!mappingNode.Children.ContainsKey(key))
+                        return null;
+
+                    node = mappingNode.Children[key];
+                }
+
+                if (node is YamlMappingNode)
+                {
+                    var mappingNode = (YamlMappingNode)node;
+
+                    if (mappingNode.Children.Count == 0)
+                        return null;
+
+                    Dictionary<string, string> dictionary = new Dictionary<string, string>(mappingNode.Children.Count);
+                    foreach (var key in mappingNode.Children.Keys)
+                    {
+                        if (dictionary.ContainsKey(key.ToString()))
+                        {
+                            dictionary[key.ToString()] = mappingNode.Children[key]?.ToString();
+                        }
+                        else
+                        {
+                            dictionary.Add(key.ToString(), mappingNode.Children[key]?.ToString());
+                        }
+                    }
+
+                    return dictionary;
+                }
+
+                return null;
             }
         }
     }

--- a/test/Amazon.Lambda.Tools.Integ.Tests/DeployServerlessTests.cs
+++ b/test/Amazon.Lambda.Tools.Integ.Tests/DeployServerlessTests.cs
@@ -133,5 +133,49 @@ namespace Amazon.Lambda.Tools.Integ.Tests
                 Assert.Contains("aws-extensions-tests:usedefaultdocker", useDefaultDockerFunction["Code"]["ImageUri"]?.ToString());
             }
         }
+
+        [Fact]
+        public async Task TestDockerBuildArgsMetadataJsonTemplate()
+        {
+            var assembly = this.GetType().GetTypeInfo().Assembly;
+
+            var toolLogger = new TestToolLogger(_testOutputHelper);
+
+            var fullPath = Path.GetFullPath(Path.GetDirectoryName(assembly.Location) + "../../../../../../testapps/ImageBasedProjects/ServerlessTemplateExamples");
+
+            var command = new PackageCICommand(toolLogger, fullPath, new string[0]);
+            command.Region = TEST_REGION;
+            command.DisableInteractive = true;
+            command.S3Bucket = this._testFixture.Bucket;
+            command.CloudFormationTemplate = "serverless-resource-dockerbuildargs-json.template";
+            command.CloudFormationOutputTemplate = Path.GetTempFileName();
+
+            var created = await command.ExecuteAsync();
+            Assert.True(created);
+            Assert.Contains("--build-arg PROJECT_PATH=/src/path-to/project", toolLogger.Buffer);
+            Assert.Contains("--build-arg PROJECT_FILE=project.csproj", toolLogger.Buffer);
+        }
+
+        [Fact]
+        public async Task TestDockerBuildArgsMetadataYamlTemplate()
+        {
+            var assembly = this.GetType().GetTypeInfo().Assembly;
+
+            var toolLogger = new TestToolLogger(_testOutputHelper);
+
+            var fullPath = Path.GetFullPath(Path.GetDirectoryName(assembly.Location) + "../../../../../../testapps/ImageBasedProjects/ServerlessTemplateExamples");
+
+            var command = new PackageCICommand(toolLogger, fullPath, new string[0]);
+            command.Region = TEST_REGION;
+            command.DisableInteractive = true;
+            command.S3Bucket = this._testFixture.Bucket;
+            command.CloudFormationTemplate = "serverless-resource-dockerbuildargs-yaml.template";
+            command.CloudFormationOutputTemplate = Path.GetTempFileName();
+
+            var created = await command.ExecuteAsync();
+            Assert.True(created);
+            Assert.Contains("--build-arg PROJECT_PATH=/src/path-to/project", toolLogger.Buffer);
+            Assert.Contains("--build-arg PROJECT_FILE=project.csproj", toolLogger.Buffer);
+        }
     }
 }

--- a/testapps/ImageBasedProjects/ServerlessTemplateExamples/serverless-resource-dockerbuildargs-json.template
+++ b/testapps/ImageBasedProjects/ServerlessTemplateExamples/serverless-resource-dockerbuildargs-json.template
@@ -1,0 +1,33 @@
+{
+  "AWSTemplateFormatVersion": "2010-09-09",
+  "Transform": "AWS::Serverless-2016-10-31",
+  "Description": "An AWS Serverless Application.",
+  "Resources": {
+    "UseDockerMetadataFunction": {
+      "Type": "AWS::Serverless::Function",
+      "Properties": {
+        "MemorySize": 256,
+        "Timeout": 30,
+        "Policies": [
+          "AWSLambdaBasicExecutionRole"
+        ],
+        "PackageType" : "Image",
+        "ImageConfig" : {
+            "Command" : "UseDockerMetadata::UseDockerMetadata.Function::FunctionHandler"
+        }
+      },
+      "Metadata": {
+        "Dockerfile": "Dockerfile.custom",
+        "DockerContext": "./UseDockerMetadata",
+        "DockerTag": "aws-extensions-tests:usedockermetadata",
+		"DockerBuildArgs": {
+		  "PROJECT_PATH": "/src/path-to/project",
+		  "PROJECT_FILE": "project.csproj"
+		}
+      }
+    }
+  },
+
+  "Outputs": {
+  }
+}

--- a/testapps/ImageBasedProjects/ServerlessTemplateExamples/serverless-resource-dockerbuildargs-yaml.template
+++ b/testapps/ImageBasedProjects/ServerlessTemplateExamples/serverless-resource-dockerbuildargs-yaml.template
@@ -1,0 +1,22 @@
+AWSTemplateFormatVersion: 2010-09-09
+Transform: 'AWS::Serverless-2016-10-31'
+Description: An AWS Serverless Application.
+Resources:
+  UseDockerMetadataFunction:
+    Type: 'AWS::Serverless::Function'
+    Properties:
+      MemorySize: 256
+      Timeout: 30
+      Policies:
+        - AWSLambdaBasicExecutionRole
+      PackageType: Image
+      ImageConfig:
+        Command: 'UseDockerMetadata::UseDockerMetadata.Function::FunctionHandler'
+    Metadata:
+      Dockerfile: Dockerfile.custom
+      DockerContext: ./UseDockerMetadata
+      DockerTag: 'aws-extensions-tests:usedockermetadata'
+      DockerBuildArgs:
+        PROJECT_PATH: /src/path-to/project
+        PROJECT_FILE: project.csproj
+Outputs: {}


### PR DESCRIPTION
*Issue #, if available:* #201

*Description of changes:*
Added ability to use `DockerBuildArgs` in `Amazon.Lambda.Tools` serverless template. This change required implementation for both JSON and YAML template parsers.

*Testing:*
Tested (in debug mode) using the following templates for sample https://github.com/aws/aws-extensions-for-dotnet-cli/tree/master/testapps/ImageBasedProjects/ServerlessTemplateExamples:
**JSON template:**
```JSON
{
  "AWSTemplateFormatVersion": "2010-09-09",
  "Transform": "AWS::Serverless-2016-10-31",
  "Description": "An AWS Serverless Application.",
  "Resources": {

    "UseDockerMetadataFunction": {
      "Type": "AWS::Serverless::Function",
      "Properties": {
        "MemorySize": 256,
        "Timeout": 30,
        "Policies": [
          "AWSLambdaBasicExecutionRole"
        ],
        "PackageType" : "Image",
        "ImageConfig" : {
            "Command" : "UseDockerMetadata::UseDockerMetadata.Function::FunctionHandler"
        }
      },
      "Metadata": {
        "Dockerfile": "Dockerfile.custom",
        "DockerContext": "./UseDockerMetadata",
        "DockerTag": "aws-extensions-tests:usedockermetadata",
		"DockerBuildArgs": {
		  "PROJECT_PATH": "/src/path-to/project",
		  "PROJECT_FILE": "project.csproj"
		}
      }
    }
  },

  "Outputs": {
  }
}
```

**YAML template:**
```
AWSTemplateFormatVersion: 2010-09-09
Transform: 'AWS::Serverless-2016-10-31'
Description: An AWS Serverless Application.
Resources:
  UseDockerMetadataFunction:
    Type: 'AWS::Serverless::Function'
    Properties:
      MemorySize: 256
      Timeout: 30
      Policies:
        - AWSLambdaBasicExecutionRole
      PackageType: Image
      ImageConfig:
        Command: 'UseDockerMetadata::UseDockerMetadata.Function::FunctionHandler'
    Metadata:
      Dockerfile: Dockerfile.custom
      DockerContext: ./UseDockerMetadata
      DockerTag: 'aws-extensions-tests:usedockermetadata'
      DockerBuildArgs:
        PROJECT_PATH: /src/path-to/project
        PROJECT_FILE: project.csproj
Outputs: {}
```

**Output:**
```
Amazon Lambda Tools for .NET Core applications (5.4.1)
Project Home: https://github.com/aws/aws-extensions-for-dotnet-cli, https://github.com/aws/aws-lambda-dotnet

Enter CloudFormation Stack Name: (CloudFormation stack name for an AWS Serverless application)
teststack
Enter S3 Bucket: (S3 bucket to upload the build output)
mappingNode.Children
Warning: Unable to determine region for bucket mappingNode.Children, assuming bucket is in correct region: The specified bucket does not exist
Processing CloudFormation resource UseDockerMetadataFunction
Initiate packaging of ./UseDockerMetadata for resource UseDockerMetadataFunction
Building Docker image for D:\source\repros\ServerlessTemplateExamples\./UseDockerMetadata
Inspecting Dockerfile to figure how to build project and docker image
Executing docker build
... invoking 'docker build', working folder 'D:\source\repros\ServerlessTemplateExamples\./UseDockerMetadata, docker file D:\source\repros\ServerlessTemplateExamples\./UseDockerMetadata\Dockerfile.custom, image name aws-extensions-tests:usedockermetadata'
... docker build  -f "D:\source\repros\ServerlessTemplateExamples\./UseDockerMetadata\Dockerfile.custom" -t aws-extensions-tests:usedockermetadata --build-arg PROJECT_PATH=/src/path-to/project --build-arg PROJECT_FILE=project.csproj .
... docker build: Sending build context to Docker daemon  228.9kB
... docker build: Step 1/3 : FROM public.ecr.aws/lambda/dotnet:5.0
... docker build: 5.0: Pulling from lambda/dotnet
... docker build: image operating system "linux" cannot be used on this platform
Error executing "docker build"
```
**NOTE:** The deployment fails due to incompatibility of Linux image while testing on Windows based environment, which is fine. The correct `--build-arg`(s) are passed to `docker build` call.

**_We need to add version bump commits in `dev` branch before actual release of queued changes._**
___
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
