### PR TITLE
bug: Continue gracefully if unable to get Function Url

### DIFF
--- a/src/Amazon.Lambda.Tools/Amazon.Lambda.Tools.csproj
+++ b/src/Amazon.Lambda.Tools/Amazon.Lambda.Tools.csproj
@@ -15,7 +15,7 @@
     <Copyright>Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.</Copyright>
     <Product>AWS Lambda Tools for .NET CLI</Product>
     <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
-    <Version>5.4.1</Version>
+    <Version>5.4.2</Version>
   </PropertyGroup>
   <ItemGroup>
     <Content Include="Resources\build-lambda-zip.exe">


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/aws-lambda-dotnet/issues/1188

*Description of changes:*
Continue gracefully if unable to get Function Url when updating a Lambda.  Getting Function Url can occur in regions that do not yet have this functionality or if the current context does not have the appropriate permissions to query function urls.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
