### PR TITLE
Prove we can build native AOT in docker

### DIFF
--- a/src/Amazon.Common.DotNetCli.Tools/DockerCLIWrapper.cs
+++ b/src/Amazon.Common.DotNetCli.Tools/DockerCLIWrapper.cs
@@ -151,5 +151,39 @@ namespace Amazon.Common.DotNetCli.Tools
 
             return base.ExecuteCommand(psi, "docker push");
         }
+
+        public int Run(string imageId, string containerName)
+        {
+            _logger?.WriteLine($"... invoking 'docker run --name {containerName} {imageId}'");
+
+            var arguments = $"run --name {containerName} {imageId}";
+
+            var psi = new ProcessStartInfo
+            {
+                FileName = this._dockerCLI,
+                Arguments = arguments.ToString(),
+                WorkingDirectory = this._workingDirectory
+            };
+
+
+            return base.ExecuteCommand(psi, "docker run");
+        }
+
+        public int Copy(string containerName, string internalContainerPathToExtract, string outputPath)
+        {
+            _logger?.WriteLine($"... invoking 'docker cp {containerName}:{internalContainerPathToExtract} .'");
+
+            var arguments = $"cp {containerName}:{internalContainerPathToExtract} {outputPath}";
+
+            var psi = new ProcessStartInfo
+            {
+                FileName = this._dockerCLI,
+                Arguments = arguments.ToString(),
+                WorkingDirectory = this._workingDirectory
+            };
+
+
+            return base.ExecuteCommand(psi, "docker cp");
+        }
     }
 }

--- a/src/Amazon.Lambda.Tools/Commands/PackageCommand.cs
+++ b/src/Amazon.Lambda.Tools/Commands/PackageCommand.cs
@@ -225,6 +225,7 @@ namespace Amazon.Lambda.Tools.Commands
                                                                      architecture: architecture,
                                                                      disableVersionCheck: disableVersionCheck,
                                                                      layerPackageInfo: layerPackageInfo,
+                                                                     buildZipInDocker: false,
                                                                      publishLocation: out publishLocation, zipArchivePath: ref zipArchivePath);
                 if (!success)
                 {

--- a/src/Amazon.Lambda.Tools/LambdaDefinedCommandOptions.cs
+++ b/src/Amazon.Lambda.Tools/LambdaDefinedCommandOptions.cs
@@ -441,5 +441,14 @@ namespace Amazon.Lambda.Tools
                 ValueType = CommandOption.CommandOptionValueType.StringValue,
                 Description = $"The type of authentication that your function URL uses, default value is NONE. Valid values: {FunctionUrlAuthType.NONE} or {FunctionUrlAuthType.AWS_IAM}"
             };
+        public static readonly CommandOption BUILD_ZIP_IN_DOCKER =
+            new CommandOption
+            {
+                Name = "Build the Lambda .zip file in Docker",
+                Switch = "--build-zip-in-docker",
+                ShortSwitch = "-bzid",
+                ValueType = CommandOption.CommandOptionValueType.BoolValue, // TODO: Not hard-code values like dockerfile location and name, and base image
+                Description = $"Tells the tool to build the Lambda .zip file in Docker locally on AL2, then extract the output zip from there for uploading."
+            };
     }
 }

--- a/src/Amazon.Lambda.Tools/Program.cs
+++ b/src/Amazon.Lambda.Tools/Program.cs
@@ -36,7 +36,7 @@ namespace Amazon.Lambda.Tools
                     new GroupHeaderInfo("Other Commands:"),
                     new CommandInfo<PackageCommand>(PackageCommand.COMMAND_NAME, PackageCommand.COMMAND_DESCRIPTION, PackageCommand.PackageCommandOptions, PackageCommand.COMMAND_ARGUMENTS),
                     new CommandInfo<PackageCICommand>(PackageCICommand.COMMAND_NAME, PackageCICommand.COMMAND_SYNOPSIS, PackageCICommand.PackageCICommandOptions),
-                    new CommandInfo<PushDockerImageCommand>(PushDockerImageCommand.COMMAND_NAME, PushDockerImageCommand.COMMAND_DESCRIPTION, PushDockerImageCommand.LambdaPushCommandOptions)
+                    new CommandInfo<PushDockerImageCommand>(PushDockerImageCommand.COMMAND_NAME, PushDockerImageCommand.COMMAND_DESCRIPTION, PushDockerImageCommand.LambdaPushCommandOptions),
                 });
 
             var exitCode = application.Execute(args);

--- a/src/Amazon.Lambda.Tools/Resources/DockerfileBuildOnly
+++ b/src/Amazon.Lambda.Tools/Resources/DockerfileBuildOnly
@@ -1,0 +1,19 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+
+FROM public.ecr.aws/amazonlinux/amazonlinux:2 AS base
+WORKDIR /source
+# Install .NET 6 and other dependencies for compiling naively
+RUN yum update -y 
+RUN yum install -y clang krb5-devel openssl-devel libicu wget zip tar gzip
+RUN mkdir -p /tmp/dotnet
+RUN wget https://download.visualstudio.microsoft.com/download/pr/9762c43b-6de2-44aa-928d-61bec028a330/ba4d124e5384ae5c5a4599afbc41b1bf/dotnet-sdk-7.0.100-preview.6.22352.1-linux-x64.tar.gz
+RUN tar zxf dotnet-sdk-7.0.100-preview.6.22352.1-linux-x64.tar.gz -C /tmp/dotnet
+#RUN export DOTNET_ROOT=/tmp/dotnet
+#RUN export PATH=$PATH:/tmp/dotnet
+
+COPY . .
+RUN /tmp/dotnet/dotnet publish -r linux-x64 -c Release --self-contained
+RUN strip /source/bin/Release/net7.0/linux-x64/native/bootstrap
+RUN cp /source/bin/Release/net7.0/linux-x64/native/bootstrap bootstrap
+RUN zip package.zip bootstrap


### PR DESCRIPTION
*Description of changes:*
This is just a POC that proves we can get an end to end solution working that builds and deploys a native AOT .NET 7 application on an Amazon Linux 2 container.

There are many TODOs throughout the code, the code is not at all generic yet.

Was tested on Windows with a `dotnet new lambda.CustomRuntimeFunction` project that was changed from `net6.0` to `net7.0` and changed `PublishReadyToRun` to `PublishAot`

To test, set Amazon.Lambda.Tool as the startup project in Visual Studio, then update the debug config working directory to your CustomRuntimeFunction and add command line arguments `deploy-function --build-zip-in-docker true`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
