### PR TITLE
Add --resolve-s3 to automatically resolve which S3 bucket to upload build output.

### DIFF
--- a/src/Amazon.Common.DotNetCli.Tools/Commands/BaseCommand.cs
+++ b/src/Amazon.Common.DotNetCli.Tools/Commands/BaseCommand.cs
@@ -14,6 +14,7 @@ using Amazon.ECR;
 using Amazon.IdentityManagement;
 using Amazon.IdentityManagement.Model;
 using Amazon.S3;
+using Amazon.SecurityToken;
 
 namespace Amazon.Common.DotNetCli.Tools.Commands
 {
@@ -754,6 +755,25 @@ namespace Amazon.Common.DotNetCli.Tools.Commands
             string version = this.GetType().GetTypeInfo().Assembly.GetName().Version.ToString();
             Util.Internal.InternalSDKUtils.SetUserAgent(this.ToolName,
                                           version);
+        }
+
+        IAmazonSecurityTokenService _stsClient;
+        public IAmazonSecurityTokenService STSClient
+        {
+            get
+            {
+                if (this._stsClient == null)
+                {
+                    SetUserAgentString();
+
+                    var config = new AmazonSecurityTokenServiceConfig();
+                    config.RegionEndpoint = DetermineAWSRegion();
+
+                    this._stsClient = new AmazonSecurityTokenServiceClient(DetermineAWSCredentials(), config);
+                }
+                return this._stsClient;
+            }
+            set { this._stsClient = value; }
         }
 
         IAmazonIdentityManagementService _iamClient;

--- a/src/Amazon.Lambda.Tools/Exceptions.cs
+++ b/src/Amazon.Lambda.Tools/Exceptions.cs
@@ -71,7 +71,9 @@ namespace Amazon.Lambda.Tools
             FailedToDetectSdkVersion,
             LayerNetSdkVersionMismatch,
 
-            DisabledSupportForNET31Layers
+            DisabledSupportForNET31Layers,
+
+            FailedToResolveS3Bucket
         }
 
         public LambdaToolsException(string message, LambdaErrorCode code) : base(message, code.ToString(), null)

--- a/src/Amazon.Lambda.Tools/LambdaConstants.cs
+++ b/src/Amazon.Lambda.Tools/LambdaConstants.cs
@@ -48,6 +48,8 @@ namespace Amazon.Lambda.Tools
         public const string ARCHITECTURE_X86_64 = "x86_64";
         public const string ARCHITECTURE_ARM64 = "arm64";
 
+        public const string DEFAULT_BUCKET_NAME_PREFIX = "aws-dotnet-lambda-tools-";
+
         // This is the same value the console is using.
         public const string FUNCTION_URL_PUBLIC_PERMISSION_STATEMENT_ID = "FunctionURLAllowPublicAccess";
 

--- a/src/Amazon.Lambda.Tools/LambdaDefinedCommandOptions.cs
+++ b/src/Amazon.Lambda.Tools/LambdaDefinedCommandOptions.cs
@@ -206,6 +206,15 @@ namespace Amazon.Lambda.Tools
                 ValueType = CommandOption.CommandOptionValueType.StringValue,
                 Description = "KMS Key ARN of a customer key used to encrypt the function's environment variables"
             };
+        public static readonly CommandOption ARGUMENT_RESOLVE_S3 =
+            new CommandOption
+            {
+                Name = "Resolve S3 Bucket",
+                ShortSwitch = "-rs",
+                Switch = "--resolve-s3",
+                ValueType = CommandOption.CommandOptionValueType.BoolValue,
+                Description = $"If set to true a bucket with the name format of \"{LambdaConstants.DEFAULT_BUCKET_NAME_PREFIX}<region>-<account-id>\" will be configured to store build outputs"
+            }; 
         public static readonly CommandOption ARGUMENT_S3_BUCKET =
             new CommandOption
             {

--- a/test/Amazon.Lambda.Tools.Test/Amazon.Lambda.Tools.Test.csproj
+++ b/test/Amazon.Lambda.Tools.Test/Amazon.Lambda.Tools.Test.csproj
@@ -58,10 +58,13 @@
     <PackageReference Include="AWSSDK.CloudFormation" Version="3.7.9.26" />
     <PackageReference Include="AWSSDK.Lambda" Version="3.7.12.4" />
     <PackageReference Include="AWSSDK.SQS" Version="3.7.2.45" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="System.IO.Compression.ZipFile" Version="4.3.0" />
-    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="YamlDotNet.Signed" Version="5.2.1" />
 	<PackageReference Include="Moq" Version="4.16.1" />
   </ItemGroup>


### PR DESCRIPTION
*Description of changes:*
Similar to the SAM CLI this PR adds a new `--resolve-s3` switch to the `deploy-serverless` and -package-ci` commands. This new switch will allow users to who set this new switch to `true` to have the S3 bucket automatically created and used for uploading deployment bundles.

The default S3 bucket name format is `aws-dotnet-lambda-tools-<region>-<account-id>`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
