### PR TITLE
Fix issue #248 where excluding pdb files from publishing broke SAM debugging

### DIFF
--- a/src/Amazon.Lambda.Tools/Amazon.Lambda.Tools.csproj
+++ b/src/Amazon.Lambda.Tools/Amazon.Lambda.Tools.csproj
@@ -15,7 +15,7 @@
     <Copyright>Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.</Copyright>
     <Product>AWS Lambda Tools for .NET CLI</Product>
     <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
-    <Version>5.6.0</Version>
+    <Version>5.6.1</Version>
   </PropertyGroup>
   <ItemGroup>
     <Content Include="Resources\build-lambda-zip.exe">

--- a/src/Amazon.Lambda.Tools/LambdaPackager.cs
+++ b/src/Amazon.Lambda.Tools/LambdaPackager.cs
@@ -589,7 +589,8 @@ namespace Amazon.Lambda.Tools
                 if (flattenRuntime && relativePath.StartsWith(RUNTIME_FOLDER_PREFIX))
                     continue;
 
-                if (relativePath.EndsWith(".dbg", StringComparison.OrdinalIgnoreCase) || relativePath.EndsWith(".pdb", StringComparison.OrdinalIgnoreCase)) // Don't include debugging symbols
+                // Native debug symbols are very large and are being excluded to keep deployment size down.
+                if (relativePath.EndsWith(".dbg", StringComparison.OrdinalIgnoreCase)) 
                     continue;
 
                 includedFiles[relativePath] = file;


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/aws-extensions-for-dotnet-cli/issues/248

*Description of changes:*
As part of the recent Native AOT work we needed to exclude the native debug symbols from the deployment bundle to keep the deployment size small. The code was also excluding pdb files which are not produced as part of Native AOT compilation and by excluding them we broke users using the tooling for SAM debugging.

This PR restores pdb files being part of the deployment bundle to fix the regression in SAM debugging. In a future release we might want to add a setting to opt into excluding pdb files.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
