### PR TITLE
Remove check that unmanaged runtimes are exe

### DIFF
--- a/src/Amazon.Lambda.Tools/Exceptions.cs
+++ b/src/Amazon.Lambda.Tools/Exceptions.cs
@@ -76,7 +76,6 @@ namespace Amazon.Lambda.Tools
             DisabledSupportForNET31Layers,
 
             InvalidNativeAotTargetFramework,
-            InvalidOutputTypeForTargetFramework,
             Net7OnArmNotSupported,
             InvalidArchitectureProvided,
             UnsupportedDefaultContainerBuild,

--- a/src/Amazon.Lambda.Tools/LambdaConstants.cs
+++ b/src/Amazon.Lambda.Tools/LambdaConstants.cs
@@ -53,19 +53,6 @@ namespace Amazon.Lambda.Tools
         // This is the same value the console is using.
         public const string FUNCTION_URL_PUBLIC_PERMISSION_STATEMENT_ID = "FunctionURLAllowPublicAccess";
 
-        public static readonly List<string> SUPPORTED_LAMBDA_MANAGED_RUNTIMES = new List<string>
-        {
-            Runtime.Dotnetcore31,
-            Runtime.Dotnet6
-        };
-
-        public static readonly List<string> DEPRECATED_LAMBDA_MANAGED_RUNTIMES = new List<string>
-        {
-            Runtime.Dotnetcore10,
-            Runtime.Dotnetcore20,
-            Runtime.Dotnetcore21
-        };
-
         public const string AWS_LAMBDA_MANAGED_POLICY_PREFIX = "AWSLambda";
 
         public static readonly Dictionary<string, string> KNOWN_MANAGED_POLICY_DESCRIPTIONS = new Dictionary<string, string>

--- a/src/Amazon.Lambda.Tools/LambdaUtilities.cs
+++ b/src/Amazon.Lambda.Tools/LambdaUtilities.cs
@@ -85,14 +85,6 @@ namespace Amazon.Lambda.Tools
             var outputType = Utilities.LookupOutputTypeFromProjectFile(projectLocation);
             var ouputTypeIsExe = outputType != null && outputType.ToLower().Equals("exe");
 
-            // Target frameworks that are not supported as managed runtimes in Lambda must have an output type of exe to support being run as a custom runtime
-            var allManagedRuntimes = LambdaConstants.DEPRECATED_LAMBDA_MANAGED_RUNTIMES.Concat(LambdaConstants.SUPPORTED_LAMBDA_MANAGED_RUNTIMES);
-            if (!allManagedRuntimes.Contains(DetermineLambdaRuntimeFromTargetFramework(targetFramework)) && !ouputTypeIsExe)
-            {
-                throw new LambdaToolsException($"Target Framework of {targetFramework} must have output type 'exe' and run on a custom runtime, since this is not a Lambda-managed .NET runtime.",
-                    LambdaToolsException.LambdaErrorCode.InvalidOutputTypeForTargetFramework);
-            }
-
             if (isNativeAot && !ouputTypeIsExe)
             {
                 throw new LambdaToolsException($"Native AOT applications must have output type 'exe'.",

--- a/test/Amazon.Lambda.Tools.Test/UtilitiesTests.cs
+++ b/test/Amazon.Lambda.Tools.Test/UtilitiesTests.cs
@@ -186,39 +186,17 @@ namespace Amazon.Lambda.Tools.Test
             Assert.Equal(expectedValue, containerImageFile);
         }
 
-        [Fact]
-        public void AllLambdaRuntimesAreSupportedOrDeprecated()
-        {
-            // All Lambda Runtimes are identified
-            var lambdaDotnetRuntimes = typeof(Lambda.Runtime).GetFields().Where(x => x.Name.ToLower().Contains("dotnet") || x.Name.ToLower().Contains(".net"));
-
-            Assert.True(lambdaDotnetRuntimes.Any());
-
-            var allKnownSupportedAndDeprecatedRuntimes = LambdaConstants.SUPPORTED_LAMBDA_MANAGED_RUNTIMES
-                .Concat(LambdaConstants.DEPRECATED_LAMBDA_MANAGED_RUNTIMES).ToList();
-
-            foreach (var runtime in lambdaDotnetRuntimes)
-            {
-                var runtimeName = (Runtime)runtime.GetValue(null);
-                Assert.Contains(runtimeName.Value, allKnownSupportedAndDeprecatedRuntimes);
-            }
-        }
-
-        [Fact]
-        public void NoLambdaRuntimesIsBothSupportedAndDeprecated()
-        {
-            Assert.Empty(LambdaConstants.SUPPORTED_LAMBDA_MANAGED_RUNTIMES.Intersect(LambdaConstants.DEPRECATED_LAMBDA_MANAGED_RUNTIMES));
-        }
-
         [Theory]
         [InlineData("../../../../../testapps/TestFunction", "net6.0", false, false)]
         [InlineData("../../../../../testapps/TestFunction", "net6.0", true, true)]
         [InlineData("../../../../../testapps/TestFunction", "net7.0", true, true)]
-        [InlineData("../../../../../testapps/TestFunction", "net7.0", false, true)]
+        [InlineData("../../../../../testapps/TestFunction", "net7.0", false, false)]
+        [InlineData("../../../../../testapps/TestFunction", "net5.0", false, false)]
         [InlineData("../../../../../testapps/TestNativeAotSingleProject", "net7.0", true, false)]
         [InlineData("../../../../../testapps/TestNativeAotSingleProject", "net7.0", false, false)]
         [InlineData("../../../../../testapps/TestNativeAotSingleProject", "net6.0", false, false)]
         [InlineData("../../../../../testapps/TestNativeAotSingleProject", "net6.0", true, true)]
+        [InlineData("../../../../../testapps/TestNativeAotSingleProject", "net5.0", true, true)]
         public void TestValidateTargetFramework(string projectLocation, string targetFramework, bool isNativeAot, bool shouldThrow)
         {
             if (shouldThrow)


### PR DESCRIPTION


*Description of changes:* 

This check for output type needs to be removed since customers could bring their own runtime support in an image. Such as in the [SAM .NET 5 Template](https://github.com/Beau-Gosse-dev/aws-sam-cli-app-templates/blob/master/dotnet5.0-image/cookiecutter-aws-sam-hello-dotnet-lambda-image/%7B%7Bcookiecutter.project_name%7D%7D/src/HelloWorld/Dockerfile)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
