### PR TITLE
Extend template-parameter definition syntax in serverless configuration

### DIFF
--- a/src/Amazon.Lambda.Tools/LambdaToolsDefaults.cs
+++ b/src/Amazon.Lambda.Tools/LambdaToolsDefaults.cs
@@ -83,6 +83,9 @@ namespace Amazon.Lambda.Tools
         {
             get
             {
+                var dict = GetValueAsDictionary(LambdaDefinedCommandOptions.ARGUMENT_CLOUDFORMATION_TEMPLATE_PARAMETER);
+                if (dict != null) return dict;
+                
                 var str = GetValueAsString(LambdaDefinedCommandOptions.ARGUMENT_CLOUDFORMATION_TEMPLATE_PARAMETER);
                 if (string.IsNullOrEmpty(str))
                     return null;
@@ -102,6 +105,9 @@ namespace Amazon.Lambda.Tools
         {
             get
             {
+                var dict = GetValueAsDictionary(LambdaDefinedCommandOptions.ARGUMENT_ENVIRONMENT_VARIABLES);
+                if (dict != null) return dict;
+                
                 var str = GetValueAsString(LambdaDefinedCommandOptions.ARGUMENT_ENVIRONMENT_VARIABLES);
                 if (string.IsNullOrEmpty(str))
                     return null;


### PR DESCRIPTION
Support object and array syntax for template-parameters configuration file setting

See description in [Issue #258](https://github.com/aws/aws-extensions-for-dotnet-cli/issues/258)

*Description of changes:*

Update AmazonLambdaTools to check the parameter type for template-parameters.

* [Current] If it's a string, generate a Dictionary using current syntax ("key1=value1;key2=value2;...keyN=valueN")
* [New] If it's an object, process it using property names for keys and cast values as string
* [New] If it's an array of strings, process it using the syntax supported by SAM, which s a list of "key=value" strings

This approach is backward compatible, it won't break usage of existing template files.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
