### PR TITLE
fix: wait for lambda to be ready before update

### DIFF
--- a/src/Amazon.Lambda.Tools/Commands/DeployFunctionCommand.cs
+++ b/src/Amazon.Lambda.Tools/Commands/DeployFunctionCommand.cs
@@ -12,6 +12,7 @@ using ThirdParty.Json.LitJson;
 using Amazon.Common.DotNetCli.Tools;
 using Amazon.Common.DotNetCli.Tools.Commands;
 using Amazon.Common.DotNetCli.Tools.Options;
+using Amazon.Runtime.Internal;
 
 namespace Amazon.Lambda.Tools.Commands
 {
@@ -482,6 +483,7 @@ namespace Amazon.Lambda.Tools.Commands
 
                     try
                     {
+                        await LambdaUtilities.WaitTillFunctionAvailableAsync(Logger, this.LambdaClient, updateCodeRequest.FunctionName);
                         await this.LambdaClient.UpdateFunctionCodeAsync(updateCodeRequest);
                     }
                     catch (Exception e)


### PR DESCRIPTION
*Issue #, if available:*
DOTNET-6627

*Description of changes:*
Integration test fails due to race condition. Need to wait for lambda to be ready before trying to update the code.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
