### PR TITLE
Self-contained in csproj project file is ignored

### DIFF
--- a/src/Amazon.Common.DotNetCli.Tools/Utilities.cs
+++ b/src/Amazon.Common.DotNetCli.Tools/Utilities.cs
@@ -234,6 +234,27 @@ namespace Amazon.Common.DotNetCli.Tools
 
             return false;
         }
+        public static bool HasExplicitSelfContainedFlag(string projectLocation, string msBuildParameters)
+        {
+            if (msBuildParameters != null && msBuildParameters.Contains("--self-contained", StringComparison.InvariantCultureIgnoreCase))
+            {
+                return true;
+            }
+
+            // If the property wasn't provided in msBuildParameters, fall back to searching project file
+            var projectFile = FindProjectFileInDirectory(projectLocation);
+
+            var xdoc = XDocument.Load(projectFile);
+
+            var element = xdoc.XPathSelectElement("//PropertyGroup/SelfContained");
+
+            if (bool.TryParse(element?.Value, out _))
+            {
+                return true;
+            }
+
+            return false;
+        }
 
         public static string FindProjectFileInDirectory(string directory)
         {

--- a/src/Amazon.Lambda.Tools/LambdaDotNetCLIWrapper.cs
+++ b/src/Amazon.Lambda.Tools/LambdaDotNetCLIWrapper.cs
@@ -318,12 +318,10 @@ namespace Amazon.Lambda.Tools
                         arguments.Append($" --runtime {LambdaUtilities.DetermineRuntimeParameter(targetFramework, architecture)}");
                     }
 
-                    if (msbuildParameters == null ||
-                        msbuildParameters.IndexOf("--self-contained", StringComparison.InvariantCultureIgnoreCase) == -1)
+                    if (!Utilities.HasExplicitSelfContainedFlag(projectLocation, msbuildParameters))
                     {
                         arguments.Append($" --self-contained {isNativeAot} ");
                     }
-
                 });
 
                 // This is here to not change existing behavior for the 2.0 and 2.1 runtimes. For those runtimes if

--- a/test/Amazon.Common.DotNetCli.Tools.Test/UtilitiesTests.cs
+++ b/test/Amazon.Common.DotNetCli.Tools.Test/UtilitiesTests.cs
@@ -83,5 +83,21 @@ namespace Amazon.Common.DotNetCli.Tools.Test
 
             Assert.Equal(expected, result);
         }
+
+        [Theory]
+        [InlineData("../../../../../testapps/TestFunction", null, false)]
+        [InlineData("../../../../../testapps/TestFunction", "", false)]
+        [InlineData("../../../../../testapps/TestFunction", "--self-contained=true", true)]
+        [InlineData("../../../../../testapps/TestFunction", "--self-contained=false", true)]
+        [InlineData("../../../../../testapps/TestFunction", "--self-contained true", true)]
+        [InlineData("../../../../../testapps/TestFunction", "--self-contained false", true)]
+        [InlineData("../../../../../testapps/TestNativeAotSingleProject", null, true)]
+        [InlineData("../../../../../testapps/TestNativeAotSingleProject", "--self-contained false", true)]
+        public void TestHasExplicitSelfContainedFlag(string projectLocation, string msBuildParameters, bool expected)
+        {
+            var result = Utilities.HasExplicitSelfContainedFlag(projectLocation, msBuildParameters);
+
+            Assert.Equal(expected, result);
+        }
     }
 }

--- a/testapps/TestNativeAotSingleProject/EntryPoint.csproj
+++ b/testapps/TestNativeAotSingleProject/EntryPoint.csproj
@@ -9,6 +9,7 @@
     <!-- This property makes the build directory similar to a publish directory and helps the AWS .NET Lambda Mock Test Tool find project dependencies. -->
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
     <PublishAot>true</PublishAot>
+    <SelfContained>true</SelfContained>
   </PropertyGroup>
   <!-- 
   When publishing Lambda functions for ARM64 to the provided.al2 runtime a newer version of libicu needs to be included


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/aws-extensions-for-dotnet-cli/issues/270

*Description of changes:*
Also checks for self contained in the csproj file in addition to the ms build arguments. This allows publishing a .NET 7 custom runtime without native AOT from the SAM CLI where msbuild parameters can't be passed. 


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
