### PR TITLE
Fixed an issue lambda deploy-serverless command tries to build image when ImageUri is set in template without any Metadata.

### DIFF
--- a/src/Amazon.Lambda.Tools/Amazon.Lambda.Tools.csproj
+++ b/src/Amazon.Lambda.Tools/Amazon.Lambda.Tools.csproj
@@ -15,7 +15,7 @@
     <Copyright>Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.</Copyright>
     <Product>AWS Lambda Tools for .NET CLI</Product>
     <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
-    <Version>5.6.4</Version>
+    <Version>5.6.5</Version>
   </PropertyGroup>
   <ItemGroup>
     <Content Include="Resources\build-lambda-zip.exe">

--- a/src/Amazon.Lambda.Tools/TemplateProcessor/ITemplateParser.cs
+++ b/src/Amazon.Lambda.Tools/TemplateProcessor/ITemplateParser.cs
@@ -93,9 +93,9 @@ namespace Amazon.Lambda.Tools.TemplateProcessor
         bool IsCode { get; }
 
         /// <summary>
-        /// True if the field points to an ImageUri.
+        /// True if the field points to an Image already pushed in ECR.
         /// </summary>
-        bool IsImageUri { get; }
+        bool IsImagePushed { get; }
 
 
         /// <summary>

--- a/src/Amazon.Lambda.Tools/TemplateProcessor/ITemplateParser.cs
+++ b/src/Amazon.Lambda.Tools/TemplateProcessor/ITemplateParser.cs
@@ -91,8 +91,13 @@ namespace Amazon.Lambda.Tools.TemplateProcessor
         /// True if the field should contain code like a Lambda package bundle.
         /// </summary>
         bool IsCode { get; }
-        
-        
+
+        /// <summary>
+        /// True if the field points to an ImageUri.
+        /// </summary>
+        bool IsImageUri { get; }
+
+
         /// <summary>
         /// Reference back to the containing updatable resource.
         /// </summary>

--- a/src/Amazon.Lambda.Tools/TemplateProcessor/TemplateProcessorManager.cs
+++ b/src/Amazon.Lambda.Tools/TemplateProcessor/TemplateProcessorManager.cs
@@ -142,12 +142,18 @@ namespace Amazon.Lambda.Tools.TemplateProcessor
             UpdateResourceResults results;
             var localPath = field.GetLocalPath();
 
-            if (!Path.IsPathRooted(localPath))
+            if (!field.IsImageUri && !Path.IsPathRooted(localPath))
                 localPath = Path.Combine(templateDirectory, localPath);
 
             bool deleteArchiveAfterUploaded = false;
+
+            // If ImageUri needs to be processed.
+            if (field.IsImageUri)
+            {
+                results = new UpdateResourceResults { ImageUri = localPath };
+            }
             // Uploading a single file as the code for the resource. If the single file is not a zip file then zip the file first.
-            if(File.Exists(localPath))
+            else if (File.Exists(localPath))
             {
                 if(field.IsCode && !string.Equals(Path.GetExtension(localPath), ".zip", StringComparison.OrdinalIgnoreCase))
                 {

--- a/src/Amazon.Lambda.Tools/TemplateProcessor/TemplateProcessorManager.cs
+++ b/src/Amazon.Lambda.Tools/TemplateProcessor/TemplateProcessorManager.cs
@@ -142,13 +142,13 @@ namespace Amazon.Lambda.Tools.TemplateProcessor
             UpdateResourceResults results;
             var localPath = field.GetLocalPath();
 
-            if (!field.IsImageUri && !Path.IsPathRooted(localPath))
+            if (!field.IsImagePushed && !Path.IsPathRooted(localPath))
                 localPath = Path.Combine(templateDirectory, localPath);
 
             bool deleteArchiveAfterUploaded = false;
 
             // If ImageUri needs to be processed.
-            if (field.IsImageUri)
+            if (field.IsImagePushed)
             {
                 results = new UpdateResourceResults { ImageUri = localPath };
             }

--- a/test/Amazon.Lambda.Tools.Integ.Tests/TestConstants.cs
+++ b/test/Amazon.Lambda.Tools.Integ.Tests/TestConstants.cs
@@ -6,7 +6,7 @@ namespace Amazon.Lambda.Tools.Integ.Tests
 {
     public static class TestConstants
     {
-        public const string TEST_REGION = "sa-east-1";
+        public const string TEST_REGION = "us-west-2";
 
         public const string TEST_ECR_REPOSITORY = "aws-extensions-tests";
     }

--- a/test/Amazon.Lambda.Tools.Test/DeployTest.cs
+++ b/test/Amazon.Lambda.Tools.Test/DeployTest.cs
@@ -453,6 +453,7 @@ namespace Amazon.Lambda.Tools.Test
                 {
                     var deleteCommand = new DeleteServerlessCommand(new TestToolLogger(_testOutputHelper), fullPath, new string[0]);
                     deleteCommand.StackName = command.StackName;
+                    deleteCommand.Region = "us-east-1";
                     await deleteCommand.ExecuteAsync();
                 }
             }
@@ -581,6 +582,7 @@ namespace Amazon.Lambda.Tools.Test
                         {
                             var deleteCommand = new DeleteServerlessCommand(new TestToolLogger(_testOutputHelper), fullPath, new string[0]);
                             deleteCommand.StackName = command.StackName;
+                            deleteCommand.Region = "us-east-2";
                             await deleteCommand.ExecuteAsync();
                         }
                         catch
@@ -648,6 +650,7 @@ namespace Amazon.Lambda.Tools.Test
                 {
                     var deleteCommand = new DeleteServerlessCommand(new TestToolLogger(_testOutputHelper), fullPath, new string[0]);
                     deleteCommand.StackName = command.StackName;
+                    deleteCommand.Region = "us-east-1";
                     await deleteCommand.ExecuteAsync();
                 }
             }

--- a/test/Amazon.Lambda.Tools.Test/UtilitiesTests.cs
+++ b/test/Amazon.Lambda.Tools.Test/UtilitiesTests.cs
@@ -12,6 +12,7 @@ using System.Threading;
 using Amazon.S3.Model;
 using Xunit.Abstractions;
 using System.Linq;
+using static Amazon.Lambda.Tools.TemplateProcessor.UpdatableResource;
 
 namespace Amazon.Lambda.Tools.Test
 {
@@ -184,6 +185,18 @@ namespace Amazon.Lambda.Tools.Test
 
             var containerImageFile = LambdaUtilities.GetDefaultBuildImage(targetFramework, architecture, new TestToolLogger(_testOutputHelper));
             Assert.Equal(expectedValue, containerImageFile);
+        }
+
+        [Theory]
+        [InlineData(null, false)]
+        [InlineData("somelocalpath", false)]
+        [InlineData("123456789012", false)]
+        [InlineData("139480602983.dkr.ecr.us-east-2.amazonaws.com/test-deploy-serverless-image-uri", true)]
+        [InlineData("139480602.dkr.ecr.us-east-2.amazonaws.com/test-deploy-serverless-image-uri", false)]
+        public void TestIsECRImage(string path, bool expectedValue)
+        {
+            bool isECRImage = UpdatableResourceField.IsECRImage(path);
+            Assert.Equal(expectedValue, isECRImage);
         }
 
         [Theory]


### PR DESCRIPTION
*Issue #, if available:* #264

*Description of changes:*
Fixed an issue lambda deploy-serverless command tries to build image when ImageUri is set in template without any Metadata.

Per https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/sam-resource-function.html#sam-function-imageuri, `Building your application with necessary Metadata entries takes precedence over ImageUri, so if you specify both then ImageUri is ignored.`.

In customer reported scenario, metadata is not present in YAML (orJSON) template. In such case, it should not try to build the Docker image locally, instead should use the `ImageUri` set in the CloudFormation template. Currently, before this fix, it tries to validate the `ImageUri` as local path and fails the validation check.

**NOTE:** We could have added a validation check to verify if image pointed out by the `ImageUri` exists in ECR, however, there is no API to get image by `ImageUri`.

___
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
