### PR TITLE
LambdaUtilities: .NET 7 supported on ARM Amazon Linux 2

### DIFF
--- a/src/Amazon.Lambda.Tools/LambdaUtilities.cs
+++ b/src/Amazon.Lambda.Tools/LambdaUtilities.cs
@@ -118,10 +118,8 @@ namespace Amazon.Lambda.Tools
 
             switch (targetFramework?.ToLower())
             {
-                case TargetFrameworkMonikers.net70:
-                    return architecture == LambdaConstants.ARCHITECTURE_ARM64 ?
-                        throw new LambdaToolsException(".NET 7 is not supported on ARM Amazon Linux 2. See https://github.com/dotnet/runtime/issues/76195", LambdaToolsException.LambdaErrorCode.Net7OnArmNotSupported)
-                        : $"public.ecr.aws/sam/build-dotnet7:latest-{architecture}";
+                case TargetFrameworkMonikers.net70:                    
+                    return $"public.ecr.aws/sam/build-dotnet7:latest-{architecture}";
                 case TargetFrameworkMonikers.net60:
                     return $"public.ecr.aws/sam/build-dotnet6:latest-{architecture}";
                 case TargetFrameworkMonikers.netcoreapp31:


### PR DESCRIPTION
The (removed) Exception references the closed issue https://github.com/dotnet/runtime/issues/76195. 

After further investigation, I found that .NET 7 is supported on ARM Amazon Linux 2 since the following PR has been merged and released as .NET 7.0.4 on March 14, 2023: [[release/7.0] Target lower glibc for Linux arm64](https://github.com/dotnet/runtime/pull/80866).

This PR only removes the Exception - however, the referenced Docker image `public.ecr.aws/sam/build-dotnet7:latest-arm64` doesn't exist yet on ECR, which is unfortunately not something I can fix. 

As a workaround, I've build a local docker image on my Mac M1 with the following Dockerfile and the following command, which tags it the way the dotnet lambda tool expects its. 

```sh
docker build . -t "public.ecr.aws/sam/build-dotnet7:latest-arm64"
```

This way, I was able to successfully build a .NET7 AOT Lamba on ARM64 locally, which runs happily on AWS Lambda.

```Dockerfile
FROM public.ecr.aws/amazonlinux/amazonlinux:2 AS base
WORKDIR /source

# Install .NET 7 and other dependencies for compiling natively
RUN yum update -y && yum install -y clang krb5-devel openssl-devel zip libicu-devel wget tar gzip

RUN wget https://dot.net/v1/dotnet-install.sh -O dotnet-install.sh
RUN chmod +x dotnet-install.sh 
RUN ./dotnet-install.sh --channel 7.0 --install-dir /opt/dotnet

ENV DOTNET_ROOT="/opt/dotnet"
ENV PATH="$PATH:/opt/dotnet:/opt/dotnet/tools"
```