### PR TITLE
Improve error reporting used by the VS Toolkit

### DIFF
--- a/src/Amazon.Common.DotNetCli.Tools/Commands/BaseCommand.cs
+++ b/src/Amazon.Common.DotNetCli.Tools/Commands/BaseCommand.cs
@@ -21,7 +21,9 @@ namespace Amazon.Common.DotNetCli.Tools.Commands
     public abstract class BaseCommand<TDefaultConfig> : ICommand
         where TDefaultConfig : DefaultConfigFile, new()
     {
-        public ToolsException LastToolsException { get; protected set; }
+        public ToolsException LastToolsException  => LastException as ToolsException;
+
+        public Exception LastException { get; private set; }
 
         public string[] OriginalCommandLineArguments { get; private set; }
 
@@ -58,13 +60,14 @@ namespace Amazon.Common.DotNetCli.Tools.Commands
             catch (ToolsException e)
             {
                 this.Logger?.WriteLine(e.Message);
-                this.LastToolsException = e;
+                this.LastException = e;
                 return false;
             }
             catch (Exception e)
             {
                 this.Logger?.WriteLine($"Unknown error executing command: {e.Message}");
                 this.Logger?.WriteLine(e.StackTrace);
+                this.LastException = e;
                 return false;
             }
  

--- a/src/Amazon.Common.DotNetCli.Tools/ToolsException.cs
+++ b/src/Amazon.Common.DotNetCli.Tools/ToolsException.cs
@@ -23,6 +23,7 @@ namespace Amazon.Common.DotNetCli.Tools
             InvalidCredentialConfiguration,
 
             DotnetPublishFailed,
+            ShellOutToDotnetPublishFailed, // Return for the specific shell out to dotnet publish
 
             DockerBuildFailed,
             FailedToFindSolutionDirectory,

--- a/src/Amazon.Lambda.Tools/Amazon.Lambda.Tools.csproj
+++ b/src/Amazon.Lambda.Tools/Amazon.Lambda.Tools.csproj
@@ -15,7 +15,7 @@
     <Copyright>Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.</Copyright>
     <Product>AWS Lambda Tools for .NET CLI</Product>
     <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
-    <Version>5.7.0</Version>
+    <Version>5.7.1</Version>
   </PropertyGroup>
   <ItemGroup>
     <Content Include="Resources\build-lambda-zip.exe">

--- a/src/Amazon.Lambda.Tools/Commands/DeployFunctionCommand.cs
+++ b/src/Amazon.Lambda.Tools/Commands/DeployFunctionCommand.cs
@@ -200,10 +200,10 @@ namespace Amazon.Lambda.Tools.Commands
 
                 if (!pushResults.Success)
                 {
-                    if (pushResults.LastToolsException != null)
-                        throw pushResults.LastToolsException;
+                    if (pushResults.LastException != null)
+                        throw pushResults.LastException;
 
-                    return false;
+                    throw new LambdaToolsException("Failed to push container image to ECR.", LambdaToolsException.LambdaErrorCode.FailedToPushImage);
                 }
 
                 ecrImageUri = pushResults.ImageUri;
@@ -256,7 +256,7 @@ namespace Amazon.Lambda.Tools.Commands
                                                             );
 
                     if (string.IsNullOrEmpty(zipArchivePath))
-                        return false;
+                        throw new LambdaToolsException("Failed to create Lambda deployment bundle.", ToolsException.CommonErrorCode.DotnetPublishFailed);
                 }
                 else
                 {
@@ -551,7 +551,7 @@ namespace Amazon.Lambda.Tools.Commands
             var result = new PushLambdaImageResult();
             result.Success = await pushCommand.ExecuteAsync();
             result.ImageUri = pushCommand.PushedImageUri;
-            result.LastToolsException = pushCommand.LastToolsException;
+            result.LastException = pushCommand.LastException;
 
             return result;
         }

--- a/src/Amazon.Lambda.Tools/Commands/PackageCommand.cs
+++ b/src/Amazon.Lambda.Tools/Commands/PackageCommand.cs
@@ -161,10 +161,10 @@ namespace Amazon.Lambda.Tools.Commands
 
                 if (!pushResults.Success)
                 {
-                    if (pushResults.LastToolsException != null)
-                        throw pushResults.LastToolsException;
+                    if (pushResults.LastException != null)
+                        throw pushResults.LastException;
 
-                    return false;
+                    throw new LambdaToolsException("Failed to push container image to ECR.", LambdaToolsException.LambdaErrorCode.FailedToPushImage);
                 }
             }
             else
@@ -246,8 +246,7 @@ namespace Amazon.Lambda.Tools.Commands
                                                                      zipArchivePath: ref zipArchivePath);
                 if (!success)
                 {
-                    this.Logger.WriteLine("Failed to create application package");
-                    return false;
+                    throw new LambdaToolsException("Failed to create Lambda deployment bundle.", ToolsException.CommonErrorCode.DotnetPublishFailed);
                 }
 
 
@@ -298,7 +297,7 @@ namespace Amazon.Lambda.Tools.Commands
 
             var result = new PushLambdaImageResult();
             result.Success = await pushCommand.ExecuteAsync();
-            result.LastToolsException = pushCommand.LastToolsException;
+            result.LastException = pushCommand.LastException;
 
             if(result.Success)
             {

--- a/src/Amazon.Lambda.Tools/Commands/PushLambdaImageResult.cs
+++ b/src/Amazon.Lambda.Tools/Commands/PushLambdaImageResult.cs
@@ -8,7 +8,7 @@ namespace Amazon.Lambda.Tools.Commands
     public class PushLambdaImageResult
     {
         public bool Success { get; set; }
-        public ToolsException LastToolsException { get; set; }
+        public Exception LastException { get; set; }
         public string ImageUri { get; set; }
     }
 }

--- a/src/Amazon.Lambda.Tools/Exceptions.cs
+++ b/src/Amazon.Lambda.Tools/Exceptions.cs
@@ -21,6 +21,9 @@ namespace Amazon.Lambda.Tools
             CloudFormationDescribeChangeSet,
             CloudFormationDescribeStack,
             CloudFormationDescribeStackEvents,
+            InvalidCloudFormationStackState,
+            FailedToCreateChangeSet,
+            FailedLambdaCreateOrUpdate,
 
             InvalidPackage,
             FrameworkNewerThanRuntime,
@@ -81,6 +84,8 @@ namespace Amazon.Lambda.Tools
             UnsupportedDefaultContainerBuild,
             NativeAotOutputTypeError,
             MismatchedNativeAotArchitectures,
+            ContainerBuildFailed,
+            FailedToPushImage
         }
 
         public LambdaToolsException(string message, LambdaErrorCode code) : base(message, code.ToString(), null)
@@ -92,6 +97,10 @@ namespace Amazon.Lambda.Tools
         }
 
         public LambdaToolsException(string message, LambdaErrorCode code, Exception e) : base(message, code.ToString(), e)
+        {
+        }
+
+        public LambdaToolsException(string message, CommonErrorCode code, Exception e) : base(message, code.ToString(), e)
         {
         }
     }

--- a/src/Amazon.Lambda.Tools/LambdaPackager.cs
+++ b/src/Amazon.Lambda.Tools/LambdaPackager.cs
@@ -155,8 +155,7 @@ namespace Amazon.Lambda.Tools
                 var runResult = dockerCli.Run(containerImageForBuild, containerName, publishCommand);
                 if (runResult != 0)
                 {
-                    logger?.WriteLine($"ERROR: Container build returned {runResult}");
-                    return false;
+                    throw new LambdaToolsException($"ERROR: Container build returned {runResult}", LambdaToolsException.LambdaErrorCode.ContainerBuildFailed);
                 }
             }
             else
@@ -170,7 +169,7 @@ namespace Amazon.Lambda.Tools
                     architecture: architecture,
                     publishManifests: publishManifestPath) != 0)
                 {
-                    return false;
+                    throw new LambdaToolsException($"ERROR: The dotnet publish command return unsuccessful error code", LambdaToolsException.CommonErrorCode.ShellOutToDotnetPublishFailed);
                 }
             }
 

--- a/src/Amazon.Lambda.Tools/TemplateProcessor/TemplateProcessorManager.cs
+++ b/src/Amazon.Lambda.Tools/TemplateProcessor/TemplateProcessorManager.cs
@@ -274,7 +274,7 @@ namespace Amazon.Lambda.Tools.TemplateProcessor
                     if (command.LastToolsException != null)
                         message += $": {command.LastToolsException.Message}";
 
-                    throw new LambdaToolsException(message, ToolsException.CommonErrorCode.DotnetPublishFailed);
+                    throw new LambdaToolsException(message, ToolsException.CommonErrorCode.DotnetPublishFailed, command.LastToolsException);
                 }
 
                 var results = new UpdateResourceResults() { ZipArchivePath = outputPackage };


### PR DESCRIPTION
*Description of changes:*
Rework in the DeployFunctionCommand and DeployServerlessCommand to replace usages of `return false` when there is an error to abort the deployment to throw a `LambdaToolsException` instead. This gives the toolkit better insight what actually went wrong and allows them to display a prompt with the error message.

All exceptions are eventually trapped at the base method called by the CLI or Toolkit so returning exceptions instead of returning false will have no introduce surprise failures.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
