### PR TITLE
fix: ensure net6.0 runtimes are copied with the publish artifacts

### DIFF
--- a/src/Amazon.Lambda.Tools/Amazon.Lambda.Tools.csproj
+++ b/src/Amazon.Lambda.Tools/Amazon.Lambda.Tools.csproj
@@ -15,7 +15,7 @@
     <Copyright>Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.</Copyright>
     <Product>AWS Lambda Tools for .NET CLI</Product>
     <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
-    <Version>5.7.1</Version>
+    <Version>5.7.2</Version>
   </PropertyGroup>
   <ItemGroup>
     <Content Include="Resources\build-lambda-zip.exe">

--- a/src/Amazon.Lambda.Tools/LambdaPackager.cs
+++ b/src/Amazon.Lambda.Tools/LambdaPackager.cs
@@ -442,8 +442,7 @@ namespace Amazon.Lambda.Tools
 
         /// <summary>
         /// Work around issues with Microsoft.PowerShell.SDK NuGet package not working correctly when publish with a
-        /// runtime switch. The nested Module folder under runtimes/win/lib/netcoreapp3.1/ needs to be copied
-        /// to the copied to the root of the deployment bundle.
+        /// runtime switch. The nested Module folder under runtimes/unix/lib/{targetFramework}/ needs to be copied to the root of the deployment bundle.
         ///
         /// https://github.com/PowerShell/PowerShell/issues/13132
         /// </summary>
@@ -451,7 +450,8 @@ namespace Amazon.Lambda.Tools
         /// <param name="publishLocation"></param>
         private static void FlattenPowerShellRuntimeModules(IToolLogger logger, string publishLocation, string targetFramework)
         {
-            var runtimeModuleDirectory = Path.Combine(publishLocation, "runtimes/win/lib/netcoreapp3.1/Modules");
+            var runtimeModuleDirectory = Path.Combine(publishLocation, $"runtimes/unix/lib/{targetFramework}/Modules");
+
             if (!File.Exists(Path.Combine(publishLocation, "Microsoft.PowerShell.SDK.dll")) || !Directory.Exists(runtimeModuleDirectory))
                 return;
 

--- a/testapps/TestPowerShellParallelTest/TestPowerShellParallelTest.csproj
+++ b/testapps/TestPowerShellParallelTest/TestPowerShellParallelTest.csproj
@@ -14,7 +14,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.PowerShell.SDK" Version="7.0.0" />
+        <PackageReference Include="Microsoft.PowerShell.SDK" Version="7.2.1" />
 
         <PackageReference Include="Amazon.Lambda.Core" Version="1.1.0" />
         <PackageReference Include="Amazon.Lambda.PowerShellHost" Version="2.0.0" />


### PR DESCRIPTION
*Issue #, if available:*
DOTNET-6497
https://github.com/aws/aws-lambda-dotnet/issues/1341

*Description of changes:*
This PR copies the `net6.0` runtime modules in the publish directory while deploying PS Lambda functions based on .NET 6.

The `Microsoft.PowerShell.SDK` version referenced by `TestPowerShellParallelTest.csproj` is also bumped up to `7.2.1` to run the PS Lambda function on .NET 6.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
