### PR TITLE
Improve error reporting with ECS workflows

### DIFF
--- a/src/Amazon.Common.DotNetCli.Tools/ToolsException.cs
+++ b/src/Amazon.Common.DotNetCli.Tools/ToolsException.cs
@@ -62,7 +62,7 @@ namespace Amazon.Common.DotNetCli.Tools
         }
 
         protected ToolsException(string message, string errorCode, Exception e)
-            : base(message)
+            : base(message, e)
         {
             this.Code = errorCode;
 

--- a/src/Amazon.ECS.Tools/Commands/DeployScheduledTaskCommand.cs
+++ b/src/Amazon.ECS.Tools/Commands/DeployScheduledTaskCommand.cs
@@ -111,7 +111,13 @@ namespace Amazon.ECS.Tools.Commands
                 var success = await pushCommand.ExecuteAsync();
 
                 if (!success)
+                {
+                    if (pushCommand.LastException != null)
+                    {
+                        throw pushCommand.LastException;
+                    }
                     return false;
+                }
 
                 this.PushDockerImageProperties.DockerImageTag = pushCommand.PushedImageUri;
             }

--- a/src/Amazon.ECS.Tools/Commands/DeployServiceCommand.cs
+++ b/src/Amazon.ECS.Tools/Commands/DeployServiceCommand.cs
@@ -128,7 +128,13 @@ namespace Amazon.ECS.Tools.Commands
                 var success = await pushCommand.ExecuteAsync();
 
                 if (!success)
+                {
+                    if (pushCommand.LastException != null)
+                    {
+                        throw pushCommand.LastException;
+                    }
                     return false;
+                }
 
                 this.PushDockerImageProperties.DockerImageTag = pushCommand.PushedImageUri;
             }

--- a/src/Amazon.ECS.Tools/Commands/DeployTaskCommand.cs
+++ b/src/Amazon.ECS.Tools/Commands/DeployTaskCommand.cs
@@ -108,7 +108,13 @@ namespace Amazon.ECS.Tools.Commands
                 var success = await pushCommand.ExecuteAsync();
 
                 if (!success)
+                {
+                    if (pushCommand.LastException != null)
+                    {
+                        throw pushCommand.LastException;
+                    }
                     return false;
+                }
 
                 this.PushDockerImageProperties.DockerImageTag = pushCommand.PushedImageUri;
             }


### PR DESCRIPTION
*Description of changes:*
This change is a follow-up to PR #281 to improve error reporting with ECS workflows. 
Changes include:
* Capturing the inner exception with the ToolsException if one is present
* Throwing `LastException` if an error is encountered with the deployment instead of returning a `false` with ECS based workflows

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
