### PR TITLE
Feature Addition: User Configurable Stack Polling Interval

### DIFF
--- a/src/Amazon.Lambda.Tools/LambdaDefinedCommandOptions.cs
+++ b/src/Amazon.Lambda.Tools/LambdaDefinedCommandOptions.cs
@@ -287,6 +287,15 @@ namespace Amazon.Lambda.Tools
                 ValueType = CommandOption.CommandOptionValueType.BoolValue,
                 Description = "If true wait for the Stack to finish updating before exiting. Default is true."
             };
+        public static readonly CommandOption ARGUMENT_STACK_POLLING_DELAY =
+            new CommandOption
+            {
+                Name = "Stack Polling Delay",
+                ShortSwitch = "-pd",
+                Switch = "--stack-polling-delay",
+                ValueType = CommandOption.CommandOptionValueType.IntValue,
+                Description = "The time interval in seconds between each check for stack updates. Default is 3 seconds."
+            };
         public static readonly CommandOption ARGUMENT_CLOUDFORMATION_ROLE =
             new CommandOption
             {


### PR DESCRIPTION
*Description of changes:*
In our CI/CD processes, we often hit rate limits due to frequent Describe requests when deploying stacks. This PR introduces a new `deploy-serverless` parameter `--stack-polling-delay` allowing users to set the polling interval and aligning this tool with SAM CLI's functionality (see [SAM CLI PR #3500](https://github.com/aws/aws-sam-cli/pull/3500)).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
