### PR TITLE
chore: Update AWS SDK dependencies, and patch version bumps.

### DIFF
--- a/src/Amazon.Common.DotNetCli.Tools/Amazon.Common.DotNetCli.Tools.csproj
+++ b/src/Amazon.Common.DotNetCli.Tools/Amazon.Common.DotNetCli.Tools.csproj
@@ -6,13 +6,13 @@
     <FileVersion>3.1.0.1</FileVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="AWSSDK.Core" Version="3.7.10.8" />
-    <PackageReference Include="AWSSDK.ECR" Version="3.7.4.10" />
-    <PackageReference Include="AWSSDK.IdentityManagement" Version="3.7.2.128" />
-    <PackageReference Include="AWSSDK.S3" Version="3.7.8.20" />
-    <PackageReference Include="AWSSDK.SecurityToken" Version="3.7.1.140" />
-    <PackageReference Include="AWSSDK.SSO" Version="3.7.0.148" />
-    <PackageReference Include="AWSSDK.SSOOIDC" Version="3.7.0.148" />
+    <PackageReference Include="AWSSDK.Core" Version="3.7.202.21" />
+    <PackageReference Include="AWSSDK.ECR" Version="3.7.201.16" />
+    <PackageReference Include="AWSSDK.IdentityManagement" Version="3.7.200.52" />
+    <PackageReference Include="AWSSDK.S3" Version="3.7.205.7" />
+    <PackageReference Include="AWSSDK.SecurityToken" Version="3.7.202.3" />
+    <PackageReference Include="AWSSDK.SSO" Version="3.7.201.3" />
+    <PackageReference Include="AWSSDK.SSOOIDC" Version="3.7.201.9" />
   </ItemGroup>
   <PropertyGroup>
     <NoWarn>1701;1702;1705;1591</NoWarn>

--- a/src/Amazon.ECS.Tools/Amazon.ECS.Tools.csproj
+++ b/src/Amazon.ECS.Tools/Amazon.ECS.Tools.csproj
@@ -10,7 +10,7 @@
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>dotnet-ecs</ToolCommandName>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Version>3.5.4</Version>
+    <Version>3.5.5</Version>
     <AssemblyName>dotnet-ecs</AssemblyName>
     <Company>Amazon.com, Inc</Company>
     <Authors>Amazon Web Services</Authors>
@@ -20,13 +20,13 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AWSSDK.CloudWatchEvents" Version="3.7.4.93" />
-    <PackageReference Include="AWSSDK.CloudWatchLogs" Version="3.7.2.42" />
-    <PackageReference Include="AWSSDK.Core" Version="3.7.10.8" />
-    <PackageReference Include="AWSSDK.EC2" Version="3.7.64.1" />
-    <PackageReference Include="AWSSDK.ECS" Version="3.7.5.18" />
-    <PackageReference Include="AWSSDK.IdentityManagement" Version="3.7.2.128" />
-    <PackageReference Include="AWSSDK.S3" Version="3.7.8.20" />
+    <PackageReference Include="AWSSDK.CloudWatchEvents" Version="3.7.202.8" />
+    <PackageReference Include="AWSSDK.CloudWatchLogs" Version="3.7.201.9" />
+    <PackageReference Include="AWSSDK.Core" Version="3.7.202.21" />
+    <PackageReference Include="AWSSDK.EC2" Version="3.7.218.3" />
+    <PackageReference Include="AWSSDK.ECS" Version="3.7.201.22" />
+    <PackageReference Include="AWSSDK.IdentityManagement" Version="3.7.200.52" />
+    <PackageReference Include="AWSSDK.S3" Version="3.7.205.7" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Amazon.ElasticBeanstalk.Tools/Amazon.ElasticBeanstalk.Tools.csproj
+++ b/src/Amazon.ElasticBeanstalk.Tools/Amazon.ElasticBeanstalk.Tools.csproj
@@ -10,7 +10,7 @@
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>dotnet-eb</ToolCommandName>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Version>4.3.2</Version>
+    <Version>4.3.3</Version>
     <AssemblyName>dotnet-eb</AssemblyName>
     <Authors>Amazon Web Services</Authors>
     <Copyright>Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.</Copyright>
@@ -25,9 +25,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="AWSSDK.ElasticBeanstalk" Version="3.7.0.148" />
-    <PackageReference Include="AWSSDK.IdentityManagement" Version="3.7.2.128" />
-    <PackageReference Include="AWSSDK.S3" Version="3.7.8.20" />
+    <PackageReference Include="AWSSDK.ElasticBeanstalk" Version="3.7.200.52" />
+    <PackageReference Include="AWSSDK.IdentityManagement" Version="3.7.200.52" />
+    <PackageReference Include="AWSSDK.S3" Version="3.7.205.7" />
   </ItemGroup>
   
   <PropertyGroup>

--- a/src/Amazon.Lambda.Tools/Amazon.Lambda.Tools.csproj
+++ b/src/Amazon.Lambda.Tools/Amazon.Lambda.Tools.csproj
@@ -15,7 +15,7 @@
     <Copyright>Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.</Copyright>
     <Product>AWS Lambda Tools for .NET CLI</Product>
     <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
-    <Version>5.8.0</Version>
+    <Version>5.8.1</Version>
   </PropertyGroup>
   <ItemGroup>
     <Content Include="Resources\build-lambda-zip.exe">
@@ -36,10 +36,10 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-    <PackageReference Include="AWSSDK.CloudFormation" Version="3.7.9.26" />
-    <PackageReference Include="AWSSDK.Lambda" Version="3.7.12.4" />
-    <PackageReference Include="AWSSDK.IdentityManagement" Version="3.7.2.128" />
-    <PackageReference Include="AWSSDK.S3" Version="3.7.8.20" />
+    <PackageReference Include="AWSSDK.CloudFormation" Version="3.7.203.46" />
+    <PackageReference Include="AWSSDK.Lambda" Version="3.7.201.48" />
+    <PackageReference Include="AWSSDK.IdentityManagement" Version="3.7.200.52" />
+    <PackageReference Include="AWSSDK.S3" Version="3.7.205.7" />
     <PackageReference Include="YamlDotNet.Signed" Version="5.2.1" />
   </ItemGroup>
   <PropertyGroup>

--- a/test/Amazon.ElasticBeanstalk.Tools.Test/Amazon.ElasticBeanstalk.Tools.Test.csproj
+++ b/test/Amazon.ElasticBeanstalk.Tools.Test/Amazon.ElasticBeanstalk.Tools.Test.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AWSSDK.ElasticBeanstalk" Version="3.7.0.148" />
+    <PackageReference Include="AWSSDK.ElasticBeanstalk" Version="3.7.200.52" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
     <PackageReference Include="Moq" Version="4.16.1" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />

--- a/test/Amazon.Lambda.Tools.Test/Amazon.Lambda.Tools.Test.csproj
+++ b/test/Amazon.Lambda.Tools.Test/Amazon.Lambda.Tools.Test.csproj
@@ -55,9 +55,9 @@
     </Content>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="AWSSDK.CloudFormation" Version="3.7.9.26" />
-    <PackageReference Include="AWSSDK.Lambda" Version="3.7.12.4" />
-    <PackageReference Include="AWSSDK.SQS" Version="3.7.2.45" />
+    <PackageReference Include="AWSSDK.CloudFormation" Version="3.7.203.46" />
+    <PackageReference Include="AWSSDK.Lambda" Version="3.7.201.48" />
+    <PackageReference Include="AWSSDK.SQS" Version="3.7.200.53" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
*Issue #, if available:* P99740122

*Description of changes:* 
* Updates AWS SDK dependencies to latest
* Patch version bump for all three tools.

This is primary to pull in the SSO fix to honor `sso-session` that was introduced in AWSSDK.Core 3.7.103.10: https://github.com/aws/aws-sdk-net/blob/master/changelogs/SDK.CHANGELOG.2023.md#374531-2023-01-04-0034-utc

The internal ticket above is reporting that attempting to use the SSO profile that is produced by  `aws configure sso` results in:
```
dotnet lambda deploy-function --profile sso-test
...
Error retrieving configuration for function EmptyLambda: Value cannot be null. (Parameter 'Property cannot be empty: Region, StartUrl')
```
Testing locally after a version upgrade deploys successfully:
```
dotnet lambda deploy-function --profile sso-test
...
Updating code for existing function
```

Existing tests pass locally via ` msbuild .\buildtools\build.proj`


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
