### PR TITLE
Enable AOT publishing for AL2023

### DIFF
--- a/src/Amazon.Lambda.Tools/Amazon.Lambda.Tools.csproj
+++ b/src/Amazon.Lambda.Tools/Amazon.Lambda.Tools.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <Description>Amazon.Lambda.Tools adds commands to the dotnet cli to deploy AWS Lambda functions.</Description>
     <AssemblyTitle>Amazon.Lambda.Tools</AssemblyTitle>
-    <TargetFrameworks>netcoreapp3.1;net6.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net6.0;net8.0</TargetFrameworks>
     <AssemblyName>dotnet-lambda</AssemblyName>
     <OutputType>Exe</OutputType>
     <PackageId>Amazon.Lambda.Tools</PackageId>
@@ -15,7 +15,7 @@
     <Copyright>Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.</Copyright>
     <Product>AWS Lambda Tools for .NET CLI</Product>
     <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
-    <Version>5.8.1</Version>
+    <Version>5.9.0</Version>
   </PropertyGroup>
   <ItemGroup>
     <Content Include="Resources\build-lambda-zip.exe">

--- a/src/Amazon.Lambda.Tools/LambdaPackager.cs
+++ b/src/Amazon.Lambda.Tools/LambdaPackager.cs
@@ -21,6 +21,7 @@ namespace Amazon.Lambda.Tools
         private const string BootstrapFilename = "bootstrap";
         private const string LinuxOSReleaseFile = @"/etc/os-release";
         private const string AmazonLinux2InOSReleaseFile = "PRETTY_NAME=\"Amazon Linux 2\"";
+        private const string AmazonLinux2023InOSReleaseFile = "PRETTY_NAME=\"Amazon Linux 2023\"";
 #if NETCOREAPP3_1_OR_GREATER        
         private static readonly string BuildLambdaZipCliPath = Path.Combine(
             Path.GetDirectoryName(new Uri(Assembly.GetExecutingAssembly().Location).LocalPath),
@@ -36,7 +37,7 @@ namespace Amazon.Lambda.Tools
             { "netcoreapp1.1", Version.Parse("1.6.1") }
         };
 
-        private static bool IsAmazonLinux2(IToolLogger logger)
+        private static bool IsAmazonLinux(IToolLogger logger)
         {
 #if !NETCOREAPP3_1_OR_GREATER
     return false;
@@ -51,6 +52,12 @@ namespace Amazon.Lambda.Tools
                     {
                         logger?.WriteLine(
                             $"Linux distribution is Amazon Linux 2, NativeAOT container build is optional");
+                        return true;
+                    }
+                    if (readText.Contains(AmazonLinux2023InOSReleaseFile))
+                    {
+                        logger?.WriteLine(
+                            $"Linux distribution is Amazon Linux 2023, NativeAOT container build is optional");
                         return true;
                     }
                 }
@@ -92,7 +99,7 @@ namespace Amazon.Lambda.Tools
             else if (string.IsNullOrWhiteSpace(containerImageForBuild))
             {
                 // Use a default container image if Use Container is set to true, or if we need to build NativeAOT on non-AL2
-                if ((useContainerForBuild.HasValue && useContainerForBuild.Value) || (isNativeAot && !IsAmazonLinux2(logger)))
+                if ((useContainerForBuild.HasValue && useContainerForBuild.Value) || (isNativeAot && !IsAmazonLinux(logger)))
                 {
                     containerImageForBuild = LambdaUtilities.GetDefaultBuildImage(targetFramework, architecture, logger);
                 }


### PR DESCRIPTION
*Description of changes:*
The deploy tooling when building for AOT will default to container builds unless we detect we on Amazon Linux. In that case container build defaults to false and we compile on the Amazon Linux instance. Originally the code only checked for AL2 but now that we have AL2023 and .NET 8 managed runtime will be based on this I extended the check for AL 2023.

I also added the .NET 8 target framework to the project file.

I verified the fix by spinning up an EC2 AL2023 instance and deployed an AOT function from there which did not trigger a container build.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
