### PR TITLE
Add the .NET 8 build image to Amazon.Lambda.Tools

### DIFF
--- a/src/Amazon.Lambda.Tools/Amazon.Lambda.Tools.csproj
+++ b/src/Amazon.Lambda.Tools/Amazon.Lambda.Tools.csproj
@@ -15,7 +15,7 @@
     <Copyright>Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.</Copyright>
     <Product>AWS Lambda Tools for .NET CLI</Product>
     <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
-    <Version>5.9.0</Version>
+    <Version>5.10.0</Version>
   </PropertyGroup>
   <ItemGroup>
     <Content Include="Resources\build-lambda-zip.exe">

--- a/src/Amazon.Lambda.Tools/LambdaUtilities.cs
+++ b/src/Amazon.Lambda.Tools/LambdaUtilities.cs
@@ -26,6 +26,7 @@ namespace Amazon.Lambda.Tools
 {
     public static class TargetFrameworkMonikers
     {
+        public const string net80 = "net8.0";
         public const string net70 = "net7.0";
         public const string net60 = "net6.0";
         public const string net50 = "net5.0";
@@ -44,7 +45,8 @@ namespace Amazon.Lambda.Tools
             netcoreapp31,
             net50,
             net60,
-            net70
+            net70,
+            net80
         };
     }
 
@@ -54,6 +56,7 @@ namespace Amazon.Lambda.Tools
 
         public static readonly IReadOnlyDictionary<string, string> _lambdaRuntimeToDotnetFramework = new Dictionary<string, string>()
         {
+            {"dotnet8", TargetFrameworkMonikers.net80}, // Use the string version since the SDK hasn't been updated yet.
             {Amazon.Lambda.Runtime.Dotnet6.Value, TargetFrameworkMonikers.net60},
             {Amazon.Lambda.Runtime.Dotnetcore31.Value, TargetFrameworkMonikers.netcoreapp31},
             {Amazon.Lambda.Runtime.Dotnetcore21.Value, TargetFrameworkMonikers.netcoreapp21},
@@ -118,6 +121,8 @@ namespace Amazon.Lambda.Tools
 
             switch (targetFramework?.ToLower())
             {
+                case TargetFrameworkMonikers.net80:
+                    return $"public.ecr.aws/sam/build-dotnet8:latest-{architecture}";
                 case TargetFrameworkMonikers.net70:                    
                     return $"public.ecr.aws/sam/build-dotnet7:latest-{architecture}";
                 case TargetFrameworkMonikers.net60:

--- a/test/Amazon.Lambda.Tools.Test/UtilitiesTests.cs
+++ b/test/Amazon.Lambda.Tools.Test/UtilitiesTests.cs
@@ -26,6 +26,8 @@ namespace Amazon.Lambda.Tools.Test
         }
 
         [Theory]
+        [InlineData("dotnet8", "net8.0")]
+        [InlineData("dotnet6", "net6.0")]
         [InlineData("dotnetcore2.1", "netcoreapp2.1")]
         [InlineData("dotnetcore2.0", "netcoreapp2.0")]
         [InlineData("dotnetcore1.0", "netcoreapp1.0")]


### PR DESCRIPTION
*Description of changes:*
The .NET 8 Lambda build image has been released. This PR adds the new image to the map of container images to use for building.

Besides updating the unit tests I have manually deployed Native AOT Lambda functions successfully with the .NET 8 build image being automatically picked up.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
