### PR TITLE
Fix issue with building Lambda Container images targeting ARM

### DIFF
--- a/src/Amazon.Lambda.Tools/Amazon.Lambda.Tools.csproj
+++ b/src/Amazon.Lambda.Tools/Amazon.Lambda.Tools.csproj
@@ -15,7 +15,7 @@
     <Copyright>Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.</Copyright>
     <Product>AWS Lambda Tools for .NET CLI</Product>
     <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
-    <Version>5.10.0</Version>
+    <Version>5.10.1</Version>
   </PropertyGroup>
   <ItemGroup>
     <Content Include="Resources\build-lambda-zip.exe">

--- a/src/Amazon.Lambda.Tools/Commands/DeployFunctionCommand.cs
+++ b/src/Amazon.Lambda.Tools/Commands/DeployFunctionCommand.cs
@@ -531,7 +531,7 @@ namespace Amazon.Lambda.Tools.Commands
                 ProjectLocation = this.ProjectLocation,
                 Region = this.Region,
                 WorkingDirectory = this.WorkingDirectory,
-                
+                Architecture = this.Architecture,
 
                 PushDockerImageProperties = new BasePushDockerImageCommand<LambdaToolsDefaults>.PushDockerImagePropertyContainer
                 {

--- a/src/Amazon.Lambda.Tools/TemplateProcessor/TemplateProcessorManager.cs
+++ b/src/Amazon.Lambda.Tools/TemplateProcessor/TemplateProcessorManager.cs
@@ -295,6 +295,7 @@ namespace Amazon.Lambda.Tools.TemplateProcessor
                 pushCommand.PushDockerImageProperties.DockerFile = field.GetMetadataDockerfile();
                 pushCommand.PushDockerImageProperties.DockerImageTag = field.GetMetadataDockerTag();
                 pushCommand.ImageTagUniqueSeed = field.Resource.Name;
+                pushCommand.Architecture = field.Resource.LambdaArchitecture;
 
                 // Refer https://docs.docker.com/engine/reference/commandline/build/#set-build-time-variables---build-arg
                 Dictionary<string, string> dockerBuildArgs = field.GetMetadataDockerBuildArgs();

--- a/test/Amazon.Lambda.Tools.Integ.Tests/DeployProjectTests.cs
+++ b/test/Amazon.Lambda.Tools.Integ.Tests/DeployProjectTests.cs
@@ -22,8 +22,10 @@ namespace Amazon.Lambda.Tools.Integ.Tests
         }
 
 
-        [Fact]
-        public async Task TestSimpleImageProjectTest()
+        [Theory]
+        [InlineData("arm64")]
+        [InlineData("x86_64")]
+        public async Task TestSimpleImageProjectTest(string architecture)
         {
             var assembly = this.GetType().GetTypeInfo().Assembly;
 
@@ -39,6 +41,7 @@ namespace Amazon.Lambda.Tools.Integ.Tests
             command.Role = await TestHelper.GetTestRoleArnAsync();
             command.DockerImageTag = $"{TEST_ECR_REPOSITORY}:simpleimageproject1";
             command.DisableInteractive = true;
+            command.Architecture = architecture;
 
             var created = await command.ExecuteAsync();
             try
@@ -66,6 +69,7 @@ namespace Amazon.Lambda.Tools.Integ.Tests
                 updateCommand.DisableInteractive = true;
                 updateCommand.Region = TEST_REGION;
                 updateCommand.DockerImageTag = $"{TEST_ECR_REPOSITORY}:simpleimageproject1";
+                updateCommand.Architecture = architecture;
 
                 var updated = await updateCommand.ExecuteAsync();
                 Assert.True(updated);
@@ -90,6 +94,7 @@ namespace Amazon.Lambda.Tools.Integ.Tests
                 updateCommand.DockerImageTag = $"{TEST_ECR_REPOSITORY}:simpleimageproject1";
                 updateCommand.Region = TEST_REGION;
                 updateCommand.DisableInteractive = true;
+                updateCommand.Architecture = architecture;
 
                 updated = await updateCommand.ExecuteAsync();
                 Assert.True(updated);

--- a/test/Amazon.Lambda.Tools.Integ.Tests/DeployServerlessTests.cs
+++ b/test/Amazon.Lambda.Tools.Integ.Tests/DeployServerlessTests.cs
@@ -25,8 +25,10 @@ namespace Amazon.Lambda.Tools.Integ.Tests
             this._testOutputHelper = testOutputHelper;
         }
 
-        [Fact]
-        public async Task TestImageFunctionServerlessTemplateExamples()
+        [Theory]
+        [InlineData("serverless-resource.template")]
+        [InlineData("serverless-resource-arm.template")]
+        public async Task TestImageFunctionServerlessTemplateExamples(string template)
         {
             var assembly = this.GetType().GetTypeInfo().Assembly;
 
@@ -38,7 +40,7 @@ namespace Amazon.Lambda.Tools.Integ.Tests
             command.Region = TEST_REGION;
             command.DisableInteractive = true;
             command.S3Bucket = this._testFixture.Bucket;
-            command.CloudFormationTemplate = "serverless-resource.template";
+            command.CloudFormationTemplate = template;
             command.CloudFormationOutputTemplate = Path.GetTempFileName();
 
             var created = await command.ExecuteAsync();

--- a/testapps/ImageBasedProjects/TestSimpleImageProject/Dockerfile
+++ b/testapps/ImageBasedProjects/TestSimpleImageProject/Dockerfile
@@ -1,10 +1,10 @@
-FROM public.ecr.aws/lambda/dotnet:6.0
+FROM public.ecr.aws/lambda/dotnet:8
 
 WORKDIR /var/task
 
 # This field should match where the .NET Lambda project built its output at. If this is being built as part of 
 # Amazon.Lambda.Tools this source in the copy command below should match the `--docker-host-build-output-dir` switch.
-COPY "bin/Release/net6.0/linux-x64/publish"  .
+COPY "bin/Release/net8.0/linux-x64/publish"  .
 
 # Defining the entry  point in the Lambda function is optional. If not set then the base image
 # will execute a shell script to determine the parameters for starting the .NET process.

--- a/testapps/ImageBasedProjects/TestSimpleImageProject/TestSimpleImageProject.csproj
+++ b/testapps/ImageBasedProjects/TestSimpleImageProject/TestSimpleImageProject.csproj
@@ -1,12 +1,12 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <AWSProjectType>Lambda</AWSProjectType>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Amazon.Lambda.Core" Version="2.1.0" />
-    <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.2.0" />
+    <PackageReference Include="Amazon.Lambda.Core" Version="2.2.0" />
+    <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.4.1" />
   </ItemGroup>
   
 </Project>

--- a/testapps/ImageBasedProjects/TestSimpleImageProject/aws-lambda-tools-defaults.json
+++ b/testapps/ImageBasedProjects/TestSimpleImageProject/aws-lambda-tools-defaults.json
@@ -12,6 +12,6 @@
   "function-timeout": 30,
   "image-command": "TestSimpleImageProject::TestSimpleImageProject.Function::FunctionHandler",
   "image-tag": "",
-  "docker-host-build-output-dir": "./bin/Release/net6.0/linux-x64/publish",
+  "docker-host-build-output-dir": "./bin/Release/net8.0/linux-x64/publish",
   "configuration": "Release"
 }


### PR DESCRIPTION
*Description of changes:*
If the architecture was specified on the command line for the deploy command or in the CloudFormation template the architecture was not being forwarded to the underlying push image command. This would cause the function to be created as ARM but with an X64 based image and the function would fail to start. If the architecture was specified in the `aws-lambda-defaults.json` file that would get picked up.

 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
