### PR TITLE
Fix incorrectly use JSON Data as the architecture value from CloudFormation template.

### DIFF
--- a/src/Amazon.Lambda.Tools/Amazon.Lambda.Tools.csproj
+++ b/src/Amazon.Lambda.Tools/Amazon.Lambda.Tools.csproj
@@ -15,7 +15,7 @@
     <Copyright>Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.</Copyright>
     <Product>AWS Lambda Tools for .NET CLI</Product>
     <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
-    <Version>5.10.1</Version>
+    <Version>5.10.2</Version>
   </PropertyGroup>
   <ItemGroup>
     <Content Include="Resources\build-lambda-zip.exe">

--- a/src/Amazon.Lambda.Tools/TemplateProcessor/UpdatableResource.cs
+++ b/src/Amazon.Lambda.Tools/TemplateProcessor/UpdatableResource.cs
@@ -64,6 +64,11 @@ namespace Amazon.Lambda.Tools.TemplateProcessor
                 }
                 else if(architectures.Length == 1)
                 {
+                    if (architectures[0] != Architecture.Arm64 && architectures[0] != Architecture.X86_64)
+                    {
+                        return null;
+                    }
+
                     return architectures[0];
                 }
                 else


### PR DESCRIPTION
*Description of changes:*
In the recent PR https://github.com/aws/aws-extensions-for-dotnet-cli/pull/301 we took the architecture specified in the CloudFormation template into the underlying Docker push command. Before this change the image would be created in whatever was the native platform's architecture. That PR doesn't work and throws an error if the CloudFormation is using a `REF` to set the architecture because Amazon.Lambda.Tools doesn't resolve the ref and so we attempt to create the image in an invalid architecture.

This PR is an immediate fix to unblock the Lambda CI and users that happen to work because the native architecture was being picked up. It reverts back to that same behavior where if the architecture coming from the template is unknown, because it is a JSON object, we return back null and allow Docker to use whatever it does by default.

A full fix would involve resolving the REF but that is a bigger change and we need to unblock behavior we broke with the previous PR.

I have tested this PR on both Windows and Mac (ARM) using a REF and got the expected behavior.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
