### PR TITLE
Switch from PRETTY_NAME to NAME and VERSION to identify OS (native AOT)

### DIFF
--- a/src/Amazon.Lambda.Tools/Amazon.Lambda.Tools.csproj
+++ b/src/Amazon.Lambda.Tools/Amazon.Lambda.Tools.csproj
@@ -15,7 +15,7 @@
     <Copyright>Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.</Copyright>
     <Product>AWS Lambda Tools for .NET CLI</Product>
     <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
-    <Version>5.10.2</Version>
+    <Version>5.10.3</Version>
   </PropertyGroup>
   <ItemGroup>
     <Content Include="Resources\build-lambda-zip.exe">

--- a/src/Amazon.Lambda.Tools/LambdaPackager.cs
+++ b/src/Amazon.Lambda.Tools/LambdaPackager.cs
@@ -20,7 +20,7 @@ namespace Amazon.Lambda.Tools
         private const char LinuxLineEnding = '\n';
         private const string BootstrapFilename = "bootstrap";
         private const string LinuxOSReleaseFile = @"/etc/os-release";
-        private const string AmazonLinuxNameInOSReleaseFile = "NAME=\"Amazon Linux\""
+        private const string AmazonLinuxNameInOSReleaseFile = "NAME=\"Amazon Linux\"";
         private const string AmazonLinux2InOSReleaseFile = "VERSION=\"2\"";
         private const string AmazonLinux2023InOSReleaseFile = "VERSION=\"2023\"";
 #if NETCOREAPP3_1_OR_GREATER        

--- a/src/Amazon.Lambda.Tools/LambdaPackager.cs
+++ b/src/Amazon.Lambda.Tools/LambdaPackager.cs
@@ -20,8 +20,9 @@ namespace Amazon.Lambda.Tools
         private const char LinuxLineEnding = '\n';
         private const string BootstrapFilename = "bootstrap";
         private const string LinuxOSReleaseFile = @"/etc/os-release";
-        private const string AmazonLinux2InOSReleaseFile = "PRETTY_NAME=\"Amazon Linux 2\"";
-        private const string AmazonLinux2023InOSReleaseFile = "PRETTY_NAME=\"Amazon Linux 2023\"";
+        private const string AmazonLinuxNameInOSReleaseFile = "NAME=\"Amazon Linux\""
+        private const string AmazonLinux2InOSReleaseFile = "VERSION=\"2\"";
+        private const string AmazonLinux2023InOSReleaseFile = "VERSION=\"2023\"";
 #if NETCOREAPP3_1_OR_GREATER        
         private static readonly string BuildLambdaZipCliPath = Path.Combine(
             Path.GetDirectoryName(new Uri(Assembly.GetExecutingAssembly().Location).LocalPath),
@@ -48,13 +49,13 @@ namespace Amazon.Lambda.Tools
                 {
                     logger?.WriteLine($"Found {LinuxOSReleaseFile}");
                     string readText = File.ReadAllText(LinuxOSReleaseFile);
-                    if (readText.Contains(AmazonLinux2InOSReleaseFile))
+                    if (readText.Contains(AmazonLinuxNameInOSReleaseFile) && readText.Contains(AmazonLinux2InOSReleaseFile))
                     {
                         logger?.WriteLine(
                             $"Linux distribution is Amazon Linux 2, NativeAOT container build is optional");
                         return true;
                     }
-                    if (readText.Contains(AmazonLinux2023InOSReleaseFile))
+                    if (readText.Contains(AmazonLinuxNameInOSReleaseFile) && readText.Contains(AmazonLinux2023InOSReleaseFile))
                     {
                         logger?.WriteLine(
                             $"Linux distribution is Amazon Linux 2023, NativeAOT container build is optional");


### PR DESCRIPTION
*Description of changes:*
It seems that `PRETTY_NAME` in `/etc/os-release` for Amazon Linux 2023 has changed to having minor version information in it now. This causes the build to think you're not on AL2023 when you really are. This is because the old string expected to end in a double quote directly after `2023` but now the full string is `PRETTY_NAME="Amazon Linux 2023.3.20240304"`

It seems like using `NAME` and `VERSION` will be more reliable than `PRETTY_NAME`. 

Below is the output from a newly created AL2 ARM EC2 instance:
```
[ec2-user@ip-172-31-11-224 ~]$ cat /etc/os-release 
NAME="Amazon Linux"
VERSION="2"
ID="amzn"
ID_LIKE="centos rhel fedora"
VERSION_ID="2"
PRETTY_NAME="Amazon Linux 2"
ANSI_COLOR="0;33"
CPE_NAME="cpe:2.3:o:amazon:amazon_linux:2"
HOME_URL="https://amazonlinux.com/"
SUPPORT_END="2025-06-30"
```

Below is the output from a newly created AL2023 ARM EC2 instance:
```
[ec2-user@ip-172-31-13-87 dotnet]$ cat /etc/os-release 
NAME="Amazon Linux"
VERSION="2023"
ID="amzn"
ID_LIKE="fedora"
VERSION_ID="2023"
PLATFORM_ID="platform:al2023"
PRETTY_NAME="Amazon Linux 2023.3.20240304"
ANSI_COLOR="0;33"
CPE_NAME="cpe:2.3:o:amazon:amazon_linux:2023"
HOME_URL="https://aws.amazon.com/linux/amazon-linux-2023/"
DOCUMENTATION_URL="https://docs.aws.amazon.com/linux/"
SUPPORT_URL="https://aws.amazon.com/premiumsupport/"
BUG_REPORT_URL="https://github.com/amazonlinux/amazon-linux-2023"
VENDOR_NAME="AWS"
VENDOR_URL="https://aws.amazon.com/"
SUPPORT_END="2028-03-15"

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
