### PR TITLE
fix: use msbuild to retrieve outputtype

### DIFF
--- a/aws-extensions-for-dotnet-cli.sln
+++ b/aws-extensions-for-dotnet-cli.sln
@@ -63,6 +63,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Amazon.Lambda.Tools.Integ.T
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TestHttpFunction", "testapps\TestHttpFunction\TestHttpFunction.csproj", "{AD31D053-97C5-4262-B187-EC42BFD51A9F}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TestNativeAotNet8WebApp", "testapps\TestNativeAotNet8WebApp\TestNativeAotNet8WebApp.csproj", "{69FFA03C-D29F-40E0-9E7F-572D5E10AF77}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -157,6 +159,10 @@ Global
 		{AD31D053-97C5-4262-B187-EC42BFD51A9F}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{AD31D053-97C5-4262-B187-EC42BFD51A9F}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{AD31D053-97C5-4262-B187-EC42BFD51A9F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{69FFA03C-D29F-40E0-9E7F-572D5E10AF77}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{69FFA03C-D29F-40E0-9E7F-572D5E10AF77}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{69FFA03C-D29F-40E0-9E7F-572D5E10AF77}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{69FFA03C-D29F-40E0-9E7F-572D5E10AF77}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -186,6 +192,7 @@ Global
 		{4FA5B55F-BE55-42F7-A2DE-1924B10296A2} = {7C227173-0F21-44DD-93A7-5D3693240271}
 		{7B2AE176-8AB5-4050-8E22-A2A80E88BB92} = {BB0A8314-3127-4159-8B6A-64F97FEF9474}
 		{AD31D053-97C5-4262-B187-EC42BFD51A9F} = {BB3CF729-8213-4DDD-85AE-A5E7754F3944}
+		{69FFA03C-D29F-40E0-9E7F-572D5E10AF77} = {BB3CF729-8213-4DDD-85AE-A5E7754F3944}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {DBFC70D6-49A2-40A1-AB08-5D9504AB7112}

--- a/src/Amazon.Common.DotNetCli.Tools/ToolsException.cs
+++ b/src/Amazon.Common.DotNetCli.Tools/ToolsException.cs
@@ -45,9 +45,7 @@ namespace Amazon.Common.DotNetCli.Tools
             BucketInDifferentRegionThenClient,
 
             S3GetBucketLocation,
-            S3UploadError,
-            
-            DotnetMsbuildError
+            S3UploadError
 
         }
 

--- a/src/Amazon.Common.DotNetCli.Tools/ToolsException.cs
+++ b/src/Amazon.Common.DotNetCli.Tools/ToolsException.cs
@@ -45,7 +45,9 @@ namespace Amazon.Common.DotNetCli.Tools
             BucketInDifferentRegionThenClient,
 
             S3GetBucketLocation,
-            S3UploadError
+            S3UploadError,
+            
+            DotnetMsbuildError
 
         }
 

--- a/src/Amazon.Common.DotNetCli.Tools/Utilities.cs
+++ b/src/Amazon.Common.DotNetCli.Tools/Utilities.cs
@@ -203,7 +203,7 @@ namespace Amazon.Common.DotNetCli.Tools
         public static string LookupOutputTypeFromProjectFile(string projectLocation)
         {
             var process = new Process();
-            var outputJson = string.Empty;
+            var output = string.Empty;
             var msbuildProcessFailed = false;
             try
             {
@@ -217,7 +217,7 @@ namespace Amazon.Common.DotNetCli.Tools
                 };
 
                 process.Start();
-                outputJson = process.StandardOutput.ReadToEnd();
+                output = process.StandardOutput.ReadToEnd();
                 var hasExited = process.WaitForExit(5000);
 
                 // If it hasn't completed in the specified timeout, stop the process and give up
@@ -244,13 +244,13 @@ namespace Amazon.Common.DotNetCli.Tools
                 var projectFile = FindProjectFileInDirectory(projectLocation);
                 var xdoc = XDocument.Load(projectFile);
                 var element = xdoc.XPathSelectElement("//PropertyGroup/OutputType");
-                outputJson = element?.Value;
+                output = element?.Value;
             }
 
             return 
-                string.IsNullOrEmpty(outputJson) ? 
+                string.IsNullOrEmpty(output) ? 
                     null : 
-                    outputJson.Trim();
+                    output.Trim();
         }
 
         public static bool LookPublishAotFlag(string projectLocation, string msBuildParameters)

--- a/src/Amazon.Common.DotNetCli.Tools/Utilities.cs
+++ b/src/Amazon.Common.DotNetCli.Tools/Utilities.cs
@@ -203,22 +203,21 @@ namespace Amazon.Common.DotNetCli.Tools
         /// <returns>The value of the project property</returns>
         private static string LookupMsbuildProperty(string projectLocation, string propertyName)
         {
+            var process = new Process();
+            string outputJson;
             try
             {
-                var process = new Process()
+                process.StartInfo = new ProcessStartInfo()
                 {
-                    StartInfo = new ProcessStartInfo()
-                    {
-                        FileName = "dotnet",
-                        Arguments = $"msbuild {projectLocation} -getProperty:{propertyName}",
-                        RedirectStandardOutput = true,
-                        UseShellExecute = false,
-                        WindowStyle = ProcessWindowStyle.Hidden
-                    }
+                    FileName = "dotnet",
+                    Arguments = $"msbuild {projectLocation} -getProperty:{propertyName}",
+                    RedirectStandardOutput = true,
+                    UseShellExecute = false,
+                    WindowStyle = ProcessWindowStyle.Hidden
                 };
 
                 process.Start();
-                var outputJson = process.StandardOutput.ReadToEnd();
+                outputJson = process.StandardOutput.ReadToEnd();
                 var hasExited = process.WaitForExit(5000);
 
                 // If it hasn't completed in the specified timeout, stop the process and give up
@@ -227,25 +226,27 @@ namespace Amazon.Common.DotNetCli.Tools
                     process.Kill();
                     return null;
                 }
-
-                // If it has completed but unsuccessfully, give up
-                if (process.ExitCode != 0)
-                {
-                    return null;
-                }
-
-                if (string.IsNullOrEmpty(outputJson))
-                {
-                    return null;
-                }
-
-                return outputJson.Trim();
             }
             catch (Exception)
             {
                 // swallow any exceptions related to `dotnet msbuild`
                 return null;
             }
+
+            // If it has completed but unsuccessfully, give up
+            if (process.ExitCode != 0)
+            {
+                if (outputJson.Contains("MSBUILD : error MSB1001: Unknown switch."))
+                {
+                    throw new ToolsException("Using 'dotnet msbuild -getProperty' is not supported by the installed .NET SDK version.", ToolsException.CommonErrorCode.DotnetMsbuildError);
+                }
+                return null;
+            }
+
+            return 
+                string.IsNullOrEmpty(outputJson) ? 
+                null : 
+                outputJson.Trim();
         }
 
         /// <summary>
@@ -255,7 +256,17 @@ namespace Amazon.Common.DotNetCli.Tools
         /// <returns>The value of the `OutputType` property</returns>
         public static string LookupOutputTypeFromProjectFile(string projectLocation)
         {
-            return LookupMsbuildProperty(projectLocation, "OutputType");
+            try
+            {
+                return LookupMsbuildProperty(projectLocation, "OutputType");
+            }
+            catch (ToolsException)
+            {
+                var projectFile = FindProjectFileInDirectory(projectLocation);
+                var xdoc = XDocument.Load(projectFile);
+                var element = xdoc.XPathSelectElement("//PropertyGroup/OutputType");
+                return element?.Value;
+            }
         }
 
         public static bool LookPublishAotFlag(string projectLocation, string msBuildParameters)

--- a/src/Amazon.Lambda.Tools/Amazon.Lambda.Tools.csproj
+++ b/src/Amazon.Lambda.Tools/Amazon.Lambda.Tools.csproj
@@ -15,7 +15,7 @@
     <Copyright>Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.</Copyright>
     <Product>AWS Lambda Tools for .NET CLI</Product>
     <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
-    <Version>5.10.3</Version>
+    <Version>5.10.4</Version>
   </PropertyGroup>
   <ItemGroup>
     <Content Include="Resources\build-lambda-zip.exe">

--- a/test/Amazon.Lambda.Tools.Test/DeployTest.cs
+++ b/test/Amazon.Lambda.Tools.Test/DeployTest.cs
@@ -186,6 +186,41 @@ namespace Amazon.Lambda.Tools.Test
             }
         }
 
+        [Fact]
+        public async Task NativeAotNet8WebApp()
+        {
+            var logger = new TestToolLogger();
+            var assembly = GetType().GetTypeInfo().Assembly;
+
+            var fullPath = Path.GetFullPath(Path.GetDirectoryName(assembly.Location) + "../../../../../../testapps/TestNativeAotNet8WebApp");
+            var command = new DeployServerlessCommand(logger, fullPath, new string[0]);
+            command.Region = "us-east-1";
+            command.Configuration = "Release";
+            command.CloudFormationTemplate = "serverless.template";
+            command.StackName = "TestDeployServerless-" + DateTime.Now.Ticks;
+            command.S3Bucket = _testFixture.Bucket;
+            command.WaitForStackToComplete = true;
+            command.ProjectLocation = fullPath;
+            command.DisableInteractive = false;
+
+            var created = await command.ExecuteAsync();
+            try
+            {
+                Assert.True(created);
+            }
+            finally
+            {
+                if (created)
+                {
+                    var deleteCommand = new DeleteServerlessCommand(new TestToolLogger(_testOutputHelper), fullPath, new string[0]);
+                    deleteCommand.StackName = command.StackName;
+                    deleteCommand.Region = command.Region;
+                    deleteCommand.DisableInteractive = true;
+                    await deleteCommand.ExecuteAsync();
+                }
+            }
+        }
+
         [Theory]
         [InlineData(TargetFrameworkMonikers.net60)]
         [InlineData(TargetFrameworkMonikers.netcoreapp31)]

--- a/test/Amazon.Lambda.Tools.Test/DeployTest.cs
+++ b/test/Amazon.Lambda.Tools.Test/DeployTest.cs
@@ -186,6 +186,10 @@ namespace Amazon.Lambda.Tools.Test
             }
         }
 
+        /// <summary>
+        /// This test deploys a .NET8 Native AOT Web App that does not explicitly set the OutputType to Exe.
+        /// In .NET8, the web app inherits the OutputType from the SDK.
+        /// </summary>
         [Fact]
         public async Task NativeAotNet8WebApp()
         {

--- a/testapps/TestNativeAotNet8WebApp/LambdaFunction.cs
+++ b/testapps/TestNativeAotNet8WebApp/LambdaFunction.cs
@@ -1,0 +1,13 @@
+using Amazon.Lambda.AspNetCoreServer;
+
+namespace TestNativeAotNet8WebApp;
+
+public class LambdaFunction : APIGatewayProxyFunction
+{
+    protected override void Init(IWebHostBuilder builder)
+    {
+        builder
+            .UseLambdaServer()
+            .UseContentRoot(Directory.GetCurrentDirectory());
+    }
+}

--- a/testapps/TestNativeAotNet8WebApp/Program.cs
+++ b/testapps/TestNativeAotNet8WebApp/Program.cs
@@ -1,0 +1,10 @@
+var builder = WebApplication.CreateSlimBuilder(args);
+
+var app = builder.Build();
+
+app.MapGet("/", async context =>
+{
+    await context.Response.WriteAsync("Welcome to running ASP.NET on AWS Lambda");
+});
+
+app.Run();

--- a/testapps/TestNativeAotNet8WebApp/TestNativeAotNet8WebApp.csproj
+++ b/testapps/TestNativeAotNet8WebApp/TestNativeAotNet8WebApp.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <InvariantGlobalization>true</InvariantGlobalization>
+    <PublishAot>true</PublishAot>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Amazon.Lambda.AspNetCoreServer" Version="9.0.0" />
+  </ItemGroup>
+
+</Project>

--- a/testapps/TestNativeAotNet8WebApp/appsettings.json
+++ b/testapps/TestNativeAotNet8WebApp/appsettings.json
@@ -1,0 +1,9 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "AllowedHosts": "*"
+}

--- a/testapps/TestNativeAotNet8WebApp/serverless.template
+++ b/testapps/TestNativeAotNet8WebApp/serverless.template
@@ -1,0 +1,33 @@
+{
+  "AWSTemplateFormatVersion" : "2010-09-09",
+  "Transform" : "AWS::Serverless-2016-10-31",
+  "Description" : "Starting template for an AWS Serverless Application.",
+  "Parameters" : {
+  },
+  "Resources" : {
+    "DefaultFunction" : {
+      "Type" : "AWS::Serverless::Function",
+      "Properties": {
+        "Handler": "TestNativeAotNet8WebApp::TestNativeAotNet8WebApp.LambdaFunction::FunctionHandlerAsync",
+        "Runtime": "dotnet8",
+        "CodeUri": "",
+        "Description": "Default function",
+        "MemorySize": 512,
+        "Timeout": 30,
+        "Role": null,
+        "Policies": [ "AWSLambda_FullAccess" ],
+        "Events": {
+          "PutResource": {
+            "Type": "Api",
+            "Properties": {
+              "Path": "/{proxy+}",
+              "Method": "ANY"
+            }
+          }
+        }
+      }
+    }
+  },
+  "Outputs" : {
+  }
+}


### PR DESCRIPTION
*Issue #, if available:*
DOTNET-7400

*Description of changes:*
* Use `dotnet msbuild` to determine the value of the `OutputType` property. This fixes an issue where deploying .NET 8 Native AOT Web Apps fails because of a check that looks for the `OutputType` property explicitly in the .csproj. In .NET8, web apps now inherit the `OutputType` property from the SDK.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
