### PR TITLE
Skip NET8 Native AOT test because it's not supported in the pipeline

### DIFF
--- a/test/Amazon.Lambda.Tools.Test/DeployTest.cs
+++ b/test/Amazon.Lambda.Tools.Test/DeployTest.cs
@@ -190,7 +190,7 @@ namespace Amazon.Lambda.Tools.Test
         /// This test deploys a .NET8 Native AOT Web App that does not explicitly set the OutputType to Exe.
         /// In .NET8, the web app inherits the OutputType from the SDK.
         /// </summary>
-        [Fact]
+        [Fact(Skip = "This test requires Docker to be available. We are using a Windows container in the release pipeline which does not support Docker.")]
         public async Task NativeAotNet8WebApp()
         {
             var logger = new TestToolLogger();

--- a/test/Amazon.Lambda.Tools.Test/DeployTest.cs
+++ b/test/Amazon.Lambda.Tools.Test/DeployTest.cs
@@ -190,9 +190,15 @@ namespace Amazon.Lambda.Tools.Test
         /// This test deploys a .NET8 Native AOT Web App that does not explicitly set the OutputType to Exe.
         /// In .NET8, the web app inherits the OutputType from the SDK.
         /// </summary>
-        [Fact(Skip = "This test requires Docker to be available. We are using a Windows container in the release pipeline which does not support Docker.")]
+        [Fact]
         public async Task NativeAotNet8WebApp()
         {
+            if (string.Equals(System.Environment.GetEnvironmentVariable("DOTNET_RUNNING_IN_CONTAINER"), "true", StringComparison.OrdinalIgnoreCase))
+            {
+                _testOutputHelper.WriteLine("Skipping container build test because test is already running inside a container");
+                return;
+            }
+            
             var logger = new TestToolLogger();
             var assembly = GetType().GetTypeInfo().Assembly;
 


### PR DESCRIPTION
*Description of changes:*
After some investigation, the NET8 Native AOT test was failing in the pipeline because it could not find the Docker CLI. This is due to the tests running on a Windows container which does not have Docker available on it.
I have skipped the test, similar to what we have done with others tests.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
