### PR TITLE
ci: onboard the repo on the testing infra

### DIFF
--- a/buildtools/ci.buildspec.yml
+++ b/buildtools/ci.buildspec.yml
@@ -1,0 +1,21 @@
+version: 0.2
+
+env:
+  variables:
+    DOTNET_RUNNING_IN_CONTAINER: "true"
+phases:
+  install:
+    runtime-versions:
+      dotnet: 8.x
+  build:
+    commands:
+      - dotnet test --verbosity normal test/Amazon.Common.DotNetCli.Tools.Test/Amazon.Common.DotNetCli.Tools.Test.csproj --configuration Release --logger trx --results-directory ./testresults
+      - dotnet test --verbosity normal test/Amazon.ECS.Tools.Test/Amazon.ECS.Tools.Test.csproj --configuration Release --logger trx --results-directory ./testresults
+      - dotnet test --verbosity normal test/Amazon.Lambda.Tools.Test/Amazon.Lambda.Tools.Test.csproj --configuration Release --logger trx --results-directory ./testresults
+      - dotnet test --verbosity normal test/Amazon.ElasticBeanstalk.Tools.Test/Amazon.ElasticBeanstalk.Tools.Test.csproj --configuration Release --logger trx --results-directory ./testresults
+reports:
+    aws-dotnet-messaging-tests:
+        file-format: VisualStudioTrx
+        files:
+            - '**/*'
+        base-directory: './testresults'

--- a/test/Amazon.Lambda.Tools.Test/LayerTests.cs
+++ b/test/Amazon.Lambda.Tools.Test/LayerTests.cs
@@ -100,6 +100,13 @@ namespace Amazon.Lambda.Tools.Test
         // mock the underlying calls to the dotnet CLI.
         public async Task AttemptToCreateAnOptmizedLayer()
         {
+            if (string.Equals(System.Environment.GetEnvironmentVariable("DOTNET_RUNNING_IN_CONTAINER"), "true", StringComparison.OrdinalIgnoreCase) &&
+                RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+            {
+                _testOutputHelper.WriteLine("Skipping test as the optimize feature does not work in CI on Linux.");
+                _testOutputHelper.WriteLine("https://github.com/aws/aws-extensions-for-dotnet-cli/issues/208");
+                return;
+            }
             var logger = new TestToolLogger(_testOutputHelper);
             var assembly = this.GetType().GetTypeInfo().Assembly;
 


### PR DESCRIPTION
*Issue #, if available:*
DOTNET-7476

*Description of changes:*
* Disable layer optimization test as it does not run on linux. I have linked the GiHub issue in the test comments.
* Added the buildspec that will be used in the testing infra.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
