### PR TITLE
Added support for new command line parameter --disable-imds-v1 to disable IMDSv1 for Elastic BeanStalk environments.

### DIFF
--- a/src/Amazon.ElasticBeanstalk.Tools/Amazon.ElasticBeanstalk.Tools.csproj
+++ b/src/Amazon.ElasticBeanstalk.Tools/Amazon.ElasticBeanstalk.Tools.csproj
@@ -10,7 +10,7 @@
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>dotnet-eb</ToolCommandName>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Version>4.3.4</Version>
+    <Version>4.4.0</Version>
     <AssemblyName>dotnet-eb</AssemblyName>
     <Authors>Amazon Web Services</Authors>
     <Copyright>Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.</Copyright>

--- a/src/Amazon.ElasticBeanstalk.Tools/Commands/CommandProperties.cs
+++ b/src/Amazon.ElasticBeanstalk.Tools/Commands/CommandProperties.cs
@@ -19,6 +19,7 @@ namespace Amazon.ElasticBeanstalk.Tools.Commands
         public string IISWebSite { get; set; }
         public bool? WaitForUpdate { get; set; }
         public bool? EnableXRay { get; set; }
+        public bool? DisableIMDSv1 { get; set; }
         public Dictionary<string,string> Tags { get; set; }
         public Dictionary<string, string> AdditionalOptions { get; set; }
 
@@ -92,6 +93,8 @@ namespace Amazon.ElasticBeanstalk.Tools.Commands
                 this.LoadBalancerType = tuple.Item2.StringValue;
             if ((tuple = values.FindCommandOption(EBDefinedCommandOptions.ARGUMENT_ENABLE_STICKY_SESSIONS.Switch)) != null)
                 this.EnableStickySessions = tuple.Item2.BoolValue;
+            if ((tuple = values.FindCommandOption(EBDefinedCommandOptions.ARGUMENT_DISABLE_IMDS_V1.Switch)) != null)
+                this.DisableIMDSv1 = tuple.Item2.BoolValue;
 
             if ((tuple = values.FindCommandOption(EBDefinedCommandOptions.ARGUMENT_PROXY_SERVER.Switch)) != null)
                 this.ProxyServer = tuple.Item2.StringValue;
@@ -119,6 +122,7 @@ namespace Amazon.ElasticBeanstalk.Tools.Commands
             data.SetIfNotNull(EBDefinedCommandOptions.ARGUMENT_ENVIRONMENT_TYPE.ConfigFileKey, command.GetStringValueOrDefault(this.EnvironmentType, EBDefinedCommandOptions.ARGUMENT_ENVIRONMENT_TYPE, false));
             data.SetIfNotNull(EBDefinedCommandOptions.ARGUMENT_LOADBALANCER_TYPE.ConfigFileKey, command.GetStringValueOrDefault(this.LoadBalancerType, EBDefinedCommandOptions.ARGUMENT_LOADBALANCER_TYPE, false));
             data.SetIfNotNull(EBDefinedCommandOptions.ARGUMENT_ENABLE_STICKY_SESSIONS.ConfigFileKey, command.GetBoolValueOrDefault(this.EnableStickySessions, EBDefinedCommandOptions.ARGUMENT_ENABLE_STICKY_SESSIONS, false));
+            data.SetIfNotNull(EBDefinedCommandOptions.ARGUMENT_DISABLE_IMDS_V1.ConfigFileKey, command.GetBoolValueOrDefault(this.DisableIMDSv1, EBDefinedCommandOptions.ARGUMENT_DISABLE_IMDS_V1, false));
             data.SetIfNotNull(EBDefinedCommandOptions.ARGUMENT_CNAME_PREFIX.ConfigFileKey, command.GetStringValueOrDefault(this.CNamePrefix, EBDefinedCommandOptions.ARGUMENT_CNAME_PREFIX, false));
             data.SetIfNotNull(EBDefinedCommandOptions.ARGUMENT_INSTANCE_TYPE.ConfigFileKey, command.GetStringValueOrDefault(this.InstanceType, EBDefinedCommandOptions.ARGUMENT_INSTANCE_TYPE, false));
             data.SetIfNotNull(EBDefinedCommandOptions.ARGUMENT_EC2_KEYPAIR.ConfigFileKey, command.GetStringValueOrDefault(this.EC2KeyPair, EBDefinedCommandOptions.ARGUMENT_EC2_KEYPAIR, false));

--- a/src/Amazon.ElasticBeanstalk.Tools/Commands/DeployEnvironmentCommand.cs
+++ b/src/Amazon.ElasticBeanstalk.Tools/Commands/DeployEnvironmentCommand.cs
@@ -40,6 +40,7 @@ namespace Amazon.ElasticBeanstalk.Tools.Commands
             EBDefinedCommandOptions.ARGUMENT_INSTANCE_TYPE,
             EBDefinedCommandOptions.ARGUMENT_HEALTH_CHECK_URL,
             EBDefinedCommandOptions.ARGUMENT_ENABLE_XRAY,
+            EBDefinedCommandOptions.ARGUMENT_DISABLE_IMDS_V1,
             EBDefinedCommandOptions.ARGUMENT_ENHANCED_HEALTH_TYPE,
             EBDefinedCommandOptions.ARGUMENT_INSTANCE_PROFILE,
             EBDefinedCommandOptions.ARGUMENT_SERVICE_ROLE,
@@ -58,6 +59,9 @@ namespace Amazon.ElasticBeanstalk.Tools.Commands
 
         const string OPTIONS_NAME_PROXY_SERVER = "ProxyServer";
         const string OPTIONS_NAME_APPLICATION_PORT = "PORT";
+
+        const string OPTIONS_NAMESPACE_DISABLE_IMDS_V1 = "aws:autoscaling:launchconfiguration";
+        const string OPTIONS_NAME_DISABLE_IMDS_V1 = "DisableIMDSv1";
 
         public string Package { get; set; }
 
@@ -415,7 +419,6 @@ namespace Amazon.ElasticBeanstalk.Tools.Commands
                     Value = loadBalancerType
                 });
             }
-           
 
             AddAdditionalOptions(createRequest.OptionSettings, true, isWindowsEnvironment);
 
@@ -452,6 +455,26 @@ namespace Amazon.ElasticBeanstalk.Tools.Commands
                         Namespace = tokens[0],
                         OptionName = tokens[1],
                         Value = kvp.Value
+                    });
+                }
+            }
+
+            var disableIMDSv1 = this.GetBoolValueOrDefault(this.DeployEnvironmentOptions.DisableIMDSv1, EBDefinedCommandOptions.ARGUMENT_DISABLE_IMDS_V1, false);
+            if (disableIMDSv1.HasValue)
+            {
+                var existingSetting = settings.FirstOrDefault(s => s.Namespace == OPTIONS_NAMESPACE_DISABLE_IMDS_V1 && s.OptionName == OPTIONS_NAME_DISABLE_IMDS_V1);
+
+                if (existingSetting != null)
+                {
+                    existingSetting.Value = disableIMDSv1.Value.ToString(CultureInfo.InvariantCulture).ToLowerInvariant();
+                }
+                else
+                {
+                    settings.Add(new ConfigurationOptionSetting()
+                    {
+                        Namespace = OPTIONS_NAMESPACE_DISABLE_IMDS_V1,
+                        OptionName = OPTIONS_NAME_DISABLE_IMDS_V1,
+                        Value = disableIMDSv1.Value.ToString(CultureInfo.InvariantCulture).ToLowerInvariant()
                     });
                 }
             }

--- a/src/Amazon.ElasticBeanstalk.Tools/EBDefinedCommandOptions.cs
+++ b/src/Amazon.ElasticBeanstalk.Tools/EBDefinedCommandOptions.cs
@@ -205,5 +205,14 @@ namespace Amazon.ElasticBeanstalk.Tools
                 ValueType = CommandOption.CommandOptionValueType.IntValue,
                 Description = $"The application port that will be redirect to port 80. The default is port {EBConstants.DEFAULT_APPLICATION_PORT}."
             };
+
+        public static readonly CommandOption ARGUMENT_DISABLE_IMDS_V1 =
+            new CommandOption
+            {
+                Name = "Disable IMDSv1",
+                Switch = "--disable-imds-v1",
+                ValueType = CommandOption.CommandOptionValueType.BoolValue,
+                Description = "If set to true then the IMDSv1 will be disabled on EC2 instances running the application."
+            };
     }
 }


### PR DESCRIPTION
*Issue #, if available:* #290 (internal issue: DOTNET-7165)

*Description of changes:*
Adds feature to disable `IMDSv1` by default for **new** Elastic BeanStalk environments. Also adds support for new command line parameter `--disable-imds-v1` useful for updating existing environments.

Refer https://docs.aws.amazon.com/elasticbeanstalk/latest/dg/environments-cfg-ec2-imds.html#environments-cfg-ec2-imds.namespace for details on how to disable IMDSv1.

**EDIT:** (Per review comment from @normj) We should not disable IMDSv1 by default for new environments since it could break existing users using legacy Visual Studio tooling. The AWS Toolkit for Visual Studio doesn't have checkbox for the new flag and hence users might not know if IMDSv1 is being disabled by default.

**Testing:**
The changes were tested in personal AWS account (via Visual Studio debugging and observing state in AWS EB console) for below scenarios (executed AWS .NET Extensions CLI command):
- Create new EB environment with `--disable-imds-v1` set to `true`.
- Created EB environment with default settings, which could enable IMDSv1.
  - Re-deployed the EB environment with `--disable-imds-v1` set to `true`. This executed update EB environment scenario and disabled IMDSv1.

After this PR is released we also need to create PR to push CLI extensions changes to AWS Toolkit for Visual Studio repository and thereafter their team could decide to add GUI checkbox for the new setting.
___
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
