### PR TITLE
Fixed an issue where CodeUri set in Globals section is ignored for AWS::Serverless::Function resource.

### DIFF
--- a/src/Amazon.Lambda.Tools/Amazon.Lambda.Tools.csproj
+++ b/src/Amazon.Lambda.Tools/Amazon.Lambda.Tools.csproj
@@ -15,7 +15,7 @@
     <Copyright>Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.</Copyright>
     <Product>AWS Lambda Tools for .NET CLI</Product>
     <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
-    <Version>5.10.6</Version>
+    <Version>5.10.7</Version>
   </PropertyGroup>
   <ItemGroup>
     <Content Include="Resources\build-lambda-zip.exe">

--- a/src/Amazon.Lambda.Tools/TemplateProcessor/UpdatableResourceDefinition.cs
+++ b/src/Amazon.Lambda.Tools/TemplateProcessor/UpdatableResourceDefinition.cs
@@ -121,7 +121,7 @@ namespace Amazon.Lambda.Tools.TemplateProcessor
                         string localPath;
                         var packageType = s.GetValue(LambdaConstants.CF_LAMBDA_PACKAGE_TYPE);
 
-                        if(isServerlessResource)
+                        if (isServerlessResource)
                         {
                             if (string.Equals(PackageType.Image.Value, packageType, StringComparison.OrdinalIgnoreCase))
                             {
@@ -134,6 +134,12 @@ namespace Amazon.Lambda.Tools.TemplateProcessor
                             else
                             {
                                 localPath = s.GetValue(LambdaConstants.CF_LAMBDA_CODEURI);
+
+                                // Get value from Globals section for AWS::Serverless::Function
+                                if (string.IsNullOrEmpty(localPath))
+                                {
+                                    localPath = s.GetValueFromRoot("Globals", "Function", LambdaConstants.CF_LAMBDA_CODEURI);
+                                }
                             }
                         }
                         else


### PR DESCRIPTION
*Issue #, if available:* #119

*Description of changes:*
Fixed an issue where CodeUri set in Globals section is ignored for `AWS::Serverless::Function` resource. Refer [Globals section of the AWS SAM template](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/sam-specification-template-anatomy-globals.html) for details.

**Testing:**
Tested locally using the customer provided sample https://github.com/drch-/dotnet-sam-repro in issue https://github.com/aws/aws-extensions-for-dotnet-cli/issues/119.
Used Visual Studio debugging,
- Setting the current directory for `Amazon.Lambda.Tools` the above repo's local directory.
- Used `deploy-serverless --template ./serverless-global.template.yml` command line argument for using both the templates.

_RESULT:_
- Before making the fix, the `CodeUri` set in `serverless-global.template.yml` in Globals section was not used.
- After making the fix, the `CodeUri` set in `serverless-global.template.yml` in Globals section was used.

Kindly note that during deployment, the updated template is uploaded to S3 bucket. In the uploaded template, `CodeUri` in `Globals` section is not updated. Instead `CodeUri` for function resources is updated. Below is the example:
```YAML
AWSTemplateFormatVersion: "2010-09-09"
Transform: "AWS::Serverless-2016-10-31"
Globals:
  Function:
    Runtime: dotnetcore3.1
    MemorySize: 256
    Timeout: 30
    CodeUri: ./func
Resources:
  UpperFunction:
    Type: AWS::Serverless::Function
    Properties:
      Handler: func::func.Function::UpperHandler
      CodeUri: s3://testbucket-issue1880/UpperFunction-CodeUri-Or-ImageUri-638549218961943105-638549219097951808.zip
  LowerFunction:
    Type: AWS::Serverless::Function
    Properties:
      Handler: func::func.Function::LowerHandler
      CodeUri: s3://testbucket-issue1880/UpperFunction-CodeUri-Or-ImageUri-638549218961943105-638549219097951808.zip
Outputs:
  upperFuncName:
    Value: !Ref UpperFunction
  lowerFuncName:
    Value: !Ref LowerFunction
```
___
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
