### PR TITLE
Fixed an issue where primitive values in payload for InvokeFunctionCommand were not working.

### DIFF
--- a/.autover/changes/8795398d-3505-4b1f-8d8f-eadf6d32d4db.json
+++ b/.autover/changes/8795398d-3505-4b1f-8d8f-eadf6d32d4db.json
@@ -1,0 +1,11 @@
+{
+  "Projects": [
+    {
+      "Name": "Amazon.Lambda.Tools",
+      "Type": "Patch",
+      "ChangelogMessages": [
+        "Fixed an issue where primitive values in payload for InvokeFunctionCommand were not working."
+      ]
+    }
+  ]
+}

--- a/aws-extensions-for-dotnet-cli.sln
+++ b/aws-extensions-for-dotnet-cli.sln
@@ -63,7 +63,9 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Amazon.Lambda.Tools.Integ.T
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TestHttpFunction", "testapps\TestHttpFunction\TestHttpFunction.csproj", "{AD31D053-97C5-4262-B187-EC42BFD51A9F}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TestNativeAotNet8WebApp", "testapps\TestNativeAotNet8WebApp\TestNativeAotNet8WebApp.csproj", "{69FFA03C-D29F-40E0-9E7F-572D5E10AF77}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TestNativeAotNet8WebApp", "testapps\TestNativeAotNet8WebApp\TestNativeAotNet8WebApp.csproj", "{69FFA03C-D29F-40E0-9E7F-572D5E10AF77}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TestIntegerFunction", "testapps\TestIntegerFunction\TestIntegerFunction.csproj", "{D7F1DFA4-066B-469C-B04C-DF032CF152C1}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -163,6 +165,10 @@ Global
 		{69FFA03C-D29F-40E0-9E7F-572D5E10AF77}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{69FFA03C-D29F-40E0-9E7F-572D5E10AF77}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{69FFA03C-D29F-40E0-9E7F-572D5E10AF77}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D7F1DFA4-066B-469C-B04C-DF032CF152C1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D7F1DFA4-066B-469C-B04C-DF032CF152C1}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D7F1DFA4-066B-469C-B04C-DF032CF152C1}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D7F1DFA4-066B-469C-B04C-DF032CF152C1}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -193,6 +199,7 @@ Global
 		{7B2AE176-8AB5-4050-8E22-A2A80E88BB92} = {BB0A8314-3127-4159-8B6A-64F97FEF9474}
 		{AD31D053-97C5-4262-B187-EC42BFD51A9F} = {BB3CF729-8213-4DDD-85AE-A5E7754F3944}
 		{69FFA03C-D29F-40E0-9E7F-572D5E10AF77} = {BB3CF729-8213-4DDD-85AE-A5E7754F3944}
+		{D7F1DFA4-066B-469C-B04C-DF032CF152C1} = {BB3CF729-8213-4DDD-85AE-A5E7754F3944}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {DBFC70D6-49A2-40A1-AB08-5D9504AB7112}

--- a/src/Amazon.Lambda.Tools/Commands/InvokeFunctionCommand.cs
+++ b/src/Amazon.Lambda.Tools/Commands/InvokeFunctionCommand.cs
@@ -62,7 +62,6 @@ namespace Amazon.Lambda.Tools.Commands
 
         protected override async Task<bool> PerformActionAsync()
         {
-
             var invokeRequest = new InvokeRequest
             {
                 FunctionName = this.GetStringValueOrDefault(this.FunctionName, LambdaDefinedCommandOptions.ARGUMENT_FUNCTION_NAME, true),
@@ -81,9 +80,20 @@ namespace Amazon.Lambda.Tools.Commands
                     invokeRequest.Payload = this.Payload.Trim();
                 }
 
-                if(!invokeRequest.Payload.StartsWith("{"))
+                // We should still check for empty payload in case it is read from a file.
+                if (!string.IsNullOrEmpty(invokeRequest.Payload))
                 {
-                    invokeRequest.Payload = "\"" + invokeRequest.Payload + "\"";
+                    if (invokeRequest.Payload[0] != '\"' && invokeRequest.Payload[0] != '{' && invokeRequest.Payload[0] != '[')
+                    {
+                        double d;
+                        long l;
+                        bool b;
+                        if (!double.TryParse(invokeRequest.Payload, out d) && !long.TryParse(invokeRequest.Payload, out l) &&
+                            !bool.TryParse(invokeRequest.Payload, out b))
+                        {
+                            invokeRequest.Payload = "\"" + invokeRequest.Payload + "\"";
+                        }
+                    }
                 }
             }
 

--- a/test/Amazon.Lambda.Tools.Test/Amazon.Lambda.Tools.Test.csproj
+++ b/test/Amazon.Lambda.Tools.Test/Amazon.Lambda.Tools.Test.csproj
@@ -74,6 +74,7 @@
   <ItemGroup>
     <ProjectReference Include="..\..\src\Amazon.Lambda.Tools\Amazon.Lambda.Tools.csproj" />
     <ProjectReference Include="..\..\testapps\TestFunction\TestFunction.csproj" />
+    <ProjectReference Include="..\..\testapps\TestIntegerFunction\TestIntegerFunction.csproj" />
     <ProjectReference Include="..\Amazon.Tools.TestHelpers\Amazon.Tools.TestHelpers.csproj" />
   </ItemGroup>
   <ItemGroup>

--- a/testapps/TestIntegerFunction/Function.cs
+++ b/testapps/TestIntegerFunction/Function.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace TestIntegerFunction
+{
+    
+    public class Function
+    {
+        [Amazon.Lambda.Core.LambdaSerializer(typeof(Amazon.Lambda.Serialization.Json.JsonSerializer))]
+        public string FunctionHandler(int input)
+        {
+            return "Hello " + input;
+        }
+    }
+}

--- a/testapps/TestIntegerFunction/TestIntegerFunction.csproj
+++ b/testapps/TestIntegerFunction/TestIntegerFunction.csproj
@@ -1,0 +1,14 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <AssemblyName>TestIntegerFunction</AssemblyName>
+    <OutputType>Library</OutputType>
+    <PackageId>TestIntegerFunction</PackageId>
+    <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
+    <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
+    <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Amazon.Lambda.Serialization.Json" Version="2.0.0" />
+  </ItemGroup>
+</Project>

--- a/testapps/TestIntegerFunction/aws-lambda-tools-defaults.json
+++ b/testapps/TestIntegerFunction/aws-lambda-tools-defaults.json
@@ -1,0 +1,5 @@
+﻿{
+  "region": "us-east-2",
+  "disable-version-check": true,
+  "function-memory-size": 128
+}


### PR DESCRIPTION
*Issue #, if available:* https://github.com/aws/aws-lambda-dotnet/issues/1197

*Description of changes:*
Fixed an issue where primitive valuesin payload for InvokeFunctionCommand were not working.

We copy .NET Extensions CLI tooling code in AWS Visual Studio Toolkit. VS Toolkit is targeting `.NET Framework` and hence it would not have `System.Text.Json`. So we have ported logic implemented in VS Toolkit, in .NET Extensions for CLI.
 
___
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
