### PR TITLE
fix: fixed an issue causing lambda package to hang in CI/CD

### DIFF
--- a/.autover/changes/e52deae1-471a-4119-b874-5ef0ccf690b3.json
+++ b/.autover/changes/e52deae1-471a-4119-b874-5ef0ccf690b3.json
@@ -1,0 +1,11 @@
+{
+  "Projects": [
+    {
+      "Name": "Amazon.Lambda.Tools",
+      "Type": "Patch",
+      "ChangelogMessages": [
+        "Fixed an issue causing 'lambda package' to hang when ran in CI/CD."
+      ]
+    }
+  ]
+}

--- a/src/Amazon.Lambda.Tools/LambdaDotNetCLIWrapper.cs
+++ b/src/Amazon.Lambda.Tools/LambdaDotNetCLIWrapper.cs
@@ -217,7 +217,7 @@ namespace Amazon.Lambda.Tools
 
                 proc.EnableRaisingEvents = true;
 
-                proc.WaitForExit();
+                proc.WaitForExit(int.MaxValue);
 
                 exitCode = proc.ExitCode;
             }


### PR DESCRIPTION
*Description of changes:*
* Applied a workaround for the hanging `dotnet publish` process which hangs on `Process.WaitForExit()` because of a dotnet tooling bug. There are issues on Microsoft's repos such as this one https://github.com/dotnet/msbuild/issues/2981. The suggested workaround is to add a very large timeout which solves the issue. I have tested it in our pipelines and the tests ran blazingly fast.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
