### PR TITLE
Fixed ApplySettingsTest.SetLoggingPropertiesForUpdateRequest test for Amazon.Lambda.Tools to expect correct type while invoking UpdateFunctionConfigurationAsync().

### DIFF
--- a/test/Amazon.Lambda.Tools.Test/ApplySettingsTest.cs
+++ b/test/Amazon.Lambda.Tools.Test/ApplySettingsTest.cs
@@ -109,7 +109,7 @@ namespace Amazon.Lambda.Tools.Test
                     Assert.Equal("DEBUG", request.LoggingConfig.ApplicationLogLevel);
                     Assert.Equal("WARN", request.LoggingConfig.SystemLogLevel);
                 })
-                .Returns((CreateFunctionRequest r, CancellationToken token) =>
+                .Returns((UpdateFunctionConfigurationRequest r, CancellationToken token) =>
                 {
                     return Task.FromResult(new UpdateFunctionConfigurationResponse());
                 });


### PR DESCRIPTION
Fixed ApplySettingsTest.SetLoggingPropertiesForUpdateRequest test for Amazon.Lambda.Tools to expect correct type while invoking UpdateFunctionConfigurationAsync().