### PR TITLE
Update warning for ARM and AMD architectures on Amazon Linux

### DIFF
--- a/.autover/changes/5ce6e470-afe4-41e4-8945-ea5f9317d53d.json
+++ b/.autover/changes/5ce6e470-afe4-41e4-8945-ea5f9317d53d.json
@@ -1,0 +1,11 @@
+{
+  "Projects": [
+    {
+      "Name": "Amazon.Lambda.Tools",
+      "Type": "Patch",
+      "ChangelogMessages": [
+        "Updated message related to self-contained runtimes with lambda functions"
+      ]
+    }
+  ]
+}

--- a/src/Amazon.Lambda.Tools/LambdaPackager.cs
+++ b/src/Amazon.Lambda.Tools/LambdaPackager.cs
@@ -38,7 +38,7 @@ namespace Amazon.Lambda.Tools
             { "netcoreapp1.1", Version.Parse("1.6.1") }
         };
 
-        public static bool IsAmazonLinux(IToolLogger logger)
+        private static bool IsAmazonLinux(IToolLogger logger)
         {
 #if !NETCOREAPP3_1_OR_GREATER
         return false;
@@ -47,7 +47,7 @@ namespace Amazon.Lambda.Tools
 #endif
         }
 
-        public static bool IsAmazonLinux2(IToolLogger logger)
+        private static bool IsAmazonLinux2(IToolLogger logger)
         {
 #if !NETCOREAPP3_1_OR_GREATER
         return false;
@@ -71,7 +71,7 @@ namespace Amazon.Lambda.Tools
 #endif
         }
 
-        public static bool IsAmazonLinux2023(IToolLogger logger)
+        private static bool IsAmazonLinux2023(IToolLogger logger)
         {
 #if !NETCOREAPP3_1_OR_GREATER
         return false;


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*

In Amazon.Lambda.Tools if you deploy to the `provided.al2023` using ARM64 the tooling displays the following warning.
```
WARNING: There is an issue with self contained ARM based .NET Lambda functions using custom runtimes that causes functions to fail to run. The following GitHub issue has further information and workaround.
https://github.com/aws/aws-lambda-dotnet/issues/920
```

This message and associated GitHub issue is out of date because it talks about `provided.al2`. In `provided.al2` the AMD64 version had a compatible libicu version and the ARM64 was too old. Customers work around this by including libicu in there deployment bundle. Our blueprints do this in the csproj using the following
```
  <ItemGroup>
    <RuntimeHostConfigurationOption Include="System.Globalization.AppLocalIcu" Value="72.1.0.3" />
    <PackageReference Include="Microsoft.ICU.ICU4C.Runtime" Version="72.1.0.3" />
  </ItemGroup>
```

In `provided.al2023` neither architecture have libicu installed but the warning is only coming up for ARM64.

This change does the following:
1. Updated Amazon.Lambda.Tools so that the warning is displayed for either architecture. Also updated the text of the warning to talk about how this affects both architectures.
* Update the linked GitHub issue for AL2023.
* Display the warning for AL2023 and for AL2 on ARM.
* Update https://github.com/aws/aws-lambda-dotnet/issues/920 comment to be more accurate

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
