### PR TITLE
Include user specified MSBuild parameters when evaluating MSBuild properties

### DIFF
--- a/.autover/changes/79b678d7-6533-4e17-ae69-100730e43027.json
+++ b/.autover/changes/79b678d7-6533-4e17-ae69-100730e43027.json
@@ -1,0 +1,11 @@
+{
+  "Projects": [
+    {
+      "Name": "Amazon.Lambda.Tools",
+      "Type": "Patch",
+      "ChangelogMessages": [
+        "Include user specified MSBuild parameters when evaluating MSBuild properties"
+      ]
+    }
+  ]
+}

--- a/src/Amazon.Common.DotNetCli.Tools/Utilities.cs
+++ b/src/Amazon.Common.DotNetCli.Tools/Utilities.cs
@@ -211,7 +211,7 @@ namespace Amazon.Common.DotNetCli.Tools
         /// Looks up specified properties from a project.
         /// </summary>
         /// <param name="projectLocation">The location of the project file.</param>
-        /// <param name="msBuildParameters">Additonal MSBuild paramteres passed by the user from the commandline</param>
+        /// <param name="msBuildParameters">Additional MSBuild parameters passed by the user from the commandline</param>
         /// <param name="propertyNames">The names of the properties to look up.</param>
         /// <returns>A dictionary of property names and their values.</returns>        
         public static Dictionary<string, string> LookupProjectProperties(string projectLocation, string msBuildParameters, params string[] propertyNames)

--- a/src/Amazon.Common.DotNetCli.Tools/Utilities.cs
+++ b/src/Amazon.Common.DotNetCli.Tools/Utilities.cs
@@ -211,9 +211,10 @@ namespace Amazon.Common.DotNetCli.Tools
         /// Looks up specified properties from a project.
         /// </summary>
         /// <param name="projectLocation">The location of the project file.</param>
+        /// <param name="msBuildParameters">Additonal MSBuild paramteres passed by the user from the commandline</param>
         /// <param name="propertyNames">The names of the properties to look up.</param>
         /// <returns>A dictionary of property names and their values.</returns>        
-        public static Dictionary<string, string> LookupProjectProperties(string projectLocation, params string[] propertyNames)
+        public static Dictionary<string, string> LookupProjectProperties(string projectLocation, string msBuildParameters, params string[] propertyNames)
         {
             var projectFile = FindProjectFileInDirectory(projectLocation);
             var properties = new Dictionary<string, string>();
@@ -224,6 +225,11 @@ namespace Amazon.Common.DotNetCli.Tools
                 "-nologo",
                 $"--getProperty:{string.Join(',', propertyNames)}"
             };
+
+            if (!string.IsNullOrEmpty(msBuildParameters))
+            {
+                arguments.Add(msBuildParameters);
+            }
 
             var process = new Process
             {
@@ -302,16 +308,17 @@ namespace Amazon.Common.DotNetCli.Tools
             {
             }
             return properties;
-        }                                   
+        }
 
         /// <summary>
         /// Looks up the target framework from a project file.
         /// </summary>
         /// <param name="projectLocation">The location of the project file.</param>
+        /// <param name="msBuildParameters">Additonal MSBuild paramteres passed by the user from the commandline</param>
         /// <returns>The target framework of the project.</returns>
-        public static string LookupTargetFrameworkFromProjectFile(string projectLocation)
+        public static string LookupTargetFrameworkFromProjectFile(string projectLocation, string msBuildParameters)
         {
-            var properties = LookupProjectProperties(projectLocation, "TargetFramework", "TargetFrameworks");
+            var properties = LookupProjectProperties(projectLocation, msBuildParameters, "TargetFramework", "TargetFrameworks");
             if (properties.TryGetValue("TargetFramework", out var targetFramework) && !string.IsNullOrEmpty(targetFramework))
             {
                 return targetFramework;
@@ -331,10 +338,11 @@ namespace Amazon.Common.DotNetCli.Tools
         /// Retrieve the `OutputType` property of a given project
         /// </summary>
         /// <param name="projectLocation">Path of the project</param>
+        /// <param name="msBuildParameters">Additonal MSBuild paramteres passed by the user from the commandline</param>
         /// <returns>The value of the `OutputType` property</returns>
-        public static string LookupOutputTypeFromProjectFile(string projectLocation)
+        public static string LookupOutputTypeFromProjectFile(string projectLocation, string msBuildParameters)
         {
-            var properties = LookupProjectProperties(projectLocation, "OutputType");
+            var properties = LookupProjectProperties(projectLocation, msBuildParameters, "OutputType");
             return properties.TryGetValue("OutputType", out var outputType) ? outputType.Trim() : null;
         }
 
@@ -353,7 +361,7 @@ namespace Amazon.Common.DotNetCli.Tools
                 }
             }
 
-            var properties = LookupProjectProperties(projectLocation, "PublishAot");
+            var properties = LookupProjectProperties(projectLocation, msBuildParameters, "PublishAot");
             if (properties.TryGetValue("PublishAot", out var publishAot))
             {
                 return bool.TryParse(publishAot, out var result) && result;
@@ -369,7 +377,7 @@ namespace Amazon.Common.DotNetCli.Tools
                 return true;
             }
 
-            var properties = LookupProjectProperties(projectLocation, "SelfContained");
+            var properties = LookupProjectProperties(projectLocation, msBuildParameters, "SelfContained");
             if (properties.TryGetValue("SelfContained", out var selfContained))
             {
                 return bool.TryParse(selfContained, out var isSelfContained) && isSelfContained;

--- a/src/Amazon.ElasticBeanstalk.Tools/Commands/DeployEnvironmentCommand.cs
+++ b/src/Amazon.ElasticBeanstalk.Tools/Commands/DeployEnvironmentCommand.cs
@@ -138,7 +138,7 @@ namespace Amazon.ElasticBeanstalk.Tools.Commands
 
                 if (string.IsNullOrEmpty(targetFramework))
                 {
-                    targetFramework = Utilities.LookupTargetFrameworkFromProjectFile(projectLocation);
+                    targetFramework = Utilities.LookupTargetFrameworkFromProjectFile(projectLocation, null);
                     if (string.IsNullOrEmpty(targetFramework))
                     {
                         targetFramework = this.GetStringValueOrDefault(this.DeployEnvironmentOptions.TargetFramework, CommonDefinedCommandOptions.ARGUMENT_FRAMEWORK, true);

--- a/src/Amazon.ElasticBeanstalk.Tools/Commands/PackageCommand.cs
+++ b/src/Amazon.ElasticBeanstalk.Tools/Commands/PackageCommand.cs
@@ -64,7 +64,7 @@ namespace Amazon.ElasticBeanstalk.Tools.Commands
 
             if (string.IsNullOrEmpty(targetFramework))
             {
-                targetFramework = Utilities.LookupTargetFrameworkFromProjectFile(projectLocation);
+                targetFramework = Utilities.LookupTargetFrameworkFromProjectFile(projectLocation, null);
                 if (string.IsNullOrEmpty(targetFramework))
                 {
                     targetFramework = this.GetStringValueOrDefault(this.DeployEnvironmentOptions.TargetFramework, CommonDefinedCommandOptions.ARGUMENT_FRAMEWORK, true);

--- a/src/Amazon.Lambda.Tools/Commands/DeployFunctionCommand.cs
+++ b/src/Amazon.Lambda.Tools/Commands/DeployFunctionCommand.cs
@@ -227,10 +227,11 @@ namespace Amazon.Lambda.Tools.Commands
                     // Release will be the default configuration if nothing set.
                     string configuration = this.GetStringValueOrDefault(this.Configuration, CommonDefinedCommandOptions.ARGUMENT_CONFIGURATION, false);
 
+                    string msbuildParameters = this.GetStringValueOrDefault(this.MSBuildParameters, CommonDefinedCommandOptions.ARGUMENT_MSBUILD_PARAMETERS, false);
                     var targetFramework = this.GetStringValueOrDefault(this.TargetFramework, CommonDefinedCommandOptions.ARGUMENT_FRAMEWORK, false);
                     if (string.IsNullOrEmpty(targetFramework))
                     {
-                        targetFramework = Utilities.LookupTargetFrameworkFromProjectFile(projectLocation);
+                        targetFramework = Utilities.LookupTargetFrameworkFromProjectFile(projectLocation, msbuildParameters);
 
                         // If we still don't know what the target framework is ask the user what targetframework to use.
                         // This is common when a project is using multi targeting.
@@ -239,7 +240,6 @@ namespace Amazon.Lambda.Tools.Commands
                             targetFramework = this.GetStringValueOrDefault(this.TargetFramework, CommonDefinedCommandOptions.ARGUMENT_FRAMEWORK, true);
                         }
                     }
-                    string msbuildParameters = this.GetStringValueOrDefault(this.MSBuildParameters, CommonDefinedCommandOptions.ARGUMENT_MSBUILD_PARAMETERS, false);
 
                     bool isNativeAot = Utilities.LookPublishAotFlag(projectLocation, this.MSBuildParameters);
 

--- a/src/Amazon.Lambda.Tools/Commands/PackageCommand.cs
+++ b/src/Amazon.Lambda.Tools/Commands/PackageCommand.cs
@@ -206,10 +206,11 @@ namespace Amazon.Lambda.Tools.Commands
                 // Release will be the default configuration if nothing set.
                 var configuration = this.GetStringValueOrDefault(this.Configuration, CommonDefinedCommandOptions.ARGUMENT_CONFIGURATION, false);
 
+                var msbuildParameters = this.GetStringValueOrDefault(this.MSBuildParameters, CommonDefinedCommandOptions.ARGUMENT_MSBUILD_PARAMETERS, false);
                 var targetFramework = this.GetStringValueOrDefault(this.TargetFramework, CommonDefinedCommandOptions.ARGUMENT_FRAMEWORK, false);
                 if (string.IsNullOrEmpty(targetFramework))
                 {
-                    targetFramework = Utilities.LookupTargetFrameworkFromProjectFile(projectLocation);
+                    targetFramework = Utilities.LookupTargetFrameworkFromProjectFile(projectLocation, msbuildParameters);
 
                     // If we still don't know what the target framework is ask the user what targetframework to use.
                     // This is common when a project is using multi targeting.
@@ -221,7 +222,6 @@ namespace Amazon.Lambda.Tools.Commands
 
                 bool isNativeAot = Utilities.LookPublishAotFlag(projectLocation, this.MSBuildParameters);
 
-                var msbuildParameters = this.GetStringValueOrDefault(this.MSBuildParameters, CommonDefinedCommandOptions.ARGUMENT_MSBUILD_PARAMETERS, false);
                 var architecture = this.GetStringValueOrDefault(this.Architecture, LambdaDefinedCommandOptions.ARGUMENT_FUNCTION_ARCHITECTURE, false);
                 var disableVersionCheck = this.GetBoolValueOrDefault(this.DisableVersionCheck, LambdaDefinedCommandOptions.ARGUMENT_DISABLE_VERSION_CHECK, false).GetValueOrDefault();
 

--- a/src/Amazon.Lambda.Tools/LambdaPackager.cs
+++ b/src/Amazon.Lambda.Tools/LambdaPackager.cs
@@ -114,7 +114,7 @@ namespace Amazon.Lambda.Tools
             bool? useContainerForBuild, string containerImageForBuild, string codeMountDirectory,
             out string publishLocation, ref string zipArchivePath)
         {
-            LambdaUtilities.ValidateTargetFramework(projectLocation, targetFramework, isNativeAot);
+            LambdaUtilities.ValidateTargetFramework(projectLocation, msbuildParameters, targetFramework, isNativeAot);
 
             LambdaUtilities.ValidateNativeAotArchitecture(architecture, isNativeAot);
 

--- a/src/Amazon.Lambda.Tools/LambdaUtilities.cs
+++ b/src/Amazon.Lambda.Tools/LambdaUtilities.cs
@@ -64,13 +64,13 @@ namespace Amazon.Lambda.Tools
             {Amazon.Lambda.Runtime.Dotnetcore10.Value, TargetFrameworkMonikers.netcoreapp10}
         };
 
-        public static string DetermineTargetFrameworkFromLambdaRuntime(string lambdaRuntime, string projectLocation)
+        public static string DetermineTargetFrameworkFromLambdaRuntime(string lambdaRuntime, string projectLocation, string msbuildParameters)
         {
             string framework;
             if (_lambdaRuntimeToDotnetFramework.TryGetValue(lambdaRuntime, out framework))
                 return framework;
 
-            framework = Utilities.LookupTargetFrameworkFromProjectFile(projectLocation);
+            framework = Utilities.LookupTargetFrameworkFromProjectFile(projectLocation, msbuildParameters);
             return framework;
         }
 
@@ -83,9 +83,9 @@ namespace Amazon.Lambda.Tools
             return kvp.Key;
         }
 
-        public static void ValidateTargetFramework(string projectLocation, string targetFramework, bool isNativeAot)
+        public static void ValidateTargetFramework(string projectLocation, string msbuildParameters, string targetFramework, bool isNativeAot)
         {
-            var outputType = Utilities.LookupOutputTypeFromProjectFile(projectLocation);
+            var outputType = Utilities.LookupOutputTypeFromProjectFile(projectLocation, msbuildParameters);
             var ouputTypeIsExe = outputType != null && outputType.ToLower().Equals("exe");
 
             if (isNativeAot && !ouputTypeIsExe)

--- a/src/Amazon.Lambda.Tools/TemplateProcessor/TemplateProcessorManager.cs
+++ b/src/Amazon.Lambda.Tools/TemplateProcessor/TemplateProcessorManager.cs
@@ -251,7 +251,7 @@ namespace Amazon.Lambda.Tools.TemplateProcessor
                 var outputPackage = GenerateOutputZipFilename(field);
                 command.OutputPackageFileName = outputPackage;
                 command.TargetFramework =
-                    LambdaUtilities.DetermineTargetFrameworkFromLambdaRuntime(field.Resource.LambdaRuntime, location);
+                    LambdaUtilities.DetermineTargetFrameworkFromLambdaRuntime(field.Resource.LambdaRuntime, location, null);
 
                 command.Architecture = field.Resource.LambdaArchitecture;
                 command.LayerVersionArns = field.Resource.LambdaLayers;

--- a/test/Amazon.Common.DotNetCli.Tools.Test/UtilitiesTests.cs
+++ b/test/Amazon.Common.DotNetCli.Tools.Test/UtilitiesTests.cs
@@ -105,6 +105,8 @@ namespace Amazon.Common.DotNetCli.Tools.Test
         [InlineData("TargetFramework", "", "net6.0")]
         [InlineData("TargetFramework", "/p:NonExistence=net20.0", "net6.0")]
         [InlineData("TargetFramework", "/p:TargetFramework=net20.0", "net20.0")]
+        [InlineData("TargetFramework", "/p:TargetFramework=net20.0 /p:OutputType=FutureDevice", "net20.0")]
+        [InlineData("OutputType", "/p:TargetFramework=net20.0 /p:OutputType=FutureDevice", "FutureDevice")]
         public void TestPropertyEvaluationWithMSBuildParameters(string property, string msbuildparameters, string expectedValue)
         {
             var projectLocation = "../../../../../testapps/TestFunction";

--- a/test/Amazon.Common.DotNetCli.Tools.Test/UtilitiesTests.cs
+++ b/test/Amazon.Common.DotNetCli.Tools.Test/UtilitiesTests.cs
@@ -18,7 +18,7 @@ namespace Amazon.Common.DotNetCli.Tools.Test
         {
             var assembly = this.GetType().GetTypeInfo().Assembly;
             var fullPath = Path.GetFullPath(Path.GetDirectoryName(assembly.Location) + projectPath);
-            var determinedFramework = Utilities.LookupTargetFrameworkFromProjectFile(projectPath);
+            var determinedFramework = Utilities.LookupTargetFrameworkFromProjectFile(projectPath, null);
             Assert.Equal(expectedFramework, determinedFramework);
         }
 
@@ -80,7 +80,7 @@ namespace Amazon.Common.DotNetCli.Tools.Test
         [InlineData("../../../../../testapps/TestNativeAotSingleProject", "Exe")]
         public void TestLookupOutputTypeFromProjectFile(string projectLocation, string expected)
         {
-            var result = Utilities.LookupOutputTypeFromProjectFile(projectLocation);
+            var result = Utilities.LookupOutputTypeFromProjectFile(projectLocation, null);
 
             Assert.Equal(expected, result);
         }
@@ -99,6 +99,18 @@ namespace Amazon.Common.DotNetCli.Tools.Test
             var result = Utilities.HasExplicitSelfContainedFlag(projectLocation, msBuildParameters);
 
             Assert.Equal(expected, result);
+        }
+
+        [Theory]
+        [InlineData("TargetFramework", "", "net6.0")]
+        [InlineData("TargetFramework", "/p:NonExistence=net20.0", "net6.0")]
+        [InlineData("TargetFramework", "/p:TargetFramework=net20.0", "net20.0")]
+        public void TestPropertyEvaluationWithMSBuildParameters(string property, string msbuildparameters, string expectedValue)
+        {
+            var projectLocation = "../../../../../testapps/TestFunction";
+
+            var value = Utilities.LookupProjectProperties(projectLocation, msbuildparameters, property)[property];
+            Assert.Equal(expectedValue, value);
         }
     }
 }

--- a/test/Amazon.Lambda.Tools.Test/UtilitiesTests.cs
+++ b/test/Amazon.Lambda.Tools.Test/UtilitiesTests.cs
@@ -216,12 +216,12 @@ namespace Amazon.Lambda.Tools.Test
         {
             if (shouldThrow)
             {
-                Assert.Throws<LambdaToolsException>(() => LambdaUtilities.ValidateTargetFramework(projectLocation, targetFramework, isNativeAot));
+                Assert.Throws<LambdaToolsException>(() => LambdaUtilities.ValidateTargetFramework(projectLocation, null, targetFramework, isNativeAot));
             }
             else
             {
                 // If this throws an exception, the test will fail, hench no assert is necessary
-                LambdaUtilities.ValidateTargetFramework(projectLocation, targetFramework, isNativeAot);
+                LambdaUtilities.ValidateTargetFramework(projectLocation, null, targetFramework, isNativeAot);
             }
         }
 


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/aws-extensions-for-dotnet-cli/issues/351

*Description of changes:*
In the recent release of Amazon.Lambda.Tools we switched to using `dotnet msbuild getproperty` command to evaluate MSBuild properties like `PublishAot`. It is possible for users to specify additional MSBuild parameters via the `--msbuild-parameters` switch that might affect the evaluation. That is the case of the linked issue.

This PR pass along the user specified value for `--msbuild-parameters` to the `dotnet msbuild getproperty` command so the evaluation has the full context for evaluation.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
