### PR TITLE
Fix MSBuild property evaluation

### DIFF
--- a/src/Amazon.Lambda.Tools/Commands/PackageCommand.cs
+++ b/src/Amazon.Lambda.Tools/Commands/PackageCommand.cs
@@ -220,7 +220,7 @@ namespace Amazon.Lambda.Tools.Commands
                     }
                 }
 
-                bool isNativeAot = Utilities.LookPublishAotFlag(projectLocation, this.MSBuildParameters);
+                bool isNativeAot = Utilities.LookPublishAotFlag(projectLocation, msbuildParameters);
 
                 var architecture = this.GetStringValueOrDefault(this.Architecture, LambdaDefinedCommandOptions.ARGUMENT_FUNCTION_ARCHITECTURE, false);
                 var disableVersionCheck = this.GetBoolValueOrDefault(this.DisableVersionCheck, LambdaDefinedCommandOptions.ARGUMENT_DISABLE_VERSION_CHECK, false).GetValueOrDefault();


### PR DESCRIPTION
Fix MSBuild parameters specified in `aws-lambda-tools-defaults.json` not being used with `Utilities.LookPublishAotFlag()`.

Taking a look at #352 I wasn't sure where to put any test that might have caught this - I'm happy to add a test for this if you can point me in the right direction.

I did test this manually against my project in Visual Studio under the debugger and it works as intended now.

Resolves #351.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
