### PR TITLE
Added logic to handle extraneous double-quotes around value for --msbuild-parameters that could be passed in .NET argument for certain execution environments.

### DIFF
--- a/.autover/changes/fd1edd27-5324-4679-b0af-e2530bcc918f.json
+++ b/.autover/changes/fd1edd27-5324-4679-b0af-e2530bcc918f.json
@@ -1,0 +1,11 @@
+{
+  "Projects": [
+    {
+      "Name": "Amazon.Lambda.Tools",
+      "Type": "Patch",
+      "ChangelogMessages": [
+        "Added logic to handle extraneous double-quotes around value for --msbuild-parameters that could be passed in .NET argument for certain execution environments."
+      ]
+    }
+  ]
+}

--- a/src/Amazon.Common.DotNetCli.Tools/Options/CommandLineParser.cs
+++ b/src/Amazon.Common.DotNetCli.Tools/Options/CommandLineParser.cs
@@ -60,6 +60,14 @@ namespace Amazon.Common.DotNetCli.Tools.Options
                                     value.BoolValue = bv;
                                     break;
                             }
+
+                            // --msbuild-parameters is a special case where multiple parameters separated by space character are enclosed in double quotes. In certain environments (like JavaScript action runner), the leading and trailing double quotes characters are also passed to .NET command arguments.
+                            if (option == CommonDefinedCommandOptions.ARGUMENT_MSBUILD_PARAMETERS && !string.IsNullOrEmpty(value.StringValue) 
+                                && (value.StringValue.Trim().StartsWith('\"') && value.StringValue.Trim().EndsWith('\"')))
+                            {
+                                value.StringValue = value.StringValue.Trim().Trim('\"');
+                            }
+
                             i++;
                         }
 

--- a/test/Amazon.Lambda.Tools.Test/CommandLineParserTest.cs
+++ b/test/Amazon.Lambda.Tools.Test/CommandLineParserTest.cs
@@ -93,5 +93,18 @@ namespace Amazon.Lambda.Tools.Test
             Assert.Equal(55, command.Timeout);
             Assert.Equal("netcore9.9", command.Runtime);
         }
+
+        [Fact]
+        public void BuildLambdaDeployCommandWithMSBuildParamAndSwitchDoubleQuotedValue()
+        {
+            var arguments = new List<string>();
+            arguments.AddRange(new string[] { "--region", "us-west-2" });
+            arguments.AddRange(new string[] { "--msbuild-parameters", "\"--no-restore --no-build\"" });
+            arguments.Add("/p:Foo=bar;Version=1.2.3");
+
+            var command = new DeployFunctionCommand(new ConsoleToolLogger(), ".", arguments.ToArray());
+            Assert.Equal("us-west-2", command.Region);
+            Assert.Equal("--no-restore --no-build /p:Foo=bar;Version=1.2.3", command.MSBuildParameters);
+        }
     }
 }

--- a/test/Amazon.Lambda.Tools.Test/OptionParseTests.cs
+++ b/test/Amazon.Lambda.Tools.Test/OptionParseTests.cs
@@ -81,5 +81,39 @@ namespace Amazon.Lambda.Tools.Test
             Assert.NotNull(param);
             Assert.Equal("us-west-2", param.Item2.StringValue);
         }
+
+        [Fact]
+        public void ParseMSBuildSwitchDoubleQuotedValue()
+        {
+            var values = CommandLineParser.ParseArguments(DeployFunctionCommand.DeployCommandOptions,
+                new[] { "myfunc", "--region", "us-west-2", "--msbuild-parameters", "\"--no-restore --no-build\"" });
+
+            Assert.Equal("myfunc", values.Arguments[0]);
+
+            var msbuildparametersParam = values.FindCommandOption("--msbuild-parameters");
+            Assert.NotNull(msbuildparametersParam);
+            Assert.Equal("--no-restore --no-build", msbuildparametersParam.Item2.StringValue);
+
+            var param = values.FindCommandOption("--region");
+            Assert.NotNull(param);
+            Assert.Equal("us-west-2", param.Item2.StringValue);
+        }
+
+        [Fact]
+        public void ParseMSBuildSwitchNotDoubleQuotedValue()
+        {
+            var values = CommandLineParser.ParseArguments(DeployFunctionCommand.DeployCommandOptions,
+                new[] { "myfunc", "--region", "us-west-2", "--msbuild-parameters", "--no-restore --no-build" });
+
+            Assert.Equal("myfunc", values.Arguments[0]);
+
+            var msbuildparametersParam = values.FindCommandOption("--msbuild-parameters");
+            Assert.NotNull(msbuildparametersParam);
+            Assert.Equal("--no-restore --no-build", msbuildparametersParam.Item2.StringValue);
+
+            var param = values.FindCommandOption("--region");
+            Assert.NotNull(param);
+            Assert.Equal("us-west-2", param.Item2.StringValue);
+        }
     }
 }


### PR DESCRIPTION
*Issue #, if available:* #358

*Description of changes:*
Added logic to handle extraneous double-quotes around value for `--msbuild-parameters` that could be passed in .NET argument for certain execution environments.

Customer is invoking `dotnet lambda` tooling via JavaScript running using `exec.exec()` from `actions/github-script@v6` package in a GitHub action. For this environment, somehow value for `--msbuild-parameters` enclosed in double quotes has leading and trailing double quotes. Did below testing as well:
- Removed use of double quotes all together, it only takes first value for `--msbuild-parameters`, ignoring other values if any.
- Tried enclosing value in single quotes `'`, it tries to parse only first value beginning with single quote (e.g. `'----no-restore`).

**NOTE(s):**
- [CommandOptions](https://github.com/aws/aws-extensions-for-dotnet-cli/blob/fa1385e31a89ace8f8bf819ac5892953464e2592/src/Amazon.Common.DotNetCli.Tools/Options/CommandOptions.cs#L12) also has separate property named `MSBuildParameters` used for storing parameters that start with `/p:` based on logic [here](https://github.com/aws/aws-extensions-for-dotnet-cli/blob/fa1385e31a89ace8f8bf819ac5892953464e2592/src/Amazon.Common.DotNetCli.Tools/Options/CommandLineParser.cs#L70).
  - These MS Build parameters are appended to existing values that might have been supplied using `--msbuild-parameters` switch (e.g., refer code [here](https://github.com/aws/aws-extensions-for-dotnet-cli/blob/fa1385e31a89ace8f8bf819ac5892953464e2592/src/Amazon.Lambda.Tools/Commands/PackageCommand.cs#L112)).
  - Hence, we would need to process trimming of enclosing double quotes `"` before we append `CommandOptions.MSBuildParameters`.
  - Values for consolidated MSBuild parameters are also used at different places while determining project information, e.g. TargetFramework using [Utilitites.LookupTargetFrameworkFromProjectFile()](https://github.com/aws/aws-extensions-for-dotnet-cli/blob/fa1385e31a89ace8f8bf819ac5892953464e2592/src/Amazon.Common.DotNetCli.Tools/Utilities.cs#L319), where it uses [Utilities.LookupProjectProperties()](https://github.com/aws/aws-extensions-for-dotnet-cli/blob/fa1385e31a89ace8f8bf819ac5892953464e2592/src/Amazon.Common.DotNetCli.Tools/Utilities.cs#L217) and invokes `msbuild` command in a separate `Process`. This command would always fail if we don't handle this issue (assuming compatible parameter for `msbuild` command is used. We do have a fallback mechanism to inspect `.csproj` project file though.
- We **should only** handle enclosing double-quote scenario only if `--msbuild-parameters` value start and end with a double-quote. 
- `--msbuild-parameters` is currently only supported by `Amazon.Lambda.Tools`.
  - Based on discussion with @normj, we could only version bump `Amazon.Lambda.Tools`.
___
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
