### PR TITLE
Fixed an ElasticBeanstalk deployment issue for Linux platform where Procfile was sometimes being generated with incorrect entrypoint when multiple runtimeconfig.json files were present.

### DIFF
--- a/.autover/changes/a4b5c0a2-7029-491b-90d1-12bba898c249.json
+++ b/.autover/changes/a4b5c0a2-7029-491b-90d1-12bba898c249.json
@@ -1,0 +1,11 @@
+{
+  "Projects": [
+    {
+      "Name": "Amazon.ElasticBeanstalk.Tools",
+      "Type": "Patch",
+      "ChangelogMessages": [
+        "Fixed an ElasticBeanstalk deployment issue for Linux platform where Procfile was sometimes being generated with incorrect entrypoint when multiple runtimeconfig.json files were present."
+      ]
+    }
+  ]
+}

--- a/src/Amazon.Common.DotNetCli.Tools/Utilities.cs
+++ b/src/Amazon.Common.DotNetCli.Tools/Utilities.cs
@@ -338,7 +338,7 @@ namespace Amazon.Common.DotNetCli.Tools
         /// Looks up the assembly name from a project file.
         /// </summary>
         /// <param name="projectLocation">The location of the project file.</param>
-        /// <param name="msBuildParameters">Additonal MSBuild paramteres passed by the user from the commandline</param>
+        /// <param name="msBuildParameters">Additional MSBuild parameters passed by the user from the commandline</param>
         /// <returns>The assembly name of the project.</returns>
         public static string LookupAssemblyNameFromProjectFile(string projectLocation, string msBuildParameters)
         {

--- a/src/Amazon.Common.DotNetCli.Tools/Utilities.cs
+++ b/src/Amazon.Common.DotNetCli.Tools/Utilities.cs
@@ -335,6 +335,18 @@ namespace Amazon.Common.DotNetCli.Tools
         }
 
         /// <summary>
+        /// Looks up the assembly name from a project file.
+        /// </summary>
+        /// <param name="projectLocation">The location of the project file.</param>
+        /// <param name="msBuildParameters">Additonal MSBuild paramteres passed by the user from the commandline</param>
+        /// <returns>The assembly name of the project.</returns>
+        public static string LookupAssemblyNameFromProjectFile(string projectLocation, string msBuildParameters)
+        {
+            var properties = LookupProjectProperties(projectLocation, msBuildParameters, "AssemblyName");
+            return properties.TryGetValue("AssemblyName", out var assemblyName) ? assemblyName : null;
+        }
+
+        /// <summary>
         /// Retrieve the `OutputType` property of a given project
         /// </summary>
         /// <param name="projectLocation">Path of the project</param>

--- a/src/Amazon.ElasticBeanstalk.Tools/Commands/DeployEnvironmentCommand.cs
+++ b/src/Amazon.ElasticBeanstalk.Tools/Commands/DeployEnvironmentCommand.cs
@@ -183,7 +183,7 @@ namespace Amazon.ElasticBeanstalk.Tools.Commands
                     }
 
                     this.Logger?.WriteLine("Configuring application bundle for a Linux deployment");
-                    EBUtilities.SetupPackageForLinux(this.Logger, this, this.DeployEnvironmentOptions, publishLocation, proxyServer, applicationPort);
+                    EBUtilities.SetupPackageForLinux(this.Logger, this, this.DeployEnvironmentOptions, publishLocation, proxyServer, applicationPort, projectLocation);
                 }
 
                 zipArchivePath = Path.Combine(Directory.GetParent(publishLocation).FullName, new DirectoryInfo(projectLocation).Name + "-" + DateTime.Now.Ticks + ".zip");


### PR DESCRIPTION
*Issue #, if available:* #285

*Description of changes:*
Fixed an ElasticBeanstalk deployment issue for Linux platform where `Procfile` was sometimes being generated with incorrect entrypoint when multiple `runtimeconfig.json` files were present.

The existing logic to determine the project file `.csproj` uses [Utilitites.FindProjectFileInDirectory()](https://github.com/aws/aws-extensions-for-dotnet-cli/blob/b2735be679eeea008d709fc7a57d2fabde66085a/src/Amazon.Common.DotNetCli.Tools/Utilities.cs#L389). It has explicit check [here](https://github.com/aws/aws-extensions-for-dotnet-cli/blob/b2735be679eeea008d709fc7a57d2fabde66085a/src/Amazon.Common.DotNetCli.Tools/Utilities.cs#L397) to ensure that we get only **one** project file; else it returns `null`. So in case there are multiple project files, it would probably throw `NullReferenceException` in subsequent logic. We are using this assumption that we only have one project file for deployment at root of working directory, to get the assembly name (via `msbuild`).

Also note that we also invoke [BaseCommand.EnsureInProjectDirectory()](https://github.com/aws/aws-extensions-for-dotnet-cli/blob/b2735be679eeea008d709fc7a57d2fabde66085a/src/Amazon.Common.DotNetCli.Tools/Commands/BaseCommand.cs#L890). This throws generic exception `$"No .NET project found in directory {projectLocation} to build."` in case where more than one project file if found in working directory, **which might be incorrect or misleading**.

**NOTE:**
Refer [Using a Procfile to configure your .NET Core on Linux Elastic Beanstalk environment](https://docs.aws.amazon.com/elasticbeanstalk/latest/dg/dotnet-linux-procfile.html) where it shows below example to configure 2 web applications.
```
web: dotnet ./dotnet-core-app1/dotnetcoreapp1.dll
web2: dotnet ./dotnet-core-app2/dotnetcoreapp2.dll
```
The PR supports one web application as of now to conform to existing logic.
CC @normj 
___
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
