### PR TITLE
chore: Update GitHub Action tags to commit hashes

### DIFF
--- a/.github/workflows/change-file-in-pr.yml
+++ b/.github/workflows/change-file-in-pr.yml
@@ -1,30 +1,29 @@
-name: Change File Included in PR
-
-on:
+"on":
   pull_request:
-    types: [opened, synchronize, reopened, labeled]
-
+    types:
+    - opened
+    - synchronize
+    - reopened
+    - labeled
+name: Change File Included in PR
 jobs:
   check-files-in-directory:
     if: ${{ !contains(github.event.pull_request.labels.*.name, 'Release Not Needed') && !contains(github.event.pull_request.labels.*.name, 'Release PR') }}
-    name: Change File Included in PR
     runs-on: ubuntu-latest
-
+    name: Change File Included in PR
     steps:
-      - name: Checkout PR code
-        uses: actions/checkout@v3
-
-      - name: Get List of Changed Files
-        id: changed-files
-        uses: tj-actions/changed-files@4edd678ac3f81e2dc578756871e4d00c19191daf #v45
-
-      - name: Check for Change File(s) in .autover/changes/
-        run: |
-          DIRECTORY=".autover/changes/"
-          if echo "${{ steps.changed-files.outputs.all_changed_files }}" | grep -q "$DIRECTORY"; then
-            echo "✅ One or more change files in '$DIRECTORY' are included in this PR."
-          else
-            echo "❌ No change files in '$DIRECTORY' are included in this PR."
-            echo "Refer to the 'Adding a change file to your contribution branch' section of https://github.com/aws/aws-extensions-for-dotnet-cli/blob/master/CONTRIBUTING.md"
-            exit 1
-          fi
+    - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744
+      name: Checkout PR code
+    - uses: tj-actions/changed-files@4edd678ac3f81e2dc578756871e4d00c19191daf
+      id: changed-files
+      name: Get List of Changed Files
+    - run: |
+        DIRECTORY=".autover/changes/"
+        if echo "${{ steps.changed-files.outputs.all_changed_files }}" | grep -q "$DIRECTORY"; then
+          echo "✅ One or more change files in '$DIRECTORY' are included in this PR."
+        else
+          echo "❌ No change files in '$DIRECTORY' are included in this PR."
+          echo "Refer to the 'Adding a change file to your contribution branch' section of https://github.com/aws/aws-extensions-for-dotnet-cli/blob/master/CONTRIBUTING.md"
+          exit 1
+        fi
+      name: Check for Change File(s) in .autover/changes/

--- a/.github/workflows/issue-regression-labeler.yml
+++ b/.github/workflows/issue-regression-labeler.yml
@@ -1,32 +1,33 @@
-# Apply potential regression label on issues
-name: issue-regression-label
-on:
+"on":
   issues:
-    types: [opened, edited]
+    types:
+    - opened
+    - edited
+name: issue-regression-label
 jobs:
   add-regression-label:
-    runs-on: ubuntu-latest
     permissions:
       issues: write
+    runs-on: ubuntu-latest
     steps:
-    - name: Fetch template body
-      id: check_regression
-      uses: actions/github-script@v7
-      env: 
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        TEMPLATE_BODY: ${{ github.event.issue.body }}
+    - id: check_regression
+      uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea
       with:
         script: |
           const regressionPattern = /\[x\] Select this option if this issue appears to be a regression\./i;
           const template = `${process.env.TEMPLATE_BODY}`
           const match = regressionPattern.test(template);
           core.setOutput('is_regression', match);
-    - name: Manage regression label
+      name: Fetch template body
       env:
+        TEMPLATE_BODY: ${{ github.event.issue.body }}
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      run: |
+    - run: |
         if [ "${{ steps.check_regression.outputs.is_regression }}" == "true" ]; then
           gh issue edit ${{ github.event.issue.number }} --add-label "potential-regression" -R ${{ github.repository }}
         else
           gh issue edit ${{ github.event.issue.number }} --remove-label "potential-regression" -R ${{ github.repository }}
         fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      name: Manage regression label

--- a/tag_updates.log
+++ b/tag_updates.log
@@ -1,0 +1,24 @@
+[2025-05-01 14:58:41] Checking out dev branch...
+[2025-05-01 14:58:42] Processing workflow file: C:\dev\testing\aws-repos\aws-extensions-for-dotnet-cli\.github\workflows\aws-ci.yml
+[2025-05-01 14:58:42] Processing workflow file: C:\dev\testing\aws-repos\aws-extensions-for-dotnet-cli\.github\workflows\change-file-in-pr.yml
+[2025-05-01 14:58:42] Found action with version tag: actions/checkout@v3
+[2025-05-01 14:58:42] Resolving commit hash for actions/checkout@v3...
+[2025-05-01 14:58:42] API Request: GET repos/actions/checkout/git/refs/tags/v3
+[2025-05-01 14:58:42] Resolved to commit: f43a0e5ff2bd294095638e18286ca9a3d1956744
+[2025-05-01 14:58:42] Updating action from actions/checkout@v3 to actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744
+[2025-05-01 14:58:42] Writing changes to C:\dev\testing\aws-repos\aws-extensions-for-dotnet-cli\.github\workflows\change-file-in-pr.yml
+[2025-05-01 14:58:42] Processing workflow file: C:\dev\testing\aws-repos\aws-extensions-for-dotnet-cli\.github\workflows\closed-issue-message.yml
+[2025-05-01 14:58:42] Processing workflow file: C:\dev\testing\aws-repos\aws-extensions-for-dotnet-cli\.github\workflows\create-release-pr.yml
+[2025-05-01 14:58:42] Processing workflow file: C:\dev\testing\aws-repos\aws-extensions-for-dotnet-cli\.github\workflows\handle-stale-discussions.yml
+[2025-05-01 14:58:42] Processing workflow file: C:\dev\testing\aws-repos\aws-extensions-for-dotnet-cli\.github\workflows\issue-regression-labeler.yml
+[2025-05-01 14:58:42] Found action with version tag: actions/github-script@v7
+[2025-05-01 14:58:42] Resolving commit hash for actions/github-script@v7...
+[2025-05-01 14:58:42] API Request: GET repos/actions/github-script/git/refs/tags/v7
+[2025-05-01 14:58:43] Found annotated tag, resolving actual commit...
+[2025-05-01 14:58:43] API Request: GET repos/actions/github-script/git/tags/5c56fde4671bc2d3592fb0f2c5b5bab9ddae03b1
+[2025-05-01 14:58:43] Resolved to commit: 60a0d83039c74a4aee543508d2ffcb1c3799cdea
+[2025-05-01 14:58:43] Updating action from actions/github-script@v7 to actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea
+[2025-05-01 14:58:43] Writing changes to C:\dev\testing\aws-repos\aws-extensions-for-dotnet-cli\.github\workflows\issue-regression-labeler.yml
+[2025-05-01 14:58:43] Processing workflow file: C:\dev\testing\aws-repos\aws-extensions-for-dotnet-cli\.github\workflows\stale_issues.yml
+[2025-05-01 14:58:43] Processing workflow file: C:\dev\testing\aws-repos\aws-extensions-for-dotnet-cli\.github\workflows\sync-master-dev.yml
+[2025-05-01 14:58:43] Committing changes...


### PR DESCRIPTION
Update GitHub Action version tags to their corresponding commit hashes for improved security and reproducibility.