### PR TITLE
Fix issue when polling for CloudFormation events

### DIFF
--- a/.autover/changes/a6c3e58d-9e9d-4a96-9cc9-704545f29cdf.json
+++ b/.autover/changes/a6c3e58d-9e9d-4a96-9cc9-704545f29cdf.json
@@ -1,0 +1,11 @@
+{
+  "Projects": [
+    {
+      "Name": "Amazon.Lambda.Tools",
+      "Type": "Patch",
+      "ChangelogMessages": [
+        "Fix issue when polling for CloudFormation events showing events before deploy-serverless command was invoked"
+      ]
+    }
+  ]
+}

--- a/src/Amazon.Lambda.Tools/Commands/DeployServerlessCommand.cs
+++ b/src/Amazon.Lambda.Tools/Commands/DeployServerlessCommand.cs
@@ -348,7 +348,7 @@ namespace Amazon.Lambda.Tools.Commands
             };
 
             // Execute the change set.
-            DateTime timeChangeSetExecuted = DateTime.Now;
+            DateTime timeChangeSetExecuted = DateTime.UtcNow;
             try
             {
                 await this.CloudFormationClient.ExecuteChangeSetAsync(executeChangeSetRequest);
@@ -436,7 +436,7 @@ namespace Amazon.Lambda.Tools.Commands
                 for (int i = events.Count - 1; i >= 0; i--)
                 {
                     string line =
-                        events[i].Timestamp.GetValueOrDefault().ToString("g").PadRight(TIMESTAMP_WIDTH) + " " +
+                        events[i].Timestamp.GetValueOrDefault().ToLocalTime().ToString("g").PadRight(TIMESTAMP_WIDTH) + " " +
                         events[i].LogicalResourceId.PadRight(LOGICAL_RESOURCE_WIDTH) + " " +
                         events[i].ResourceStatus.ToString().PadRight(RESOURCE_STATUS);
 


### PR DESCRIPTION
*Description of changes:*
Noticed that when I was using the `deploy-serverless` command when it polls for CloudFormation events it should only be showing events that were created since `deploy-serverless` was invoked but it was showing events in the past. I'm guessing this was a subtle bug introduced when we updated to V4 of the AWS SDK where now all `DateTime` are returned back from the SDK in UTC.

Corrected the filtering code to do the comparisons using UTC.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
