### PR TITLE
Add AWSSDK.Signin dependency to resolve 'aws login' credentials

### DIFF
--- a/.autover/changes/cdab5d4f-ee2b-47a3-82a0-99420c41c9ed.json
+++ b/.autover/changes/cdab5d4f-ee2b-47a3-82a0-99420c41c9ed.json
@@ -1,0 +1,25 @@
+{
+  "Projects": [
+    {
+      "Name": "Amazon.Lambda.Tools",
+      "Type": "Patch",
+      "ChangelogMessages": [
+        "Added AWSSDK.Signin dependency to resolve AWS credentials when authenticated using the AWS CLI v2 'aws login' SSO flow"
+      ]
+    },
+    {
+      "Name": "Amazon.ECS.Tools",
+      "Type": "Patch",
+      "ChangelogMessages": [
+        "Added AWSSDK.Signin dependency to resolve AWS credentials when authenticated using the AWS CLI v2 'aws login' SSO flow"
+      ]
+    },
+    {
+      "Name": "Amazon.ElasticBeanstalk.Tools",
+      "Type": "Patch",
+      "ChangelogMessages": [
+        "Added AWSSDK.Signin dependency to resolve AWS credentials when authenticated using the AWS CLI v2 'aws login' SSO flow"
+      ]
+    }
+  ]
+}

--- a/src/Amazon.Common.DotNetCli.Tools/Amazon.Common.DotNetCli.Tools.csproj
+++ b/src/Amazon.Common.DotNetCli.Tools/Amazon.Common.DotNetCli.Tools.csproj
@@ -14,6 +14,7 @@
     <PackageReference Include="AWSSDK.IdentityManagement" Version="4.0.3.2" />
     <PackageReference Include="AWSSDK.S3" Version="4.0.6.13" />
     <PackageReference Include="AWSSDK.SecurityToken" Version="4.0.2.1" />
+    <PackageReference Include="AWSSDK.Signin" Version="4.0.1.1" />
     <PackageReference Include="AWSSDK.SSO" Version="4.0.1.1" />
     <PackageReference Include="AWSSDK.SSOOIDC" Version="4.0.1.1" />
   </ItemGroup>


### PR DESCRIPTION
*Issue #, if available:* N/A, but port of https://github.com/aws/aws-dotnet-deploy/pull/1011

*Description of changes:* Adds the AWSSDK.Signin package so that the CLI tooling can resolve credentials created via `aws login`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
