### PR TITLE
Update minimum version of .NET required for install to .NET 8 dropping the .NET 6 target.

### DIFF
--- a/.autover/changes/b8aa94cb-c432-4f7d-a5fc-42822f8c84d3.json
+++ b/.autover/changes/b8aa94cb-c432-4f7d-a5fc-42822f8c84d3.json
@@ -5,7 +5,7 @@
       "Type": "Major",
       "ChangelogMessages": [
 	    "[Breaking Change] Tool's minimum .NET version updated from .NET 6 to .NET 8",
-	    "Added `--file-system-configs`, `--durable-execution-timeout` and `--durable-retention-period-in-days` switches to the `deploy-function` and `update-function-config` commands to configure the function's file system (Amazon EFS/S3) and durable execution settings",
+	    "Added `--file-system-configs`, `--durable-execution-timeout` and `--durable-retention-period` switches to the `deploy-function` and `update-function-config` commands to configure the function's file system (Amazon EFS/S3) and durable execution settings",
         "Bumped AWS SDK for .NET dependencies to latest versions"
       ]
     },

--- a/.autover/changes/b8aa94cb-c432-4f7d-a5fc-42822f8c84d3.json
+++ b/.autover/changes/b8aa94cb-c432-4f7d-a5fc-42822f8c84d3.json
@@ -1,0 +1,27 @@
+{
+  "Projects": [
+    {
+      "Name": "Amazon.Lambda.Tools",
+      "Type": "Major",
+      "ChangelogMessages": [
+	    "[Breaking Change] Tool's minimum .NET version updated from .NET 6 to .NET 8",
+	    "Added `--file-system-configs`, `--durable-execution-timeout` and `--durable-retention-period-in-days` switches to the `deploy-function` and `update-function-config` commands to configure the function's file system (Amazon EFS/S3) and durable execution settings",
+        "Bumped AWS SDK for .NET dependencies to latest versions"
+      ]
+    },
+    {
+      "Name": "Amazon.ECS.Tools",
+      "Type": "Major",
+      "ChangelogMessages": [
+	    "[Breaking Change] Tool's minimum .NET version updated from .NET 6 to .NET 8"
+      ]
+    },
+    {
+      "Name": "Amazon.ElasticBeanstalk.Tools",
+      "Type": "Major",
+      "ChangelogMessages": [
+	    "[Breaking Change] Tool's minimum .NET version updated from .NET 6 to .NET 8"
+      ]
+    }	
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -1057,7 +1057,7 @@ Example of within the AWS SAM Template syntax `Globals` in a `serverless.templat
 ...
   "Globals": {
     "Function": {
-      "Runtime": "dotnet6",
+      "Runtime": "dotnet10",
       "Architectures": [
         "arm64"
       ]

--- a/src/Amazon.Common.DotNetCli.Tools/Amazon.Common.DotNetCli.Tools.csproj
+++ b/src/Amazon.Common.DotNetCli.Tools/Amazon.Common.DotNetCli.Tools.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\..\buildtools\common.props" />
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
     <!-- 
         This is explicitly set to 7.3 to match what the AWS VS Toolkit uses. This is required because
         the source code here is also copied into the AWS VS Toolkit.
@@ -9,14 +9,14 @@
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="AWSSDK.Core" Version="4.0.3.3" />
-    <PackageReference Include="AWSSDK.ECR" Version="4.0.4.1" />
-    <PackageReference Include="AWSSDK.IdentityManagement" Version="4.0.3.2" />
-    <PackageReference Include="AWSSDK.S3" Version="4.0.6.13" />
-    <PackageReference Include="AWSSDK.SecurityToken" Version="4.0.2.1" />
-    <PackageReference Include="AWSSDK.Signin" Version="4.0.1.1" />
-    <PackageReference Include="AWSSDK.SSO" Version="4.0.1.1" />
-    <PackageReference Include="AWSSDK.SSOOIDC" Version="4.0.1.1" />
+    <PackageReference Include="AWSSDK.Core" Version="4.0.9.2" />
+    <PackageReference Include="AWSSDK.ECR" Version="4.0.14.5" />
+    <PackageReference Include="AWSSDK.IdentityManagement" Version="4.0.10.5" />
+    <PackageReference Include="AWSSDK.S3" Version="4.0.24.4" />
+    <PackageReference Include="AWSSDK.SecurityToken" Version="4.0.7.4" />
+    <PackageReference Include="AWSSDK.Signin" Version="4.0.2.1" />
+    <PackageReference Include="AWSSDK.SSO" Version="4.0.3.4" />
+    <PackageReference Include="AWSSDK.SSOOIDC" Version="4.0.4.6" />
   </ItemGroup>
   <PropertyGroup>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>

--- a/src/Amazon.ECS.Tools/Amazon.ECS.Tools.csproj
+++ b/src/Amazon.ECS.Tools/Amazon.ECS.Tools.csproj
@@ -1,10 +1,10 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <Import Project="..\..\buildtools\common.props" />
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
     <PackageId>Amazon.ECS.Tools</PackageId>
     <PackageTags>AWS;Amazon;Docker;ECS</PackageTags>
     <PackAsTool>true</PackAsTool>
@@ -25,13 +25,13 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AWSSDK.CloudWatchEvents" Version="4.0.0.21" />
-    <PackageReference Include="AWSSDK.CloudWatchLogs" Version="4.0.7.7" />
-    <PackageReference Include="AWSSDK.Core" Version="4.0.3.3" />
-    <PackageReference Include="AWSSDK.EC2" Version="4.0.37" />
-    <PackageReference Include="AWSSDK.ECS" Version="4.0.4.8" />
-    <PackageReference Include="AWSSDK.IdentityManagement" Version="4.0.3.2" />
-    <PackageReference Include="AWSSDK.S3" Version="4.0.6.13" />
+    <PackageReference Include="AWSSDK.CloudWatchEvents" Version="4.0.2.5" />
+    <PackageReference Include="AWSSDK.CloudWatchLogs" Version="4.0.26.4" />
+    <PackageReference Include="AWSSDK.Core" Version="4.0.9.2" />
+    <PackageReference Include="AWSSDK.EC2" Version="4.0.93.1" />
+    <PackageReference Include="AWSSDK.ECS" Version="4.0.24.1" />
+    <PackageReference Include="AWSSDK.IdentityManagement" Version="4.0.10.5" />
+    <PackageReference Include="AWSSDK.S3" Version="4.0.24.4" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Amazon.ElasticBeanstalk.Tools/Amazon.ElasticBeanstalk.Tools.csproj
+++ b/src/Amazon.ElasticBeanstalk.Tools/Amazon.ElasticBeanstalk.Tools.csproj
@@ -4,7 +4,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
     <PackageId>Amazon.ElasticBeanstalk.Tools</PackageId>
     <PackageTags>AWS;Amazon;Beanstalk</PackageTags>
     <PackAsTool>true</PackAsTool>
@@ -30,9 +30,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="AWSSDK.ElasticBeanstalk" Version="4.0.1.1" />
-    <PackageReference Include="AWSSDK.IdentityManagement" Version="4.0.3.2" />
-    <PackageReference Include="AWSSDK.S3" Version="4.0.6.13" />
+    <PackageReference Include="AWSSDK.ElasticBeanstalk" Version="4.0.4.5" />
+    <PackageReference Include="AWSSDK.IdentityManagement" Version="4.0.10.5" />
+    <PackageReference Include="AWSSDK.S3" Version="4.0.24.4" />
   </ItemGroup>
   
   <PropertyGroup>

--- a/src/Amazon.Lambda.Tools/Amazon.Lambda.Tools.csproj
+++ b/src/Amazon.Lambda.Tools/Amazon.Lambda.Tools.csproj
@@ -1,9 +1,9 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\..\buildtools\common.props" />
   <PropertyGroup>
     <Description>Amazon.Lambda.Tools adds commands to the dotnet cli to deploy AWS Lambda functions.</Description>
     <AssemblyTitle>Amazon.Lambda.Tools</AssemblyTitle>
-    <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
     <AssemblyName>dotnet-lambda</AssemblyName>
     <OutputType>Exe</OutputType>
     <PackageId>Amazon.Lambda.Tools</PackageId>
@@ -20,7 +20,7 @@
         the source code here is also copied into the AWS VS Toolkit.
     -->
     <LangVersion>7.3</LangVersion>   
-    <Version>6.0.6</Version>
+    <Version>6.1.1111</Version>
   </PropertyGroup>
   <ItemGroup>
     <Content Include="Resources\build-lambda-zip.exe">
@@ -41,10 +41,10 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-    <PackageReference Include="AWSSDK.CloudFormation" Version="4.0.3" />
-    <PackageReference Include="AWSSDK.Lambda" Version="4.0.2.8" />
-    <PackageReference Include="AWSSDK.IdentityManagement" Version="4.0.3.2" />
-    <PackageReference Include="AWSSDK.S3" Version="4.0.6.13" />
+    <PackageReference Include="AWSSDK.CloudFormation" Version="4.0.9.4" />
+    <PackageReference Include="AWSSDK.Lambda" Version="4.0.17.4" />
+    <PackageReference Include="AWSSDK.IdentityManagement" Version="4.0.10.5" />
+    <PackageReference Include="AWSSDK.S3" Version="4.0.24.4" />
     <PackageReference Include="YamlDotNet.Signed" Version="5.2.1" />
   </ItemGroup>
   <PropertyGroup>

--- a/src/Amazon.Lambda.Tools/Amazon.Lambda.Tools.csproj
+++ b/src/Amazon.Lambda.Tools/Amazon.Lambda.Tools.csproj
@@ -20,7 +20,7 @@
         the source code here is also copied into the AWS VS Toolkit.
     -->
     <LangVersion>7.3</LangVersion>   
-    <Version>6.1.1111</Version>
+    <Version>6.0.6</Version>
   </PropertyGroup>
   <ItemGroup>
     <Content Include="Resources\build-lambda-zip.exe">

--- a/src/Amazon.Lambda.Tools/Commands/DeployFunctionCommand.cs
+++ b/src/Amazon.Lambda.Tools/Commands/DeployFunctionCommand.cs
@@ -82,7 +82,11 @@ namespace Amazon.Lambda.Tools.Commands
             LambdaDefinedCommandOptions.ARGUMENT_LOG_SYSTEM_LEVEL,
             LambdaDefinedCommandOptions.ARGUMENT_LOG_GROUP,
 
-            LambdaDefinedCommandOptions.ARGUMENT_SNAP_START_APPLY_ON
+            LambdaDefinedCommandOptions.ARGUMENT_SNAP_START_APPLY_ON,
+
+            LambdaDefinedCommandOptions.ARGUMENT_FILE_SYSTEM_CONFIGS,
+            LambdaDefinedCommandOptions.ARGUMENT_DURABLE_EXECUTION_TIMEOUT,
+            LambdaDefinedCommandOptions.ARGUMENT_DURABLE_RETENTION_PERIOD_IN_DAYS
         });
 
         public string Architecture { get; set; }
@@ -479,6 +483,25 @@ namespace Amazon.Lambda.Tools.Commands
                         createRequest.SnapStart = new SnapStart {ApplyOn = Amazon.Lambda.SnapStartApplyOn.FindValue(snapStartApplyOn)};
                     }
 
+                    var fileSystemConfigs = this.GetKeyValuePairOrDefault(this.FileSystemConfigs, LambdaDefinedCommandOptions.ARGUMENT_FILE_SYSTEM_CONFIGS, false);
+                    if (fileSystemConfigs != null && fileSystemConfigs.Count > 0)
+                    {
+                        createRequest.FileSystemConfigs = fileSystemConfigs
+                            .Select(x => new FileSystemConfig { Arn = x.Key, LocalMountPath = x.Value })
+                            .ToList();
+                    }
+
+                    var durableExecutionTimeout = this.GetIntValueOrDefault(this.DurableExecutionTimeout, LambdaDefinedCommandOptions.ARGUMENT_DURABLE_EXECUTION_TIMEOUT, false);
+                    var durableRetentionPeriodInDays = this.GetIntValueOrDefault(this.DurableRetentionPeriodInDays, LambdaDefinedCommandOptions.ARGUMENT_DURABLE_RETENTION_PERIOD_IN_DAYS, false);
+                    if (durableExecutionTimeout.HasValue || durableRetentionPeriodInDays.HasValue)
+                    {
+                        createRequest.DurableConfig = new DurableConfig();
+                        if (durableExecutionTimeout.HasValue)
+                            createRequest.DurableConfig.ExecutionTimeout = durableExecutionTimeout.Value;
+                        if (durableRetentionPeriodInDays.HasValue)
+                            createRequest.DurableConfig.RetentionPeriodInDays = durableRetentionPeriodInDays.Value;
+                    }
+
                     try
                     {
                         await this.LambdaClient.CreateFunctionAsync(createRequest);
@@ -687,6 +710,10 @@ namespace Amazon.Lambda.Tools.Commands
             data.SetIfNotNull(LambdaDefinedCommandOptions.ARGUMENT_LOG_GROUP.ConfigFileKey, this.GetStringValueOrDefault(this.LogGroup, LambdaDefinedCommandOptions.ARGUMENT_LOG_GROUP, false));
 
             data.SetIfNotNull(LambdaDefinedCommandOptions.ARGUMENT_SNAP_START_APPLY_ON.ConfigFileKey, this.GetStringValueOrDefault(this.SnapStartApplyOn, LambdaDefinedCommandOptions.ARGUMENT_SNAP_START_APPLY_ON, false));
+
+            data.SetIfNotNull(LambdaDefinedCommandOptions.ARGUMENT_FILE_SYSTEM_CONFIGS.ConfigFileKey, LambdaToolsDefaults.FormatKeyValue(this.GetKeyValuePairOrDefault(this.FileSystemConfigs, LambdaDefinedCommandOptions.ARGUMENT_FILE_SYSTEM_CONFIGS, false)));
+            data.SetIfNotNull(LambdaDefinedCommandOptions.ARGUMENT_DURABLE_EXECUTION_TIMEOUT.ConfigFileKey, this.GetIntValueOrDefault(this.DurableExecutionTimeout, LambdaDefinedCommandOptions.ARGUMENT_DURABLE_EXECUTION_TIMEOUT, false));
+            data.SetIfNotNull(LambdaDefinedCommandOptions.ARGUMENT_DURABLE_RETENTION_PERIOD_IN_DAYS.ConfigFileKey, this.GetIntValueOrDefault(this.DurableRetentionPeriodInDays, LambdaDefinedCommandOptions.ARGUMENT_DURABLE_RETENTION_PERIOD_IN_DAYS, false));
 
         }
     }

--- a/src/Amazon.Lambda.Tools/Commands/UpdateFunctionConfigCommand.cs
+++ b/src/Amazon.Lambda.Tools/Commands/UpdateFunctionConfigCommand.cs
@@ -58,7 +58,11 @@ namespace Amazon.Lambda.Tools.Commands
             LambdaDefinedCommandOptions.ARGUMENT_LOG_SYSTEM_LEVEL,
             LambdaDefinedCommandOptions.ARGUMENT_LOG_GROUP,
 
-            LambdaDefinedCommandOptions.ARGUMENT_SNAP_START_APPLY_ON
+            LambdaDefinedCommandOptions.ARGUMENT_SNAP_START_APPLY_ON,
+
+            LambdaDefinedCommandOptions.ARGUMENT_FILE_SYSTEM_CONFIGS,
+            LambdaDefinedCommandOptions.ARGUMENT_DURABLE_EXECUTION_TIMEOUT,
+            LambdaDefinedCommandOptions.ARGUMENT_DURABLE_RETENTION_PERIOD_IN_DAYS
         });
 
         public string FunctionName { get; set; }
@@ -97,6 +101,10 @@ namespace Amazon.Lambda.Tools.Commands
         public string LogSystemLevel { get; set; }
         public string LogGroup { get; set; }
         public string SnapStartApplyOn { get; set; }
+
+        public Dictionary<string, string> FileSystemConfigs { get; set; }
+        public int? DurableExecutionTimeout { get; set; }
+        public int? DurableRetentionPeriodInDays { get; set; }
 
 
         public UpdateFunctionConfigCommand(IToolLogger logger, string workingDirectory, string[] args)
@@ -184,6 +192,13 @@ namespace Amazon.Lambda.Tools.Commands
 
             if ((tuple = values.FindCommandOption(LambdaDefinedCommandOptions.ARGUMENT_SNAP_START_APPLY_ON.Switch)) != null)
                 this.SnapStartApplyOn = tuple.Item2.StringValue;
+
+            if ((tuple = values.FindCommandOption(LambdaDefinedCommandOptions.ARGUMENT_FILE_SYSTEM_CONFIGS.Switch)) != null)
+                this.FileSystemConfigs = tuple.Item2.KeyValuePairs;
+            if ((tuple = values.FindCommandOption(LambdaDefinedCommandOptions.ARGUMENT_DURABLE_EXECUTION_TIMEOUT.Switch)) != null)
+                this.DurableExecutionTimeout = tuple.Item2.IntValue;
+            if ((tuple = values.FindCommandOption(LambdaDefinedCommandOptions.ARGUMENT_DURABLE_RETENTION_PERIOD_IN_DAYS.Switch)) != null)
+                this.DurableRetentionPeriodInDays = tuple.Item2.IntValue;
         }
 
 
@@ -387,6 +402,23 @@ namespace Amazon.Lambda.Tools.Commands
                 request.TracingConfig = new TracingConfig
                 {
                     Mode = existingConfiguration.TracingConfig.Mode
+                };
+            }
+
+            if (existingConfiguration.FileSystemConfigs != null)
+            {
+                request.FileSystemConfigs = existingConfiguration.FileSystemConfigs
+                    .Select(x => new FileSystemConfig { Arn = x.Arn, LocalMountPath = x.LocalMountPath })
+                    .ToList();
+                request.IsFileSystemConfigsSet = existingConfiguration.FileSystemConfigs.Any();
+            }
+
+            if (existingConfiguration.DurableConfig != null)
+            {
+                request.DurableConfig = new DurableConfig
+                {
+                    ExecutionTimeout = existingConfiguration.DurableConfig.ExecutionTimeout,
+                    RetentionPeriodInDays = existingConfiguration.DurableConfig.RetentionPeriodInDays
                 };
             }
 
@@ -717,6 +749,38 @@ namespace Amazon.Lambda.Tools.Commands
                     request.SnapStart.ApplyOn = snapStartApplyOn;
                     different = true;
                 }
+            }
+
+            var fileSystemConfigs = this.GetKeyValuePairOrDefault(this.FileSystemConfigs, LambdaDefinedCommandOptions.ARGUMENT_FILE_SYSTEM_CONFIGS, false);
+            if (fileSystemConfigs != null)
+            {
+                var existingFileSystemConfigs = existingConfiguration.FileSystemConfigs?.ToDictionary(x => x.Arn, x => x.LocalMountPath);
+                if (AreDifferent(fileSystemConfigs, existingFileSystemConfigs))
+                {
+                    request.FileSystemConfigs = fileSystemConfigs.Select(x => new FileSystemConfig { Arn = x.Key, LocalMountPath = x.Value }).ToList();
+                    request.IsFileSystemConfigsSet = true;
+                    different = true;
+                }
+            }
+
+            var durableExecutionTimeout = this.GetIntValueOrDefault(this.DurableExecutionTimeout, LambdaDefinedCommandOptions.ARGUMENT_DURABLE_EXECUTION_TIMEOUT, false);
+            if (durableExecutionTimeout.HasValue && durableExecutionTimeout.Value != existingConfiguration.DurableConfig?.ExecutionTimeout)
+            {
+                if (request.DurableConfig == null)
+                    request.DurableConfig = new DurableConfig();
+
+                request.DurableConfig.ExecutionTimeout = durableExecutionTimeout.Value;
+                different = true;
+            }
+
+            var durableRetentionPeriodInDays = this.GetIntValueOrDefault(this.DurableRetentionPeriodInDays, LambdaDefinedCommandOptions.ARGUMENT_DURABLE_RETENTION_PERIOD_IN_DAYS, false);
+            if (durableRetentionPeriodInDays.HasValue && durableRetentionPeriodInDays.Value != existingConfiguration.DurableConfig?.RetentionPeriodInDays)
+            {
+                if (request.DurableConfig == null)
+                    request.DurableConfig = new DurableConfig();
+
+                request.DurableConfig.RetentionPeriodInDays = durableRetentionPeriodInDays.Value;
+                different = true;
             }
 
 

--- a/src/Amazon.Lambda.Tools/LambdaDefinedCommandOptions.cs
+++ b/src/Amazon.Lambda.Tools/LambdaDefinedCommandOptions.cs
@@ -531,5 +531,32 @@ namespace Amazon.Lambda.Tools
                 ValueType = CommandOption.CommandOptionValueType.StringValue,
                 Description = "Configure when a snapshot of the initialized execution environment should be taken. Valid values are: PublishedVersions, None. Default is None.",
             };
+        public static readonly CommandOption ARGUMENT_FILE_SYSTEM_CONFIGS =
+            new CommandOption
+            {
+                Name = "File System Configs",
+                Switch = "--file-system-configs",
+                ShortSwitch = "-fsc",
+                ValueType = CommandOption.CommandOptionValueType.KeyValuePairs,
+                Description = "Connection settings for an Amazon EFS or Amazon S3 file system. Format is <access-point-arn1>=<local-mount-path1>;<access-point-arn2>=<local-mount-path2>. Local mount paths must start with /mnt/."
+            };
+        public static readonly CommandOption ARGUMENT_DURABLE_EXECUTION_TIMEOUT =
+            new CommandOption
+            {
+                Name = "Durable Execution Timeout",
+                Switch = "--durable-execution-timeout",
+                ShortSwitch = "-det",
+                ValueType = CommandOption.CommandOptionValueType.IntValue,
+                Description = "For durable functions, the maximum time in seconds that a durable execution can run before timing out."
+            };
+        public static readonly CommandOption ARGUMENT_DURABLE_RETENTION_PERIOD_IN_DAYS =
+            new CommandOption
+            {
+                Name = "Durable Retention Period In Days",
+                Switch = "--durable-retention-period",
+                ShortSwitch = "-drp",
+                ValueType = CommandOption.CommandOptionValueType.IntValue,
+                Description = "For durable functions, the number of days to retain execution history after a durable execution completes."
+            };
     }
 }

--- a/test/Amazon.Common.DotNetCli.Tools.Test/Amazon.Common.DotNetCli.Tools.Test.csproj
+++ b/test/Amazon.Common.DotNetCli.Tools.Test/Amazon.Common.DotNetCli.Tools.Test.csproj
@@ -1,15 +1,15 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/test/Amazon.Common.DotNetCli.Tools.Test/UtilitiesTests.cs
+++ b/test/Amazon.Common.DotNetCli.Tools.Test/UtilitiesTests.cs
@@ -10,10 +10,10 @@ namespace Amazon.Common.DotNetCli.Tools.Test
     public class UtilitiesTests
     {
         [Theory]
-        [InlineData("../../../../../testapps/TestFunction", "net6.0")]
-        [InlineData("../../../../../testapps/ServerlessWithYamlFunction", "net6.0")]
+        [InlineData("../../../../../testapps/TestFunction", "net10.0")]
+        [InlineData("../../../../../testapps/ServerlessWithYamlFunction", "net10.0")]
         [InlineData("../../../../../testapps/TestBeanstalkWebApp", "net8.0")]
-        [InlineData("../../../../../testapps/TestFunctionBuildProps/TestFunctionBuildProps", "net6.0")]
+        [InlineData("../../../../../testapps/TestFunctionBuildProps/TestFunctionBuildProps", "net10.0")]
         public void CheckFramework(string projectPath, string expectedFramework)
         {
             var assembly = this.GetType().GetTypeInfo().Assembly;
@@ -102,8 +102,8 @@ namespace Amazon.Common.DotNetCli.Tools.Test
         }
 
         [Theory]
-        [InlineData("TargetFramework", "", "net6.0")]
-        [InlineData("TargetFramework", "/p:NonExistence=net20.0", "net6.0")]
+        [InlineData("TargetFramework", "", "net10.0")]
+        [InlineData("TargetFramework", "/p:NonExistence=net20.0", "net10.0")]
         [InlineData("TargetFramework", "/p:TargetFramework=net20.0", "net20.0")]
         [InlineData("TargetFramework", "/p:TargetFramework=net20.0 /p:OutputType=FutureDevice", "net20.0")]
         [InlineData("OutputType", "/p:TargetFramework=net20.0 /p:OutputType=FutureDevice", "FutureDevice")]

--- a/test/Amazon.ECS.Tools.Test/Amazon.ECS.Tools.Test.csproj
+++ b/test/Amazon.ECS.Tools.Test/Amazon.ECS.Tools.Test.csproj
@@ -1,15 +1,15 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/test/Amazon.ElasticBeanstalk.Tools.Test/Amazon.ElasticBeanstalk.Tools.Test.csproj
+++ b/test/Amazon.ElasticBeanstalk.Tools.Test/Amazon.ElasticBeanstalk.Tools.Test.csproj
@@ -1,18 +1,18 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AWSSDK.ElasticBeanstalk" Version="4.0.1.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
-    <PackageReference Include="Moq" Version="4.16.1" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+    <PackageReference Include="AWSSDK.ElasticBeanstalk" Version="4.0.4.5" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
+    <PackageReference Include="Moq" Version="4.20.72" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/test/Amazon.ElasticBeanstalk.Tools.Test/DeployTests.cs
+++ b/test/Amazon.ElasticBeanstalk.Tools.Test/DeployTests.cs
@@ -37,6 +37,11 @@ namespace Amazon.ElasticBeanstalk.Tools.Test
 
             var mockS3Client = new Mock<IAmazonS3>();
             mockS3Client.Setup(client => client.Config).Returns(new AmazonS3Config());
+            mockS3Client.Setup(client => client.PutObjectAsync(It.IsAny<PutObjectRequest>(), It.IsAny<CancellationToken>()))
+                .Returns((PutObjectRequest r, CancellationToken token) =>
+                {
+                    return Task.FromResult(new PutObjectResponse());
+                });
 
             var calls = new Dictionary<string, int>();
             Action<string> addCall = x =>
@@ -162,6 +167,11 @@ namespace Amazon.ElasticBeanstalk.Tools.Test
 
             var mockS3Client = new Mock<IAmazonS3>();
             mockS3Client.Setup(client => client.Config).Returns(new AmazonS3Config());
+            mockS3Client.Setup(client => client.PutObjectAsync(It.IsAny<PutObjectRequest>(), It.IsAny<CancellationToken>()))
+                .Returns((PutObjectRequest r, CancellationToken token) =>
+                {
+                    return Task.FromResult(new PutObjectResponse());
+                });
 
             var calls = new Dictionary<string, int>();
             Action<string> addCall = x =>
@@ -294,6 +304,11 @@ namespace Amazon.ElasticBeanstalk.Tools.Test
 
             var mockS3Client = new Mock<IAmazonS3>();
             mockS3Client.Setup(client => client.Config).Returns(new AmazonS3Config());
+            mockS3Client.Setup(client => client.PutObjectAsync(It.IsAny<PutObjectRequest>(), It.IsAny<CancellationToken>()))
+                .Returns((PutObjectRequest r, CancellationToken token) =>
+                {
+                    return Task.FromResult(new PutObjectResponse());
+                });
 
             var calls = new Dictionary<string, int>();
             Action<string> addCall = x =>

--- a/test/Amazon.Lambda.Tools.Integ.Tests/Amazon.Lambda.Tools.Integ.Tests.csproj
+++ b/test/Amazon.Lambda.Tools.Integ.Tests/Amazon.Lambda.Tools.Integ.Tests.csproj
@@ -1,18 +1,21 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0-preview-20211109-03" />
-    <PackageReference Include="xunit" Version="2.4.2-pre.12" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="1.2.0" />
+    <PackageReference Include="coverlet.collector" Version="10.0.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/test/Amazon.Lambda.Tools.Integ.Tests/DeployProjectTests.cs
+++ b/test/Amazon.Lambda.Tools.Integ.Tests/DeployProjectTests.cs
@@ -296,7 +296,7 @@ namespace Amazon.Lambda.Tools.Integ.Tests
             var command = new DeployFunctionCommand(toolLogger, fullPath, new string[0]);
             command.FunctionName = functionName;
             command.Role = await TestHelper.GetTestRoleArnAsync();
-            command.Runtime = "dotnet6";
+            command.Runtime = "dotnet10";
             command.EphemeralStorageSize = 750;
             command.EnvironmentVariables = new System.Collections.Generic.Dictionary<string, string> { { "Key1", "Value1" } };
             command.DisableInteractive = true;
@@ -313,7 +313,7 @@ namespace Amazon.Lambda.Tools.Integ.Tests
                 command = new DeployFunctionCommand(toolLogger, fullPath, new string[0]);
                 command.FunctionName = functionName;
                 command.Role = await TestHelper.GetTestRoleArnAsync();
-                command.Runtime = "dotnet6";
+                command.Runtime = "dotnet10";
                 command.EphemeralStorageSize = 800;
                 command.EnvironmentVariables = new System.Collections.Generic.Dictionary<string, string> ();
                 command.DisableInteractive = true;
@@ -429,7 +429,7 @@ namespace Amazon.Lambda.Tools.Integ.Tests
                 var command = new DeployFunctionCommand(toolLogger, fullPath, new string[0]);
                 command.FunctionName = functionName;
                 command.Role = await TestHelper.GetTestRoleArnAsync();
-                command.Runtime = "dotnet6";
+                command.Runtime = "dotnet10";
 
                 command.DisableInteractive = true;
                 

--- a/test/Amazon.Lambda.Tools.Test/Amazon.Lambda.Tools.Test.csproj
+++ b/test/Amazon.Lambda.Tools.Test/Amazon.Lambda.Tools.Test.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <AssemblyName>Amazon.Lambda.Tools.Test</AssemblyName>
     <OutputType>Library</OutputType>
     <PackageId>Amazon.Lambda.Tools.Test</PackageId>
@@ -55,18 +55,18 @@
     </Content>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="AWSSDK.CloudFormation" Version="4.0.3" />
-    <PackageReference Include="AWSSDK.Lambda" Version="4.0.2.8" />
-    <PackageReference Include="AWSSDK.SQS" Version="4.0.1.2" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+    <PackageReference Include="AWSSDK.CloudFormation" Version="4.0.9.4" />
+    <PackageReference Include="AWSSDK.Lambda" Version="4.0.17.4" />
+    <PackageReference Include="AWSSDK.SQS" Version="4.0.3.4" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="System.IO.Compression.ZipFile" Version="4.3.0" />
-    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="YamlDotNet.Signed" Version="5.2.1" />
-	<PackageReference Include="Moq" Version="4.16.1" />
+	<PackageReference Include="Moq" Version="4.20.72" />
   </ItemGroup>
   <ItemGroup>
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />

--- a/test/Amazon.Lambda.Tools.Test/ArmTests.cs
+++ b/test/Amazon.Lambda.Tools.Test/ArmTests.cs
@@ -60,7 +60,7 @@ namespace Amazon.Lambda.Tools.Test
             command.MemorySize = 512;
             command.Role = await TestHelper.GetTestRoleArnAsync();
             command.Configuration = "Release";
-            command.Runtime = "dotnet6";
+            command.Runtime = "dotnet10";
             command.Architecture = LambdaConstants.ARCHITECTURE_ARM64;
             command.DisableInteractive = true;
             command.LambdaClient = mockClient.Object;

--- a/test/Amazon.Lambda.Tools.Test/DeployTest.cs
+++ b/test/Amazon.Lambda.Tools.Test/DeployTest.cs
@@ -68,7 +68,7 @@ namespace Amazon.Lambda.Tools.Test
             command.MemorySize = 512;
             command.Role = await TestHelper.GetTestRoleArnAsync();
             command.Configuration = "Release";
-            command.Runtime = "dotnet6";
+            command.Runtime = "dotnet10";
             command.DisableInteractive = true;
             command.UseContainerForBuild = true;
 
@@ -282,7 +282,7 @@ namespace Amazon.Lambda.Tools.Test
             command.MemorySize = 512;
             command.Role = await TestHelper.GetTestRoleArnAsync();
             command.Configuration = "Release";
-            command.Runtime = "dotnet6";
+            command.Runtime = "dotnet10";
             command.DisableInteractive = true;
 
             var created = await command.ExecuteAsync();
@@ -325,7 +325,7 @@ namespace Amazon.Lambda.Tools.Test
             command.MemorySize = 512;
             command.Role = await TestHelper.GetTestRoleArnAsync();
             command.Configuration = "Release";
-            command.Runtime = "dotnet6";
+            command.Runtime = "dotnet10";
             command.DisableInteractive = true;
 
             var created = await command.ExecuteAsync();
@@ -413,7 +413,7 @@ namespace Amazon.Lambda.Tools.Test
             command.Timeout = 10;
             command.Role = await TestHelper.GetTestRoleArnAsync();
             command.Configuration = "Release";
-            command.Runtime = "dotnet6";
+            command.Runtime = "dotnet10";
             command.DisableInteractive = true;
 
             var created = await command.ExecuteAsync();
@@ -466,7 +466,7 @@ namespace Amazon.Lambda.Tools.Test
             deployCommand.MemorySize = 512;
             deployCommand.Role = await TestHelper.GetTestRoleArnAsync();
             deployCommand.Package = packageZip;
-            deployCommand.Runtime = "dotnet6";
+            deployCommand.Runtime = "dotnet10";
             deployCommand.Region = "us-east-1";
             deployCommand.DisableInteractive = true;
 
@@ -586,7 +586,7 @@ namespace Amazon.Lambda.Tools.Test
                 initialDeployCommand.MemorySize = 512;
                 initialDeployCommand.Role = await TestHelper.GetTestRoleArnAsync();
                 initialDeployCommand.Configuration = "Release";
-                initialDeployCommand.Runtime = "dotnet6";
+                initialDeployCommand.Runtime = "dotnet10";
                 initialDeployCommand.DeadLetterTargetArn = queueArn;
                 initialDeployCommand.DisableInteractive = true;
 
@@ -602,7 +602,7 @@ namespace Amazon.Lambda.Tools.Test
                     var redeployCommand = new DeployFunctionCommand(new TestToolLogger(_testOutputHelper), fullPath, Array.Empty<string>());
                     redeployCommand.FunctionName = initialDeployCommand.FunctionName;
                     redeployCommand.Configuration = "Release";
-                    redeployCommand.Runtime = "dotnet6";
+                    redeployCommand.Runtime = "dotnet10";
                     redeployCommand.DisableInteractive = true;
 
                     var redeployed = await redeployCommand.ExecuteAsync();
@@ -614,7 +614,7 @@ namespace Amazon.Lambda.Tools.Test
                     redeployCommand = new DeployFunctionCommand(new TestToolLogger(_testOutputHelper), fullPath, Array.Empty<string>());
                     redeployCommand.FunctionName = initialDeployCommand.FunctionName;
                     redeployCommand.Configuration = "Release";
-                    redeployCommand.Runtime = "dotnet6";
+                    redeployCommand.Runtime = "dotnet10";
                     redeployCommand.DeadLetterTargetArn = "";
                     redeployCommand.DisableInteractive = true;
 

--- a/test/Amazon.Lambda.Tools.Test/LambdaSingleFilePackageTests.cs
+++ b/test/Amazon.Lambda.Tools.Test/LambdaSingleFilePackageTests.cs
@@ -181,13 +181,13 @@ namespace Amazon.Lambda.Tools.Test
             
             // Test with regular project - should use bin/Release/targetFramework/publish
             var regularProjectPath = Path.GetFullPath(Path.GetDirectoryName(assembly.Location) + "../../../../../../testapps/TestFunction");
-            var regularProjectPublishLocation = Utilities.DeterminePublishLocation(Environment.CurrentDirectory, regularProjectPath, "Release", "net6.0");
+            var regularProjectPublishLocation = Utilities.DeterminePublishLocation(Environment.CurrentDirectory, regularProjectPath, "Release", "net10.0");
             
             // Regular project should have "bin" and "publish" in the path
             Assert.Contains("bin", regularProjectPublishLocation);
             Assert.Contains("publish", regularProjectPublishLocation);
             Assert.Contains("Release", regularProjectPublishLocation);
-            Assert.Contains("net6.0", regularProjectPublishLocation);
+            Assert.Contains("net10.0", regularProjectPublishLocation);
         }
 
         [Fact]

--- a/test/Amazon.Lambda.Tools.Test/LayerTests.cs
+++ b/test/Amazon.Lambda.Tools.Test/LayerTests.cs
@@ -58,7 +58,7 @@ namespace Amazon.Lambda.Tools.Test
             command.Region = "us-east-1";
             command.S3Bucket = this._testFixture.Bucket;
             command.DisableInteractive = true;
-            command.TargetFramework = "net6.0";
+            command.TargetFramework = "net10.0";
             command.LayerName = "DotnetTest-CreateLayer";
             command.LayerType = LambdaConstants.LAYER_TYPE_RUNTIME_PACKAGE_STORE;
             command.PackageManifest = _singleLayerFunctionPath;
@@ -115,7 +115,7 @@ namespace Amazon.Lambda.Tools.Test
             command.Region = "us-east-1";
             command.S3Bucket = this._testFixture.Bucket;
             command.DisableInteractive = true;
-            command.TargetFramework = "net6.0";
+            command.TargetFramework = "net10.0";
             command.LayerName = "DotnetTest-AttemptToCreateAnOptmizedLayer";
             command.LayerType = LambdaConstants.LAYER_TYPE_RUNTIME_PACKAGE_STORE;
             command.PackageManifest = fullPath;
@@ -186,7 +186,7 @@ namespace Amazon.Lambda.Tools.Test
                 deployCommand.MemorySize = 512;
                 deployCommand.Role = await TestHelper.GetTestRoleArnAsync();
                 deployCommand.Configuration = "Release";
-                deployCommand.Runtime = "dotnet6";
+                deployCommand.Runtime = "dotnet10";
                 deployCommand.LayerVersionArns = new string[] { publishLayerCommand.NewLayerVersionArn };
                 deployCommand.DisableInteractive = true;
 
@@ -481,7 +481,7 @@ namespace Amazon.Lambda.Tools.Test
             publishLayerCommand.LayerName = "Dotnet-IntegTest-";
             publishLayerCommand.LayerType = LambdaConstants.LAYER_TYPE_RUNTIME_PACKAGE_STORE;
             publishLayerCommand.OptDirectory = optDirectory;
-            publishLayerCommand.TargetFramework = "net6.0";
+            publishLayerCommand.TargetFramework = "net10.0";
 //            publishLayerCommand.PackageManifest = _singleLayerFunctionPath;
 
             if(!(await publishLayerCommand.ExecuteAsync()))

--- a/test/Amazon.Lambda.Tools.Test/OptionParseTests.cs
+++ b/test/Amazon.Lambda.Tools.Test/OptionParseTests.cs
@@ -115,5 +115,24 @@ namespace Amazon.Lambda.Tools.Test
             Assert.NotNull(param);
             Assert.Equal("us-west-2", param.Item2.StringValue);
         }
+
+        [Fact]
+        public void ParseFileSystemConfigsSwitch()
+        {
+            var logger = new TestToolLogger();
+            var command = new DeployFunctionCommand(logger, "", new[]
+            {
+                "myfunc",
+                "--file-system-configs", "arn:aws:elasticfilesystem:us-east-1:123456789012:access-point/fsap-1=/mnt/efs",
+                "--durable-execution-timeout", "3600",
+                "--durable-retention-period", "30"
+            });
+
+            Assert.NotNull(command.FileSystemConfigs);
+            Assert.Single(command.FileSystemConfigs);
+            Assert.Equal("/mnt/efs", command.FileSystemConfigs["arn:aws:elasticfilesystem:us-east-1:123456789012:access-point/fsap-1"]);
+            Assert.Equal(3600, command.DurableExecutionTimeout);
+            Assert.Equal(30, command.DurableRetentionPeriodInDays);
+        }
     }
 }

--- a/test/Amazon.Lambda.Tools.Test/TestFiles/testtemplate.yaml
+++ b/test/Amazon.Lambda.Tools.Test/TestFiles/testtemplate.yaml
@@ -98,7 +98,7 @@ Resources :
     Type: AWS::Serverless::Function
     Properties: 
       Handler: WildRydes::Function.Functions::Post
-      Runtime: dotnet6
+      Runtime: dotnet10
       CodeUri: 
       MemorySize: 256
       Timeout: 30

--- a/test/Amazon.Lambda.Tools.Test/UtilitiesTests.cs
+++ b/test/Amazon.Lambda.Tools.Test/UtilitiesTests.cs
@@ -26,6 +26,7 @@ namespace Amazon.Lambda.Tools.Test
         }
 
         [Theory]
+        [InlineData("dotnet10", "net10.0")]
         [InlineData("dotnet8", "net8.0")]
         [InlineData("dotnet6", "net6.0")]
         [InlineData("dotnetcore2.1", "netcoreapp2.1")]
@@ -215,8 +216,8 @@ namespace Amazon.Lambda.Tools.Test
         [InlineData("../../../../../testapps/TestFunction", "net5.0", false, false)]
         [InlineData("../../../../../testapps/TestNativeAotSingleProject", "net7.0", true, false)]
         [InlineData("../../../../../testapps/TestNativeAotSingleProject", "net7.0", false, false)]
-        [InlineData("../../../../../testapps/TestNativeAotSingleProject", "net6.0", false, false)]
-        [InlineData("../../../../../testapps/TestNativeAotSingleProject", "net6.0", true, true)]
+        [InlineData("../../../../../testapps/TestNativeAotSingleProject", "net10.0", false, false)]
+        [InlineData("../../../../../testapps/TestNativeAotSingleProject", "net10.0", true, false)]
         [InlineData("../../../../../testapps/TestNativeAotSingleProject", "net5.0", true, true)]
         public void TestValidateTargetFramework(string projectLocation, string targetFramework, bool isNativeAot, bool shouldThrow)
         {

--- a/test/Amazon.Tools.TestHelpers/Amazon.Tools.TestHelpers.csproj
+++ b/test/Amazon.Tools.TestHelpers/Amazon.Tools.TestHelpers.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/testapps/ImageBasedProjects/TestSimpleImageProject/Dockerfile
+++ b/testapps/ImageBasedProjects/TestSimpleImageProject/Dockerfile
@@ -1,10 +1,10 @@
-FROM public.ecr.aws/lambda/dotnet:8
+FROM public.ecr.aws/lambda/dotnet:10
 
 WORKDIR /var/task
 
 # This field should match where the .NET Lambda project built its output at. If this is being built as part of 
 # Amazon.Lambda.Tools this source in the copy command below should match the `--docker-host-build-output-dir` switch.
-COPY "bin/Release/net8.0/linux-x64/publish"  .
+COPY "bin/Release/net10.0/linux-x64/publish"  .
 
 # Defining the entry  point in the Lambda function is optional. If not set then the base image
 # will execute a shell script to determine the parameters for starting the .NET process.

--- a/testapps/ImageBasedProjects/TestSimpleImageProject/TestSimpleImageProject.csproj
+++ b/testapps/ImageBasedProjects/TestSimpleImageProject/TestSimpleImageProject.csproj
@@ -1,12 +1,12 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <AWSProjectType>Lambda</AWSProjectType>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Amazon.Lambda.Core" Version="2.2.0" />
-    <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.4.1" />
+    <PackageReference Include="Amazon.Lambda.Core" Version="3.1.0" />
+    <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="3.0.0" />
   </ItemGroup>
   
 </Project>

--- a/testapps/MPDeployServerless/CurrentDirectoryTest/CurrentDirectoryTest.csproj
+++ b/testapps/MPDeployServerless/CurrentDirectoryTest/CurrentDirectoryTest.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <AWSProjectType>Lambda</AWSProjectType>
   </PropertyGroup>

--- a/testapps/MPDeployServerless/CurrentDirectoryTest/serverless.template
+++ b/testapps/MPDeployServerless/CurrentDirectoryTest/serverless.template
@@ -9,7 +9,7 @@
       "Type" : "AWS::Serverless::Function",
       "Properties": {
         "Handler": "CurrentDirectoryTest::CurrentDirectoryTest.Functions::Get",
-        "Runtime": "dotnet6",
+        "Runtime": "dotnet10",
         "CodeUri": "",
         "MemorySize": 256,
         "Timeout": 30,
@@ -31,7 +31,7 @@
       "Type" : "AWS::Serverless::Function",
       "Properties": {
         "Handler": "CurrentDirectoryTest::CurrentDirectoryTest.Functions::Get2",
-        "Runtime": "dotnet6",
+        "Runtime": "dotnet10",
         "CodeUri": "",
         "MemorySize": 256,
         "Timeout": 30,
@@ -53,7 +53,7 @@
       "Type" : "AWS::Serverless::Function",
       "Properties": {
         "Handler": "SiblingProjectTest::SiblingProjectTest.Function::Get",
-        "Runtime": "dotnet6",
+        "Runtime": "dotnet10",
         "CodeUri": "../SiblingProjectTest",
         "MemorySize": 256,
         "Timeout": 30,

--- a/testapps/MPDeployServerless/SiblingProjectTest/SiblingProjectTest.csproj
+++ b/testapps/MPDeployServerless/SiblingProjectTest/SiblingProjectTest.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <AWSProjectType>Lambda</AWSProjectType>
   </PropertyGroup>

--- a/testapps/ServerlessWithYamlFunction/ServerlessWithYamlFunction.csproj
+++ b/testapps/ServerlessWithYamlFunction/ServerlessWithYamlFunction.csproj
@@ -1,15 +1,15 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <AWSProjectType>Lambda</AWSProjectType>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Amazon.Lambda.Core" Version="2.1.0" />
-    <PackageReference Include="Amazon.Lambda.Serialization.Json" Version="2.0.0" />
-    <PackageReference Include="Amazon.Lambda.APIGatewayEvents" Version="2.4.0" />
+    <PackageReference Include="Amazon.Lambda.Core" Version="3.1.0" />
+    <PackageReference Include="Amazon.Lambda.Serialization.Json" Version="3.0.0" />
+    <PackageReference Include="Amazon.Lambda.APIGatewayEvents" Version="3.0.0" />
   </ItemGroup>
 
 </Project>

--- a/testapps/ServerlessWithYamlFunction/rename-params-template.yaml
+++ b/testapps/ServerlessWithYamlFunction/rename-params-template.yaml
@@ -14,7 +14,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: ServerlessWithYamlFunction::ServerlessWithYamlFunction.Functions::Get
-      Runtime: dotnet6
+      Runtime: dotnet10
       CodeUri: ''
       MemorySize: 512
       Timeout: 30

--- a/testapps/ServerlessWithYamlFunction/serverless.yaml
+++ b/testapps/ServerlessWithYamlFunction/serverless.yaml
@@ -11,7 +11,7 @@ Parameters:
     Default: "Secret"
 Globals:
   Function:
-    Runtime: "dotnet6"
+    Runtime: "dotnet10"
 Resources:
   Get:
     Type: AWS::Serverless::Function

--- a/testapps/TemplateSubstitutionTestProjects/StateMachineDefinitionStringTest/StateMachineDefinitionStringTest.csproj
+++ b/testapps/TemplateSubstitutionTestProjects/StateMachineDefinitionStringTest/StateMachineDefinitionStringTest.csproj
@@ -1,13 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Amazon.Lambda.Core" Version="2.1.0" />
-    <PackageReference Include="Amazon.Lambda.Serialization.Json" Version="2.0.0" />
-    <PackageReference Include="Amazon.Lambda.APIGatewayEvents" Version="2.4.0" />
+    <PackageReference Include="Amazon.Lambda.Core" Version="3.1.0" />
+    <PackageReference Include="Amazon.Lambda.Serialization.Json" Version="3.0.0" />
+    <PackageReference Include="Amazon.Lambda.APIGatewayEvents" Version="3.0.0" />
   </ItemGroup>
 
 </Project>

--- a/testapps/TemplateSubstitutionTestProjects/StateMachineDefinitionStringTest/serverless.template
+++ b/testapps/TemplateSubstitutionTestProjects/StateMachineDefinitionStringTest/serverless.template
@@ -77,7 +77,7 @@
         "Properties" : {
             "Handler" : "StateMachineDefinitionStringTest::StateMachineDefinitionStringTest.Functions::Processor",
             "Role"    : {"Fn::GetAtt" : [ "LambdaRole", "Arn"]},
-            "Runtime" : "dotnet6",
+            "Runtime" : "dotnet10",
             "MemorySize" : 256,
             "Timeout" : 30,
             "Code" : {

--- a/testapps/TestFunction/TestFunction.csproj
+++ b/testapps/TestFunction/TestFunction.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <AssemblyName>TestFunction</AssemblyName>
     <OutputType>Library</OutputType>
     <PackageId>TestFunction</PackageId>
@@ -9,6 +9,6 @@
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Amazon.Lambda.Serialization.Json" Version="2.0.0" />
+    <PackageReference Include="Amazon.Lambda.Serialization.Json" Version="3.0.0" />
   </ItemGroup>
 </Project>

--- a/testapps/TestFunctionBuildProps/Directory.Build.props
+++ b/testapps/TestFunctionBuildProps/Directory.Build.props
@@ -1,5 +1,5 @@
 <Project>
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
   </PropertyGroup>
 </Project>

--- a/testapps/TestHttpFunction/TestHttpFunction.csproj
+++ b/testapps/TestHttpFunction/TestHttpFunction.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
@@ -9,9 +9,9 @@
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
   <ItemGroup>
-	<PackageReference Include="Amazon.Lambda.Core" Version="2.1.0" />
-	<PackageReference Include="Amazon.Lambda.APIGatewayEvents" Version="2.4.0" />
-	<PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.3.0" />
+	<PackageReference Include="Amazon.Lambda.Core" Version="3.1.0" />
+	<PackageReference Include="Amazon.Lambda.APIGatewayEvents" Version="3.0.0" />
+	<PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="3.0.0" />
   </ItemGroup>
 
 </Project>

--- a/testapps/TestHttpFunction/aws-lambda-tools-defaults.json
+++ b/testapps/TestHttpFunction/aws-lambda-tools-defaults.json
@@ -1,6 +1,6 @@
 {
   "configuration": "Release",
-  "function-runtime": "dotnet6",
+  "function-runtime": "dotnet10",
   "function-memory-size": 256,
   "function-timeout": 30,
   "function-handler": "TestHttpFunction::TestHttpFunction.Function::FunctionHandler"

--- a/testapps/TestIntegerFunction/TestIntegerFunction.csproj
+++ b/testapps/TestIntegerFunction/TestIntegerFunction.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <AssemblyName>TestIntegerFunction</AssemblyName>
     <OutputType>Library</OutputType>
     <PackageId>TestIntegerFunction</PackageId>
@@ -9,6 +9,6 @@
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Amazon.Lambda.Serialization.Json" Version="2.0.0" />
+    <PackageReference Include="Amazon.Lambda.Serialization.Json" Version="3.0.0" />
   </ItemGroup>
 </Project>

--- a/testapps/TestLayerAspNetCore/TestLayerAspNetCore.csproj
+++ b/testapps/TestLayerAspNetCore/TestLayerAspNetCore.csproj
@@ -1,12 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <AWSProjectType>Lambda</AWSProjectType>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="AWSSDK.S3" Version="4.0.6.13" />
-    <PackageReference Include="AWSSDK.Extensions.NETCore.Setup" Version="4.0.2.2" />
-    <PackageReference Include="Amazon.Lambda.AspNetCoreServer" Version="9.2.0" />
+    <PackageReference Include="AWSSDK.S3" Version="4.0.24.4" />
+    <PackageReference Include="AWSSDK.Extensions.NETCore.Setup" Version="4.0.4.7" />
+    <PackageReference Include="Amazon.Lambda.AspNetCoreServer" Version="10.1.1" />
   </ItemGroup>
 </Project>

--- a/testapps/TestLayerAspNetCore/fake.template
+++ b/testapps/TestLayerAspNetCore/fake.template
@@ -12,7 +12,7 @@
 				"Type" : "AWS::Serverless::Function",
 				"Properties": {
 				"Handler": "TestLayerAspNetCore::TestLayerAspNetCore.LambdaEntryPoint::FunctionHandlerAsync",
-				"Runtime": "dotnet6",
+				"Runtime": "dotnet10",
 				"CodeUri": "",
 				"MemorySize": 256,
 				"Timeout": 30,

--- a/testapps/TestLayerExample/TestLayerExample.csproj
+++ b/testapps/TestLayerExample/TestLayerExample.csproj
@@ -1,15 +1,15 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <AWSProjectType>Lambda</AWSProjectType>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Amazon.Lambda.Core" Version="2.7.0" />
-    <PackageReference Include="Amazon.Lambda.Serialization.Json" Version="2.2.4" />
-    <PackageReference Include="AWSSDK.S3" Version="4.0.6.13" />
+    <PackageReference Include="Amazon.Lambda.Core" Version="3.1.0" />
+    <PackageReference Include="Amazon.Lambda.Serialization.Json" Version="3.0.0" />
+    <PackageReference Include="AWSSDK.S3" Version="4.0.24.4" />
   </ItemGroup>
 
 </Project>

--- a/testapps/TestLayerExample/aws-lambda-tools-defaults.json
+++ b/testapps/TestLayerExample/aws-lambda-tools-defaults.json
@@ -11,7 +11,7 @@
   "profile":"default",
   "region" : "us-west-2",
   "configuration" : "Release",
-  "function-runtime":"dotnet6",
+  "function-runtime":"dotnet10",
   "function-memory-size" : 256,
   "function-timeout" : 30,
   "function-handler" : "TestLayerExample::TestLayerExample.Function::FunctionHandler"

--- a/testapps/TestLayerServerless/TestLayerServerless.csproj
+++ b/testapps/TestLayerServerless/TestLayerServerless.csproj
@@ -1,15 +1,15 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <AWSProjectType>Lambda</AWSProjectType>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Amazon.Lambda.Core" Version="2.7.0" />
-    <PackageReference Include="Amazon.Lambda.Serialization.Json" Version="2.2.4" />
-    <PackageReference Include="Amazon.Lambda.APIGatewayEvents" Version="2.7.1" />
+    <PackageReference Include="Amazon.Lambda.Core" Version="3.1.0" />
+    <PackageReference Include="Amazon.Lambda.Serialization.Json" Version="3.0.0" />
+    <PackageReference Include="Amazon.Lambda.APIGatewayEvents" Version="3.0.0" />
   </ItemGroup>
 
 </Project>

--- a/testapps/TestLayerServerless/fake.template
+++ b/testapps/TestLayerServerless/fake.template
@@ -9,7 +9,7 @@
       "Type" : "AWS::Serverless::Function",
       "Properties": {
         "Handler": "TestLayerServerless::TestLayerServerless.Functions::ToUpper",
-        "Runtime": "dotnet6",
+        "Runtime": "dotnet10",
         "CodeUri": "",
         "MemorySize": 256,
         "Timeout": 30,
@@ -26,7 +26,7 @@
       "Description" : "Add second function using the same source to make sure DOTNET_SHARED_STORE env is set even though not rebuilt",
       "Properties": {
         "Handler": "TestLayerServerless::TestLayerServerless.Functions::ToUpper",
-        "Runtime": "dotnet6",
+        "Runtime": "dotnet10",
         "CodeUri": "",
         "MemorySize": 256,
         "Timeout": 30,

--- a/testapps/TestNativeAotNet8WebApp/TestNativeAotNet8WebApp.csproj
+++ b/testapps/TestNativeAotNet8WebApp/TestNativeAotNet8WebApp.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <InvariantGlobalization>true</InvariantGlobalization>
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Amazon.Lambda.AspNetCoreServer" Version="9.0.0" />
+    <PackageReference Include="Amazon.Lambda.AspNetCoreServer" Version="10.1.1" />
   </ItemGroup>
 
 </Project>

--- a/testapps/TestNativeAotNet8WebApp/serverless.template
+++ b/testapps/TestNativeAotNet8WebApp/serverless.template
@@ -9,7 +9,7 @@
       "Type" : "AWS::Serverless::Function",
       "Properties": {
         "Handler": "TestNativeAotNet8WebApp::TestNativeAotNet8WebApp.LambdaFunction::FunctionHandlerAsync",
-        "Runtime": "dotnet8",
+        "Runtime": "dotnet10",
         "CodeUri": "",
         "Description": "Default function",
         "MemorySize": 512,

--- a/testapps/TestPowerShellParallelTest/TestPowerShellParallelTest.csproj
+++ b/testapps/TestPowerShellParallelTest/TestPowerShellParallelTest.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
         <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     </PropertyGroup>
 
@@ -14,9 +14,9 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.PowerShell.SDK" Version="7.2.3" />
+        <PackageReference Include="Microsoft.PowerShell.SDK" Version="7.6.2" />
 
-        <PackageReference Include="Amazon.Lambda.Core" Version="1.1.0" />
-        <PackageReference Include="Amazon.Lambda.PowerShellHost" Version="2.0.0" />
+        <PackageReference Include="Amazon.Lambda.Core" Version="3.1.0" />
+        <PackageReference Include="Amazon.Lambda.PowerShellHost" Version="4.0.0" />
     </ItemGroup>
 </Project>

--- a/testapps/TestPowerShellParallelTest/aws-lambda-tools-defaults.json
+++ b/testapps/TestPowerShellParallelTest/aws-lambda-tools-defaults.json
@@ -2,7 +2,7 @@
     "profile"     : "",
     "region"      : "",
     "configuration" : "Release",
-    "function-runtime" : "dotnet6",
+    "function-runtime" : "dotnet10",
     "function-memory-size" : 512,
     "function-timeout"     : 90,
     "function-handler"     : "TestPowerShellParallelTest::TestPowerShellParallelTest.Bootstrap::ExecuteFunction",

--- a/testapps/TestServerlessWebApp/Startup.cs
+++ b/testapps/TestServerlessWebApp/Startup.cs
@@ -7,7 +7,6 @@ using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
-using Microsoft.OpenApi.Models;
 using Swashbuckle.AspNetCore.Swagger;
 
 namespace TestServerlessWebApp
@@ -24,11 +23,6 @@ namespace TestServerlessWebApp
         // This method gets called by the runtime. Use this method to add services to the container
         public void ConfigureServices(IServiceCollection services)
         {
-            services.AddSwaggerGen(c =>
-            {
-                c.SwaggerDoc("v1", new OpenApiInfo() { Title = "My API", Version = "v1" });
-            });
-
             services.AddAuthorization(options =>
             {
                 options.AddPolicy("YouAreSpecial", policy => policy.RequireClaim("you_are_special"));

--- a/testapps/TestServerlessWebApp/Startup.cs
+++ b/testapps/TestServerlessWebApp/Startup.cs
@@ -34,8 +34,6 @@ namespace TestServerlessWebApp
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline
         public void Configure(IApplicationBuilder app)
         {
-            app.UseSwagger();
-
             app.UseMiddleware<Middleware>();
 
             app.UseRouting();

--- a/testapps/TestServerlessWebApp/TestServerlessWebApp.csproj
+++ b/testapps/TestServerlessWebApp/TestServerlessWebApp.csproj
@@ -1,13 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <PreserveCompilationContext>true</PreserveCompilationContext>
     <AssemblyName>TestServerlessWebApp</AssemblyName>
     <OutputType>Exe</OutputType>
     <PackageId>TestWebApp</PackageId>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Amazon.Lambda.AspNetCoreServer" Version="6.1.0" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.2.3" />
+    <PackageReference Include="Amazon.Lambda.AspNetCoreServer" Version="10.1.1" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="10.2.1" />
   </ItemGroup>
 </Project>

--- a/testapps/TestServerlessWebApp/large-serverless.template
+++ b/testapps/TestServerlessWebApp/large-serverless.template
@@ -21,7 +21,7 @@
       "Description" : "0123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789",
       "Properties": {
         "Handler": "TestServerlessWebApp::TestServerlessWebApp.LambdaFunction::FunctionHandlerAsync",
-        "Runtime": "dotnet6",
+        "Runtime": "dotnet10",
         "CodeUri": "",
         "Description": "Default function",
         "MemorySize": 256,

--- a/testapps/TestServerlessWebApp/serverless-arm.template
+++ b/testapps/TestServerlessWebApp/serverless-arm.template
@@ -10,7 +10,7 @@
       "Properties": {
         "Handler": "TestServerlessWebApp::TestServerlessWebApp.LambdaFunction::FunctionHandlerAsync",
         "Architectures" : ["arm64"],
-        "Runtime": "dotnet6",
+        "Runtime": "dotnet10",
         "CodeUri": "",
         "Description": "Default function",
         "MemorySize": 256,

--- a/testapps/TestServerlessWebApp/serverless-global-arm.template
+++ b/testapps/TestServerlessWebApp/serverless-global-arm.template
@@ -14,7 +14,7 @@
       "Type" : "AWS::Serverless::Function",
       "Properties": {
         "Handler": "TestServerlessWebApp::TestServerlessWebApp.LambdaFunction::FunctionHandlerAsync",
-        "Runtime": "dotnet6",
+        "Runtime": "dotnet10",
         "CodeUri": "",
         "Description": "Default function",
         "MemorySize": 256,

--- a/testapps/TestServerlessWebApp/serverless.template
+++ b/testapps/TestServerlessWebApp/serverless.template
@@ -9,7 +9,7 @@
       "Type" : "AWS::Serverless::Function",
       "Properties": {
         "Handler": "TestServerlessWebApp::TestServerlessWebApp.LambdaFunction::FunctionHandlerAsync",
-        "Runtime": "dotnet6",
+        "Runtime": "dotnet10",
         "CodeUri": "",
         "Description": "Default function",
         "MemorySize": 256,


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
I thought I would update the Amazon.Lambda.Tools to support setting the Durable Function config since we are [working on that feature](https://github.com/aws/aws-lambda-dotnet/issues/2418). While there I also added the file system config settings and then realized a lot of the tests in the repo were still targeting .NET 6. So I took decided to also update all of the tests to .NET 10 and change the build target of the tools from .NET 6 and 8 to .NET 8 and 10. Since we are dropping .NET 6 from the build targets I marked the change as a major version bump. This will bump up the tool to major version 7.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
