### PR TITLE
Added `--invoke-mode` switch to the `invoke-function` command

### DIFF
--- a/.autover/changes/a8aa94cb-c432-4f7d-a5fc-42822f8c84d2.json
+++ b/.autover/changes/a8aa94cb-c432-4f7d-a5fc-42822f8c84d2.json
@@ -1,0 +1,12 @@
+{
+  "Projects": [
+    {
+      "Name": "Amazon.Lambda.Tools",
+      "Type": "Minor",
+      "ChangelogMessages": [
+		"Added `--invoke-mode` switch to the `invoke-function` command with values RequestResponse (default), Event, Stream and DurableExecution. Stream invokes the function with InvokeWithResponseStream and streams the response to the console; Event invokes asynchronously and displays any function error and the durable execution ARN; DurableExecution invokes asynchronously and monitors the durable execution by polling GetDurableExecution and GetDurableExecutionHistory, resolving the latest published version ARN when a function name is supplied",
+		"The `deploy-function` and `update-function-config` commands now write the new function version ARN to the output when `--function-publish` is set to true"
+      ]
+    }	
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -686,7 +686,12 @@ invoke-function:
       -pcfg  | --persist-config-file          If true the arguments used for a successful deployment are persisted to a config file.
       -fn    | --function-name                AWS Lambda function name
       -p     | --payload                      The input payload to send to the Lambda function
+      -im    | --invoke-mode                  How the function is invoked. Valid values are: RequestResponse, Event, Stream or DurableExecution. Default is RequestResponse.
 ```
+
+When `--invoke-mode` is set to `Stream` the function is invoked with `InvokeWithResponseStream` and the response payload is streamed to the console as it is produced. When set to `Event` the function is invoked asynchronously and any function error and the durable execution ARN are displayed.
+
+When `--invoke-mode` is set to `DurableExecution` the function is assumed to be configured for durable execution. The function is invoked asynchronously, the durable execution ARN is read from the response, and the execution is monitored by polling the `GetDurableExecution` and `GetDurableExecutionHistory` APIs, writing progress to the console until the execution reaches a terminal state. For each history event any associated details (such as step inputs, results and errors) are written to the console; large string payload fields are truncated to the first 1000 characters with a note that the payload was truncated. If the supplied function name is not an ARN the latest published version is resolved and its ARN is used for the invocation (the resolved ARN is written to the console); if the function has no published versions an error is reported.
 
 ##### List Functions
 ```

--- a/src/Amazon.Common.DotNetCli.Tools/IToolLogger.cs
+++ b/src/Amazon.Common.DotNetCli.Tools/IToolLogger.cs
@@ -16,6 +16,12 @@ namespace Amazon.Common.DotNetCli.Tools
         void WriteLine(string message);
 
         void WriteLine(string message, params object[] args);
+
+        /// <summary>
+        /// Writes a message without appending a line terminator. Used for streaming output where
+        /// content arrives in chunks that should be concatenated on the same line.
+        /// </summary>
+        void Write(string message);
     }
 
     /// <summary>
@@ -37,6 +43,14 @@ namespace Amazon.Common.DotNetCli.Tools
             Console.WriteLine(str);
 #if DEBUG
             Debugger.Log(0, "console", str + "\n");
+#endif
+        }
+
+        public void Write(string message)
+        {
+            Console.Write(message);
+#if DEBUG
+            Debugger.Log(0, "console", message);
 #endif
         }
     }

--- a/src/Amazon.Lambda.Tools/Commands/InvokeFunctionCommand.cs
+++ b/src/Amazon.Lambda.Tools/Commands/InvokeFunctionCommand.cs
@@ -99,7 +99,11 @@ namespace Amazon.Lambda.Tools.Commands
         /// </summary>
         private static InvokeMode ParseInvokeMode(string value)
         {
-            if (Enum.TryParse<InvokeMode>(value, true, out var mode) && Enum.IsDefined(typeof(InvokeMode), mode))
+            // Only accept the named enum values. Numeric input like "0" or "1" is rejected even though
+            // Enum.TryParse would otherwise parse it, since the CLI help only documents the named values.
+            if (!string.IsNullOrEmpty(value) &&
+                !char.IsDigit(value[0]) && value[0] != '-' && value[0] != '+' &&
+                Enum.TryParse<InvokeMode>(value, true, out var mode) && Enum.IsDefined(typeof(InvokeMode), mode))
             {
                 return mode;
             }
@@ -139,8 +143,9 @@ namespace Amazon.Lambda.Tools.Commands
 
         /// <summary>
         /// Resolves the payload to send to the function. If <see cref="Payload"/> points to an existing file then
-        /// the contents of the file are used, otherwise the raw value is used. Scalar values that are not already
-        /// valid JSON are wrapped in quotes so they are sent as valid JSON strings.
+        /// the contents of the file are used, otherwise the raw value is used. If the value is already valid JSON
+        /// (an object, array, or scalar such as a number, boolean, string or null) it is sent as-is; otherwise it is
+        /// JSON-serialized as a string so the function receives a valid JSON value.
         /// </summary>
         private string ResolvePayload()
         {
@@ -161,22 +166,37 @@ namespace Amazon.Lambda.Tools.Commands
             }
 
             // We should still check for empty payload in case it is read from a file.
-            if (!string.IsNullOrEmpty(payload))
+            if (string.IsNullOrEmpty(payload))
             {
-                if (payload[0] != '\"' && payload[0] != '{' && payload[0] != '[')
-                {
-                    double d;
-                    long l;
-                    bool b;
-                    if (!double.TryParse(payload, out d) && !long.TryParse(payload, out l) &&
-                        !bool.TryParse(payload, out b))
-                    {
-                        payload = "\"" + payload + "\"";
-                    }
-                }
+                return payload;
             }
 
-            return payload;
+            // If the value is already valid JSON (including scalars like 123, true or null) send it unchanged.
+            // Otherwise treat it as a raw string and JSON-serialize it so quotes/backslashes are escaped correctly.
+            if (IsValidJson(payload))
+            {
+                return payload;
+            }
+
+            return System.Text.Json.JsonSerializer.Serialize(payload);
+        }
+
+        /// <summary>
+        /// Returns true if the supplied text is a complete, well-formed JSON value.
+        /// </summary>
+        private static bool IsValidJson(string value)
+        {
+            try
+            {
+                using (var doc = System.Text.Json.JsonDocument.Parse(value))
+                {
+                    return true;
+                }
+            }
+            catch (System.Text.Json.JsonException)
+            {
+                return false;
+            }
         }
 
         /// <summary>
@@ -358,13 +378,22 @@ namespace Amazon.Lambda.Tools.Commands
         }
 
         /// <summary>
+        /// The delay between polls of the durable execution status while monitoring its progress.
+        /// </summary>
+        protected virtual TimeSpan PollInterval => TimeSpan.FromSeconds(3);
+
+        /// <summary>
+        /// Waits <see cref="PollInterval"/> between durable execution status polls. Exposed as a virtual method so
+        /// tests can override it to avoid slowing down the suite.
+        /// </summary>
+        protected virtual Task PollDelayAsync() => Task.Delay(PollInterval);
+
+        /// <summary>
         /// Polls the GetDurableExecution and GetDurableExecutionHistory APIs to monitor a durable execution,
         /// writing new history events and status changes to the console until the execution reaches a terminal state.
         /// </summary>
         private async Task MonitorDurableExecutionAsync(string durableExecutionArn)
         {
-            const int POLL_INTERVAL = 3000;
-
             this.Logger.WriteLine("");
             this.Logger.WriteLine("Monitoring durable execution progress:");
 
@@ -385,7 +414,7 @@ namespace Amazon.Lambda.Tools.Commands
                 catch (ResourceNotFoundException)
                 {
                     // It is possible for the durable execution to not be immediately visible after the invocation returns, so treat a not found error as an empty execution history and keep polling until it appears.
-                    await Task.Delay(POLL_INTERVAL);
+                    await PollDelayAsync();
                     continue;
                 }
                 catch (Exception e)
@@ -398,7 +427,7 @@ namespace Amazon.Lambda.Tools.Commands
                     break;
                 }
 
-                await Task.Delay(POLL_INTERVAL);
+                await PollDelayAsync();
             }
 
             this.Logger.WriteLine("");
@@ -762,14 +791,22 @@ namespace Amazon.Lambda.Tools.Commands
             string errorDetails = null;
             try
             {
+                // Use a Decoder to preserve state across chunks so multi-byte UTF-8 characters that are split
+                // across chunk boundaries are decoded correctly instead of producing replacement characters.
+                var decoder = System.Text.UTF8Encoding.UTF8.GetDecoder();
                 using (var response = await this.LambdaClient.InvokeWithResponseStreamAsync(invokeRequest))
                 {
                     foreach (var streamEvent in response.EventStream)
                     {
                         if (streamEvent is InvokeResponseStreamUpdate update && update.Payload != null)
                         {
-                            var chunk = System.Text.UTF8Encoding.UTF8.GetString(update.Payload.ToArray());
-                            this.Logger.Write(chunk);
+                            var bytes = update.Payload.ToArray();
+                            var chars = new char[decoder.GetCharCount(bytes, 0, bytes.Length, false)];
+                            var charCount = decoder.GetChars(bytes, 0, bytes.Length, chars, 0, false);
+                            if (charCount > 0)
+                            {
+                                this.Logger.Write(new string(chars, 0, charCount));
+                            }
                         }
                         else if (streamEvent is InvokeWithResponseStreamCompleteEvent complete)
                         {
@@ -778,6 +815,14 @@ namespace Amazon.Lambda.Tools.Commands
                             errorDetails = complete.ErrorDetails;
                         }
                     }
+                }
+
+                // Flush any remaining buffered bytes from the decoder.
+                var tail = new char[decoder.GetCharCount(Array.Empty<byte>(), 0, 0, true)];
+                var tailCount = decoder.GetChars(Array.Empty<byte>(), 0, 0, tail, 0, true);
+                if (tailCount > 0)
+                {
+                    this.Logger.Write(new string(tail, 0, tailCount));
                 }
             }
             catch (Exception e)

--- a/src/Amazon.Lambda.Tools/Commands/InvokeFunctionCommand.cs
+++ b/src/Amazon.Lambda.Tools/Commands/InvokeFunctionCommand.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Threading.Tasks;
@@ -17,11 +17,40 @@ namespace Amazon.Lambda.Tools.Commands
         public const string COMMAND_DESCRIPTION = "Command to invoke a function in Lambda with an optional input";
         public const string COMMAND_ARGUMENTS = "<FUNCTION-NAME> The name of the function to invoke";
 
+        /// <summary>
+        /// How the Lambda function should be invoked.
+        /// </summary>
+        public enum InvokeMode
+        {
+            /// <summary>
+            /// Invoke the function synchronously and wait for the response. This is the default.
+            /// </summary>
+            RequestResponse,
+
+            /// <summary>
+            /// Invoke the function asynchronously.
+            /// </summary>
+            Event,
+
+            /// <summary>
+            /// Invoke the function and stream the response payload to the console as it is produced.
+            /// </summary>
+            Stream,
+
+            /// <summary>
+            /// Invoke a function that is configured for durable execution. The function is invoked
+            /// asynchronously (Event) and the durable execution is then monitored by polling the
+            /// GetDurableExecution and GetDurableExecutionHistory APIs until the execution completes.
+            /// </summary>
+            DurableExecution
+        }
+
 
         public static readonly IList<CommandOption> InvokeCommandOptions = BuildLineOptions(new List<CommandOption>
         {
             LambdaDefinedCommandOptions.ARGUMENT_FUNCTION_NAME,
-            LambdaDefinedCommandOptions.ARGUMENT_PAYLOAD
+            LambdaDefinedCommandOptions.ARGUMENT_PAYLOAD,
+            LambdaDefinedCommandOptions.ARGUMENT_INVOKE_MODE
         });
 
         public string FunctionName { get; set; }
@@ -31,6 +60,11 @@ namespace Amazon.Lambda.Tools.Commands
         /// the value of Payload is sent as the input to the function.
         /// </summary>
         public string Payload { get; set; }
+
+        /// <summary>
+        /// How the function should be invoked. Defaults to <see cref="InvokeMode.RequestResponse"/>.
+        /// </summary>
+        public InvokeMode? Mode { get; set; }
 
         public InvokeFunctionCommand(IToolLogger logger, string workingDirectory, string[] args)
             : base(logger, workingDirectory, InvokeCommandOptions, args)
@@ -56,66 +90,720 @@ namespace Amazon.Lambda.Tools.Commands
                 this.FunctionName = tuple.Item2.StringValue;
             if ((tuple = values.FindCommandOption(LambdaDefinedCommandOptions.ARGUMENT_PAYLOAD.Switch)) != null)
                 this.Payload = tuple.Item2.StringValue;
+            if ((tuple = values.FindCommandOption(LambdaDefinedCommandOptions.ARGUMENT_INVOKE_MODE.Switch)) != null)
+                this.Mode = ParseInvokeMode(tuple.Item2.StringValue);
+        }
+
+        /// <summary>
+        /// Parse the --invoke-mode switch value into an <see cref="InvokeMode"/>.
+        /// </summary>
+        private static InvokeMode ParseInvokeMode(string value)
+        {
+            if (Enum.TryParse<InvokeMode>(value, true, out var mode) && Enum.IsDefined(typeof(InvokeMode), mode))
+            {
+                return mode;
+            }
+
+            throw new LambdaToolsException(
+                $"Invalid value \"{value}\" for {LambdaDefinedCommandOptions.ARGUMENT_INVOKE_MODE.Switch}. Valid values are: " +
+                $"{InvokeMode.RequestResponse}, {InvokeMode.Event}, {InvokeMode.Stream} or {InvokeMode.DurableExecution}.",
+                ToolsException.CommonErrorCode.CommandLineParseError);
         }
 
         protected override async Task<bool> PerformActionAsync()
         {
-            var invokeRequest = new InvokeRequest
-            {
-                FunctionName = this.GetStringValueOrDefault(this.FunctionName, LambdaDefinedCommandOptions.ARGUMENT_FUNCTION_NAME, true),
-                LogType = LogType.Tail
-            };
+            var functionName = this.GetStringValueOrDefault(this.FunctionName, LambdaDefinedCommandOptions.ARGUMENT_FUNCTION_NAME, true);
+            var payload = ResolvePayload();
+            var mode = this.Mode ?? InvokeMode.RequestResponse;
 
-            if (!string.IsNullOrWhiteSpace(this.Payload))
-            {
-                if (File.Exists(this.Payload))
-                {
-                    Logger.WriteLine($"Reading {Path.GetFullPath(this.Payload)} as input to Lambda function");
-                    invokeRequest.Payload = File.ReadAllText(this.Payload);
-                }
-                else
-                {
-                    invokeRequest.Payload = this.Payload.Trim();
-                }
+            await LambdaUtilities.WaitTillFunctionAvailableAsync(this.Logger, this.LambdaClient, functionName);
 
-                // We should still check for empty payload in case it is read from a file.
-                if (!string.IsNullOrEmpty(invokeRequest.Payload))
+            switch (mode)
+            {
+                case InvokeMode.Stream:
+                    await InvokeWithResponseStreamAsync(functionName, payload);
+                    break;
+                case InvokeMode.Event:
+                    await InvokeEventAsync(functionName, payload);
+                    break;
+                case InvokeMode.DurableExecution:
+                    await InvokeDurableExecutionAsync(functionName, payload);
+                    break;
+                default:
+                    await InvokeRequestResponseAsync(functionName, payload);
+                    break;
+            }
+
+            return true;
+        }
+
+        /// <summary>
+        /// Resolves the payload to send to the function. If <see cref="Payload"/> points to an existing file then
+        /// the contents of the file are used, otherwise the raw value is used. Scalar values that are not already
+        /// valid JSON are wrapped in quotes so they are sent as valid JSON strings.
+        /// </summary>
+        private string ResolvePayload()
+        {
+            if (string.IsNullOrWhiteSpace(this.Payload))
+            {
+                return null;
+            }
+
+            string payload;
+            if (File.Exists(this.Payload))
+            {
+                Logger.WriteLine($"Reading {Path.GetFullPath(this.Payload)} as input to Lambda function");
+                payload = File.ReadAllText(this.Payload);
+            }
+            else
+            {
+                payload = this.Payload.Trim();
+            }
+
+            // We should still check for empty payload in case it is read from a file.
+            if (!string.IsNullOrEmpty(payload))
+            {
+                if (payload[0] != '\"' && payload[0] != '{' && payload[0] != '[')
                 {
-                    if (invokeRequest.Payload[0] != '\"' && invokeRequest.Payload[0] != '{' && invokeRequest.Payload[0] != '[')
+                    double d;
+                    long l;
+                    bool b;
+                    if (!double.TryParse(payload, out d) && !long.TryParse(payload, out l) &&
+                        !bool.TryParse(payload, out b))
                     {
-                        double d;
-                        long l;
-                        bool b;
-                        if (!double.TryParse(invokeRequest.Payload, out d) && !long.TryParse(invokeRequest.Payload, out l) &&
-                            !bool.TryParse(invokeRequest.Payload, out b))
-                        {
-                            invokeRequest.Payload = "\"" + invokeRequest.Payload + "\"";
-                        }
+                        payload = "\"" + payload + "\"";
                     }
                 }
             }
 
+            return payload;
+        }
+
+        /// <summary>
+        /// Invoke the function synchronously (RequestResponse) and print the response payload and log tail.
+        /// </summary>
+        private async Task InvokeRequestResponseAsync(string functionName, string payload)
+        {
+            var invokeRequest = new InvokeRequest
+            {
+                FunctionName = functionName,
+                LogType = LogType.Tail,
+                InvocationType = InvocationType.RequestResponse,
+                Payload = payload
+            };
+
             InvokeResponse response;
             try
             {
-                await LambdaUtilities.WaitTillFunctionAvailableAsync(this.Logger, this.LambdaClient, invokeRequest.FunctionName);
                 response = await this.LambdaClient.InvokeAsync(invokeRequest);
             }
-            catch(Exception e)
+            catch (Exception e)
             {
                 throw new LambdaToolsException("Error invoking Lambda function: " + e.Message, LambdaToolsException.LambdaErrorCode.LambdaInvokeFunction, e);
             }
 
-            this.Logger.WriteLine("Payload:");
+            if (!string.IsNullOrEmpty(response.FunctionError))
+            {
+                this.Logger.WriteLine($"Function error: {response.FunctionError}");
+            }
 
+            this.Logger.WriteLine("Payload:");
             PrintPayload(response);
 
             this.Logger.WriteLine("");
             this.Logger.WriteLine("Log Tail:");
             var log = System.Text.UTF8Encoding.UTF8.GetString(Convert.FromBase64String(response.LogResult));
             this.Logger.WriteLine(log);
+        }
 
-            return true;
+        /// <summary>
+        /// Invoke the function asynchronously (Event). Lambda does not return a payload for asynchronous
+        /// invocations so display any function error and the durable execution ARN if one was returned.
+        /// </summary>
+        private async Task InvokeEventAsync(string functionName, string payload)
+        {
+            var invokeRequest = new InvokeRequest
+            {
+                FunctionName = functionName,
+                InvocationType = InvocationType.Event,
+                Payload = payload
+            };
+
+            InvokeResponse response;
+            try
+            {
+                response = await this.LambdaClient.InvokeAsync(invokeRequest);
+            }
+            catch (Exception e)
+            {
+                throw new LambdaToolsException("Error invoking Lambda function: " + e.Message, LambdaToolsException.LambdaErrorCode.LambdaInvokeFunction, e);
+            }
+
+            this.Logger.WriteLine($"Request to invoke function accepted (HTTP status code {(int)response.StatusCode}).");
+
+            if (!string.IsNullOrEmpty(response.FunctionError))
+            {
+                this.Logger.WriteLine($"Function error: {response.FunctionError}");
+            }
+
+            if (!string.IsNullOrEmpty(response.DurableExecutionArn))
+            {
+                this.Logger.WriteLine($"Durable execution ARN: {response.DurableExecutionArn}");
+            }
+        }
+
+        /// <summary>
+        /// Invoke a function configured for durable execution. The function is invoked asynchronously
+        /// (InvocationType Event), the durable execution ARN is grabbed from the response and the execution
+        /// is then monitored by polling the GetDurableExecution and GetDurableExecutionHistory APIs until
+        /// it completes. If the supplied function name is not an ARN the latest published version is resolved
+        /// and its ARN is used for the invocation.
+        /// </summary>
+        private async Task InvokeDurableExecutionAsync(string functionName, string payload)
+        {
+            var resolvedFunctionArn = await ResolveDurableFunctionArnAsync(functionName);
+
+            var invokeRequest = new InvokeRequest
+            {
+                FunctionName = resolvedFunctionArn,
+                InvocationType = InvocationType.Event,
+                Payload = payload
+            };
+
+            InvokeResponse response;
+            try
+            {
+                response = await this.LambdaClient.InvokeAsync(invokeRequest);
+            }
+            catch (Exception e)
+            {
+                throw new LambdaToolsException("Error invoking Lambda function: " + e.Message, LambdaToolsException.LambdaErrorCode.LambdaInvokeFunction, e);
+            }
+
+            if (!string.IsNullOrEmpty(response.FunctionError))
+            {
+                this.Logger.WriteLine($"Function error: {response.FunctionError}");
+            }
+
+            if (string.IsNullOrEmpty(response.DurableExecutionArn))
+            {
+                throw new LambdaToolsException(
+                    "The function invocation did not return a durable execution ARN. Confirm the function is configured for durable execution.",
+                    LambdaToolsException.LambdaErrorCode.LambdaInvokeFunction);
+            }
+
+            this.Logger.WriteLine($"Durable execution ARN: {response.DurableExecutionArn}");
+
+            await MonitorDurableExecutionAsync(response.DurableExecutionArn);
+        }
+
+        /// <summary>
+        /// Resolves the function ARN to use for a durable execution invocation. If the supplied value is already
+        /// an ARN it is returned unchanged. Otherwise the latest published version is looked up and its ARN is used.
+        /// If the function has no published versions an error is reported.
+        /// </summary>
+        private async Task<string> ResolveDurableFunctionArnAsync(string functionName)
+        {
+            if (functionName.StartsWith("arn:", StringComparison.OrdinalIgnoreCase))
+            {
+                return functionName;
+            }
+
+            FunctionConfiguration latestVersion = null;
+            try
+            {
+                string marker = null;
+                do
+                {
+                    var listResponse = await this.LambdaClient.ListVersionsByFunctionAsync(new ListVersionsByFunctionRequest
+                    {
+                        FunctionName = functionName,
+                        Marker = marker
+                    });
+
+                    if (listResponse.Versions != null)
+                    {
+                        foreach (var version in listResponse.Versions)
+                        {
+                            // Skip the $LATEST pseudo-version, only published numeric versions are considered.
+                            if (!long.TryParse(version.Version, out var versionNumber))
+                            {
+                                continue;
+                            }
+
+                            if (latestVersion == null || versionNumber > long.Parse(latestVersion.Version))
+                            {
+                                latestVersion = version;
+                            }
+                        }
+                    }
+
+                    marker = listResponse.NextMarker;
+                } while (!string.IsNullOrEmpty(marker));
+            }
+            catch (Exception e)
+            {
+                throw new LambdaToolsException($"Error looking up versions for Lambda function {functionName}: {e.Message}", LambdaToolsException.LambdaErrorCode.LambdaListVersions, e);
+            }
+
+            if (latestVersion == null)
+            {
+                throw new LambdaToolsException(
+                    $"No published versions were found for Lambda function {functionName}. A published version is required to invoke a durable execution.",
+                    LambdaToolsException.LambdaErrorCode.NoFunctionVersionsFound);
+            }
+
+            this.Logger.WriteLine($"Resolved latest version {latestVersion.Version} for function {functionName} to ARN: {latestVersion.FunctionArn}");
+            return latestVersion.FunctionArn;
+        }
+
+        /// <summary>
+        /// Polls the GetDurableExecution and GetDurableExecutionHistory APIs to monitor a durable execution,
+        /// writing new history events and status changes to the console until the execution reaches a terminal state.
+        /// </summary>
+        private async Task MonitorDurableExecutionAsync(string durableExecutionArn)
+        {
+            const int POLL_INTERVAL = 3000;
+
+            this.Logger.WriteLine("");
+            this.Logger.WriteLine("Monitoring durable execution progress:");
+
+            var seenEventIds = new HashSet<int>();
+            GetDurableExecutionResponse execution = null;
+
+            while (true)
+            {
+                try
+                {
+                    execution = await this.LambdaClient.GetDurableExecutionAsync(new GetDurableExecutionRequest
+                    {
+                        DurableExecutionArn = durableExecutionArn
+                    });
+
+                    await WriteNewHistoryEventsAsync(durableExecutionArn, seenEventIds);
+                }
+                catch (ResourceNotFoundException)
+                {
+                    // It is possible for the durable execution to not be immediately visible after the invocation returns, so treat a not found error as an empty execution history and keep polling until it appears.
+                    await Task.Delay(POLL_INTERVAL);
+                    continue;
+                }
+                catch (Exception e)
+                {
+                    throw new LambdaToolsException($"Error monitoring durable execution: {e.Message}", LambdaToolsException.LambdaErrorCode.LambdaGetDurableExecution, e);
+                }
+
+                if (execution.Status != ExecutionStatus.RUNNING)
+                {
+                    break;
+                }
+
+                await Task.Delay(POLL_INTERVAL);
+            }
+
+            this.Logger.WriteLine("");
+            this.Logger.WriteLine($"Durable execution finished with status: {execution.Status}");
+
+            if (!string.IsNullOrEmpty(execution.Result))
+            {
+                this.Logger.WriteLine("Result:");
+                this.Logger.WriteLine(execution.Result);
+            }
+
+            if (execution.Error != null)
+            {
+                this.Logger.WriteLine("Error:");
+                if (!string.IsNullOrEmpty(execution.Error.ErrorType))
+                {
+                    this.Logger.WriteLine($"   Type: {execution.Error.ErrorType}");
+                }
+                if (!string.IsNullOrEmpty(execution.Error.ErrorMessage))
+                {
+                    this.Logger.WriteLine($"   Message: {execution.Error.ErrorMessage}");
+                }
+                if (execution.Error.StackTrace != null && execution.Error.StackTrace.Count > 0)
+                {
+                    this.Logger.WriteLine("   Stack Trace:");
+                    foreach (var frame in execution.Error.StackTrace)
+                    {
+                        this.Logger.WriteLine($"      {frame}");
+                    }
+                }
+            }
+        }
+
+        /// <summary>
+        /// Fetches the durable execution history and writes any events that have not already been written to the console.
+        /// </summary>
+        private async Task WriteNewHistoryEventsAsync(string durableExecutionArn, HashSet<int> seenEventIds)
+        {
+            string marker = null;
+            do
+            {
+                var historyResponse = await this.LambdaClient.GetDurableExecutionHistoryAsync(new GetDurableExecutionHistoryRequest
+                {
+                    DurableExecutionArn = durableExecutionArn,
+                    IncludeExecutionData = true,
+                    Marker = marker
+                });
+
+                if (historyResponse.Events != null)
+                {
+                    foreach (var historyEvent in historyResponse.Events)
+                    {
+                        if (historyEvent.EventId.HasValue && !seenEventIds.Add(historyEvent.EventId.Value))
+                        {
+                            continue;
+                        }
+
+                        var timestamp = historyEvent.EventTimestamp.HasValue
+                            ? historyEvent.EventTimestamp.Value.ToString("u")
+                            : string.Empty;
+                        this.Logger.WriteLine($"   [{timestamp}] {historyEvent.Name}: {historyEvent.EventType}".TrimEnd());
+
+                        WriteEventDetails(historyEvent);
+                    }
+                }
+
+                marker = historyResponse.NextMarker;
+            } while (!string.IsNullOrEmpty(marker));
+        }
+
+        /// <summary>
+        /// The maximum number of characters of a string field that will be written to the console. Larger string
+        /// payload fields in the durable execution details are truncated to this length.
+        /// </summary>
+        private const int MAX_PAYLOAD_DISPLAY_LENGTH = 1000;
+
+        // Indentation used when writing the details of a durable execution history event.
+        private const string DETAILS_INDENT = "      ";
+        private const string DETAILS_INDENT2 = "         ";
+
+        /// <summary>
+        /// Each durable execution history <see cref="Event"/> carries at most one populated "*Details" object
+        /// describing what happened (e.g. ExecutionStartedDetails, StepSucceededDetails). Inspect each known detail
+        /// type and write out its contents.
+        /// </summary>
+        private void WriteEventDetails(Event historyEvent)
+        {
+            if (historyEvent.ExecutionStartedDetails != null)
+            {
+                var d = historyEvent.ExecutionStartedDetails;
+                WriteValue("Execution Timeout", d.ExecutionTimeout);
+                WriteEventInput(d.Input);
+            }
+            else if (historyEvent.ExecutionSucceededDetails != null)
+            {
+                WriteEventResult(historyEvent.ExecutionSucceededDetails.Result);
+            }
+            else if (historyEvent.ExecutionFailedDetails != null)
+            {
+                WriteEventError(historyEvent.ExecutionFailedDetails.Error);
+            }
+            else if (historyEvent.ExecutionStoppedDetails != null)
+            {
+                WriteEventError(historyEvent.ExecutionStoppedDetails.Error);
+            }
+            else if (historyEvent.ExecutionTimedOutDetails != null)
+            {
+                WriteEventError(historyEvent.ExecutionTimedOutDetails.Error);
+            }
+            else if (historyEvent.StepStartedDetails != null)
+            {
+                // StepStartedDetails has no fields.
+            }
+            else if (historyEvent.StepSucceededDetails != null)
+            {
+                var d = historyEvent.StepSucceededDetails;
+                WriteEventResult(d.Result);
+                WriteRetryDetails(d.RetryDetails);
+            }
+            else if (historyEvent.StepFailedDetails != null)
+            {
+                var d = historyEvent.StepFailedDetails;
+                WriteEventError(d.Error);
+                WriteRetryDetails(d.RetryDetails);
+            }
+            else if (historyEvent.WaitStartedDetails != null)
+            {
+                var d = historyEvent.WaitStartedDetails;
+                WriteValue("Duration", d.Duration);
+                WriteValue("Scheduled End Timestamp", d.ScheduledEndTimestamp);
+            }
+            else if (historyEvent.WaitSucceededDetails != null)
+            {
+                WriteValue("Duration", historyEvent.WaitSucceededDetails.Duration);
+            }
+            else if (historyEvent.WaitCancelledDetails != null)
+            {
+                WriteEventError(historyEvent.WaitCancelledDetails.Error);
+            }
+            else if (historyEvent.CallbackStartedDetails != null)
+            {
+                var d = historyEvent.CallbackStartedDetails;
+                WriteValue("Callback Id", d.CallbackId);
+                WriteValue("Heartbeat Timeout", d.HeartbeatTimeout);
+                WriteValue("Timeout", d.Timeout);
+            }
+            else if (historyEvent.CallbackSucceededDetails != null)
+            {
+                WriteEventResult(historyEvent.CallbackSucceededDetails.Result);
+            }
+            else if (historyEvent.CallbackFailedDetails != null)
+            {
+                WriteEventError(historyEvent.CallbackFailedDetails.Error);
+            }
+            else if (historyEvent.CallbackTimedOutDetails != null)
+            {
+                WriteEventError(historyEvent.CallbackTimedOutDetails.Error);
+            }
+            else if (historyEvent.ChainedInvokeStartedDetails != null)
+            {
+                var d = historyEvent.ChainedInvokeStartedDetails;
+                WriteValue("Function Name", d.FunctionName);
+                WriteValue("Executed Version", d.ExecutedVersion);
+                WriteValue("Durable Execution Arn", d.DurableExecutionArn);
+                WriteValue("Tenant Id", d.TenantId);
+                WriteEventInput(d.Input);
+            }
+            else if (historyEvent.ChainedInvokeSucceededDetails != null)
+            {
+                WriteEventResult(historyEvent.ChainedInvokeSucceededDetails.Result);
+            }
+            else if (historyEvent.ChainedInvokeFailedDetails != null)
+            {
+                WriteEventError(historyEvent.ChainedInvokeFailedDetails.Error);
+            }
+            else if (historyEvent.ChainedInvokeStoppedDetails != null)
+            {
+                WriteEventError(historyEvent.ChainedInvokeStoppedDetails.Error);
+            }
+            else if (historyEvent.ChainedInvokeTimedOutDetails != null)
+            {
+                WriteEventError(historyEvent.ChainedInvokeTimedOutDetails.Error);
+            }
+            else if (historyEvent.ContextStartedDetails != null)
+            {
+                // ContextStartedDetails has no fields.
+            }
+            else if (historyEvent.ContextSucceededDetails != null)
+            {
+                WriteEventResult(historyEvent.ContextSucceededDetails.Result);
+            }
+            else if (historyEvent.ContextFailedDetails != null)
+            {
+                WriteEventError(historyEvent.ContextFailedDetails.Error);
+            }
+            else if (historyEvent.InvocationCompletedDetails != null)
+            {
+                var d = historyEvent.InvocationCompletedDetails;
+                WriteValue("Request Id", d.RequestId);
+                WriteValue("Start Timestamp", d.StartTimestamp);
+                WriteValue("End Timestamp", d.EndTimestamp);
+                WriteEventError(d.Error);
+            }
+        }
+
+        /// <summary>
+        /// Writes the payload of an <see cref="EventInput"/>. If the payload is null nothing is written so the
+        /// Truncated flag is never reported on its own.
+        /// </summary>
+        private void WriteEventInput(EventInput input)
+        {
+            if (input?.Payload == null)
+            {
+                return;
+            }
+
+            WritePayload("Input", input.Payload, input.Truncated);
+        }
+
+        /// <summary>
+        /// Writes the payload of an <see cref="EventResult"/>. If the payload is null nothing is written so the
+        /// Truncated flag is never reported on its own.
+        /// </summary>
+        private void WriteEventResult(EventResult result)
+        {
+            if (result?.Payload == null)
+            {
+                return;
+            }
+
+            WritePayload("Result", result.Payload, result.Truncated);
+        }
+
+        /// <summary>
+        /// Writes the contents of an <see cref="EventError"/>. If the error payload is null nothing is written so the
+        /// Truncated flag is never reported on its own.
+        /// </summary>
+        private void WriteEventError(EventError error)
+        {
+            var errorObject = error?.Payload;
+            if (errorObject == null)
+            {
+                return;
+            }
+
+            this.Logger.WriteLine($"{DETAILS_INDENT}Error:");
+            if (!string.IsNullOrEmpty(errorObject.ErrorType))
+            {
+                this.Logger.WriteLine($"{DETAILS_INDENT2}Type: {errorObject.ErrorType}");
+            }
+            if (!string.IsNullOrEmpty(errorObject.ErrorMessage))
+            {
+                this.Logger.WriteLine($"{DETAILS_INDENT2}Message: {Truncate(errorObject.ErrorMessage)}");
+            }
+            if (!string.IsNullOrEmpty(errorObject.ErrorData))
+            {
+                this.Logger.WriteLine($"{DETAILS_INDENT2}Data: {Truncate(errorObject.ErrorData)}");
+            }
+            if (errorObject.StackTrace != null && errorObject.StackTrace.Count > 0)
+            {
+                this.Logger.WriteLine($"{DETAILS_INDENT2}Stack Trace:");
+                foreach (var frame in errorObject.StackTrace)
+                {
+                    this.Logger.WriteLine($"{DETAILS_INDENT2}   {frame}");
+                }
+            }
+
+            // Only note truncation when there was actually a payload, which is guaranteed here.
+            if (error.Truncated == true)
+            {
+                this.Logger.WriteLine($"{DETAILS_INDENT2}(error payload was truncated by the service)");
+            }
+        }
+
+        /// <summary>
+        /// Writes the details of a <see cref="RetryDetails"/> if present.
+        /// </summary>
+        private void WriteRetryDetails(RetryDetails retryDetails)
+        {
+            if (retryDetails == null)
+            {
+                return;
+            }
+
+            WriteValue("Current Attempt", retryDetails.CurrentAttempt);
+            WriteValue("Next Attempt Delay Seconds", retryDetails.NextAttemptDelaySeconds);
+        }
+
+        /// <summary>
+        /// Writes a named payload string, truncating it for display, and noting when the service marked the payload
+        /// as truncated. The caller must only invoke this when the payload is non-null.
+        /// </summary>
+        private void WritePayload(string label, string payload, bool? truncatedByService)
+        {
+            this.Logger.WriteLine($"{DETAILS_INDENT}{label}: {Truncate(payload)}");
+
+            // Only report the service truncation flag here where we know the payload was present.
+            if (truncatedByService == true)
+            {
+                this.Logger.WriteLine($"{DETAILS_INDENT2}({label.ToLowerInvariant()} payload was truncated by the service)");
+            }
+        }
+
+        /// <summary>
+        /// Writes a labelled value if it is not null or empty.
+        /// </summary>
+        private void WriteValue(string label, string value)
+        {
+            if (!string.IsNullOrEmpty(value))
+            {
+                this.Logger.WriteLine($"{DETAILS_INDENT}{label}: {value}");
+            }
+        }
+
+        /// <summary>
+        /// Writes a labelled nullable value if it has a value.
+        /// </summary>
+        private void WriteValue<T>(string label, T? value) where T : struct
+        {
+            if (value.HasValue)
+            {
+                this.Logger.WriteLine($"{DETAILS_INDENT}{label}: {value.Value}");
+            }
+        }
+
+        /// <summary>
+        /// Truncates a string to <see cref="MAX_PAYLOAD_DISPLAY_LENGTH"/> characters, appending a note when the value
+        /// was truncated so the user knows the payload was not shown in full.
+        /// </summary>
+        private static string Truncate(string value)
+        {
+            if (value != null && value.Length > MAX_PAYLOAD_DISPLAY_LENGTH)
+            {
+                return value.Substring(0, MAX_PAYLOAD_DISPLAY_LENGTH) +
+                    $"... [payload truncated, showing first {MAX_PAYLOAD_DISPLAY_LENGTH} of {value.Length} characters]";
+            }
+
+            return value;
+        }
+
+        /// <summary>
+        /// Invoke the function and stream the response payload to the console as it is produced by the function.
+        /// </summary>
+        private async Task InvokeWithResponseStreamAsync(string functionName, string payload)
+        {
+            var invokeRequest = new InvokeWithResponseStreamRequest
+            {
+                FunctionName = functionName,
+                LogType = LogType.Tail
+            };
+
+            if (!string.IsNullOrEmpty(payload))
+            {
+                invokeRequest.Payload = new MemoryStream(System.Text.UTF8Encoding.UTF8.GetBytes(payload));
+            }
+
+            this.Logger.WriteLine("Payload:");
+
+            string logResult = null;
+            string errorCode = null;
+            string errorDetails = null;
+            try
+            {
+                using (var response = await this.LambdaClient.InvokeWithResponseStreamAsync(invokeRequest))
+                {
+                    foreach (var streamEvent in response.EventStream)
+                    {
+                        if (streamEvent is InvokeResponseStreamUpdate update && update.Payload != null)
+                        {
+                            var chunk = System.Text.UTF8Encoding.UTF8.GetString(update.Payload.ToArray());
+                            this.Logger.Write(chunk);
+                        }
+                        else if (streamEvent is InvokeWithResponseStreamCompleteEvent complete)
+                        {
+                            logResult = complete.LogResult;
+                            errorCode = complete.ErrorCode;
+                            errorDetails = complete.ErrorDetails;
+                        }
+                    }
+                }
+            }
+            catch (Exception e)
+            {
+                throw new LambdaToolsException("Error invoking Lambda function: " + e.Message, LambdaToolsException.LambdaErrorCode.LambdaInvokeFunction, e);
+            }
+
+            // Terminate the streamed payload with a newline so following output is on its own line.
+            this.Logger.WriteLine("");
+
+            if (!string.IsNullOrEmpty(errorCode))
+            {
+                this.Logger.WriteLine($"Function error: {errorCode}");
+                if (!string.IsNullOrEmpty(errorDetails))
+                {
+                    this.Logger.WriteLine(errorDetails);
+                }
+            }
+
+            if (!string.IsNullOrEmpty(logResult))
+            {
+                this.Logger.WriteLine("");
+                this.Logger.WriteLine("Log Tail:");
+                var log = System.Text.UTF8Encoding.UTF8.GetString(Convert.FromBase64String(logResult));
+                this.Logger.WriteLine(log);
+            }
         }
 
 
@@ -131,11 +819,12 @@ namespace Amazon.Lambda.Tools.Commands
                 this.Logger.WriteLine("<unparseable data>");
             }
         }
-        
+
         protected override void SaveConfigFile(Dictionary<string, object> data)
         {
-            data.SetIfNotNull(LambdaDefinedCommandOptions.ARGUMENT_FUNCTION_NAME.ConfigFileKey, this.GetStringValueOrDefault(this.FunctionName, LambdaDefinedCommandOptions.ARGUMENT_FUNCTION_NAME, false));    
-            data.SetIfNotNull(LambdaDefinedCommandOptions.ARGUMENT_PAYLOAD.ConfigFileKey, this.GetStringValueOrDefault(this.Payload, LambdaDefinedCommandOptions.ARGUMENT_PAYLOAD, false));              
+            data.SetIfNotNull(LambdaDefinedCommandOptions.ARGUMENT_FUNCTION_NAME.ConfigFileKey, this.GetStringValueOrDefault(this.FunctionName, LambdaDefinedCommandOptions.ARGUMENT_FUNCTION_NAME, false));
+            data.SetIfNotNull(LambdaDefinedCommandOptions.ARGUMENT_PAYLOAD.ConfigFileKey, this.GetStringValueOrDefault(this.Payload, LambdaDefinedCommandOptions.ARGUMENT_PAYLOAD, false));
+            data.SetIfNotNull(LambdaDefinedCommandOptions.ARGUMENT_INVOKE_MODE.ConfigFileKey, this.Mode?.ToString());
         }
     }
 }

--- a/src/Amazon.Lambda.Tools/Commands/UpdateFunctionConfigCommand.cs
+++ b/src/Amazon.Lambda.Tools/Commands/UpdateFunctionConfigCommand.cs
@@ -238,6 +238,7 @@ namespace Amazon.Lambda.Tools.Commands
                     FunctionName = functionName
                 });
                 this.Logger.WriteLine("Published new Lambda function version: " + response.Version);
+                this.Logger.WriteLine("Function version arn: " + response.FunctionArn);
             }
             catch (Exception e)
             {

--- a/src/Amazon.Lambda.Tools/Commands/UpdateFunctionConfigCommand.cs
+++ b/src/Amazon.Lambda.Tools/Commands/UpdateFunctionConfigCommand.cs
@@ -238,7 +238,7 @@ namespace Amazon.Lambda.Tools.Commands
                     FunctionName = functionName
                 });
                 this.Logger.WriteLine("Published new Lambda function version: " + response.Version);
-                this.Logger.WriteLine("Function version arn: " + response.FunctionArn);
+                this.Logger.WriteLine("Function version ARN: " + response.FunctionArn);
             }
             catch (Exception e)
             {

--- a/src/Amazon.Lambda.Tools/Exceptions.cs
+++ b/src/Amazon.Lambda.Tools/Exceptions.cs
@@ -56,6 +56,10 @@ namespace Amazon.Lambda.Tools
             ParseLayerVersionArnFail,
             LambdaWaitTillFunctionAvailable,
 
+            LambdaListVersions,
+            NoFunctionVersionsFound,
+            LambdaGetDurableExecution,
+
             UnknownLayerType,
             StoreCommandError,
             FailedToFindArtifactZip,

--- a/src/Amazon.Lambda.Tools/LambdaDefinedCommandOptions.cs
+++ b/src/Amazon.Lambda.Tools/LambdaDefinedCommandOptions.cs
@@ -317,6 +317,16 @@ namespace Amazon.Lambda.Tools
                 Description = "The input payload to send to the Lambda function"
             };
 
+        public static readonly CommandOption ARGUMENT_INVOKE_MODE =
+            new CommandOption
+            {
+                Name = "Invoke mode",
+                ShortSwitch = "-im",
+                Switch = "--invoke-mode",
+                ValueType = CommandOption.CommandOptionValueType.StringValue,
+                Description = "How the function is invoked. Valid values are: RequestResponse, Event, Stream or DurableExecution. Default is RequestResponse."
+            };
+
         public static readonly CommandOption ARGUMENT_OUTPUT_PACKAGE =
             new CommandOption
             {

--- a/test/Amazon.Common.DotNetCli.Tools.Test/Mocks/MockToolLogger.cs
+++ b/test/Amazon.Common.DotNetCli.Tools.Test/Mocks/MockToolLogger.cs
@@ -19,5 +19,10 @@ public class MockToolLogger : IToolLogger
         _sbLog.Append('\n');
     }
 
+    public void Write(string text)
+    {
+        _sbLog.Append(text);
+    }
+
     public string Log => _sbLog.ToString();
 }

--- a/test/Amazon.Lambda.Tools.Integ.Tests/TestToolLogger.cs
+++ b/test/Amazon.Lambda.Tools.Integ.Tests/TestToolLogger.cs
@@ -25,6 +25,12 @@ namespace Amazon.Lambda.Tools.Integ.Tests
             this.WriteLine(string.Format(message, args));
         }
 
+        public void Write(string message)
+        {
+            this._buffer.Append(message);
+            _testOutputHelper?.WriteLine(message);
+        }
+
         public void ClearBuffer()
         {
             this._buffer.Clear();

--- a/test/Amazon.Lambda.Tools.Test/InvokeFunctionCommandTests.cs
+++ b/test/Amazon.Lambda.Tools.Test/InvokeFunctionCommandTests.cs
@@ -35,14 +35,27 @@ namespace Amazon.Lambda.Tools.Test
             return mockLambda;
         }
 
-        private static InvokeFunctionCommand CreateCommand(TestToolLogger logger, IAmazonLambda lambdaClient, params string[] args)
+        private static TestableInvokeFunctionCommand CreateCommand(TestToolLogger logger, IAmazonLambda lambdaClient, params string[] args)
         {
-            var command = new InvokeFunctionCommand(logger, Directory.GetCurrentDirectory(), args)
+            var command = new TestableInvokeFunctionCommand(logger, Directory.GetCurrentDirectory(), args)
             {
                 LambdaClient = lambdaClient,
                 DisableInteractive = true
             };
             return command;
+        }
+
+        /// <summary>
+        /// Test subclass that makes the durable execution polling delay a no-op so polling tests run instantly.
+        /// </summary>
+        private class TestableInvokeFunctionCommand : InvokeFunctionCommand
+        {
+            public TestableInvokeFunctionCommand(IToolLogger logger, string workingDirectory, string[] args)
+                : base(logger, workingDirectory, args)
+            {
+            }
+
+            protected override Task PollDelayAsync() => Task.CompletedTask;
         }
 
         [Theory]
@@ -80,6 +93,21 @@ namespace Amazon.Lambda.Tools.Test
 
             Assert.Contains("NotAMode", ex.Message);
             Assert.Contains("RequestResponse", ex.Message);
+        }
+
+        [Theory]
+        [InlineData("0")]
+        [InlineData("1")]
+        [InlineData("-1")]
+        public void ParseNumericInvokeModeThrows(string value)
+        {
+            // Numeric values must be rejected even though they map to enum members, since the CLI only documents
+            // the named values.
+            var ex = Assert.Throws<LambdaToolsException>(() =>
+                new InvokeFunctionCommand(new TestToolLogger(), Directory.GetCurrentDirectory(),
+                    new[] { FunctionName, "--invoke-mode", value }));
+
+            Assert.Contains(value, ex.Message);
         }
 
         [Fact]
@@ -432,6 +460,34 @@ namespace Amazon.Lambda.Tools.Test
             Assert.DoesNotContain("Result:", logger.Buffer);
             Assert.DoesNotContain("Error:", logger.Buffer);
             Assert.DoesNotContain("truncated", logger.Buffer);
+        }
+
+        [Theory]
+        // Already valid JSON values are sent unchanged (including scalars such as numbers, booleans, null and strings).
+        [InlineData("{\"key\":\"value\"}", "{\"key\":\"value\"}")]
+        [InlineData("[1,2,3]", "[1,2,3]")]
+        [InlineData("123", "123")]
+        [InlineData("true", "true")]
+        [InlineData("null", "null")]
+        [InlineData("\"already a json string\"", "\"already a json string\"")]
+        // Non-JSON values are serialized as a JSON string with proper escaping.
+        [InlineData("hello world", "\"hello world\"")]
+        [InlineData("a \"quoted\" value", "\"a \\u0022quoted\\u0022 value\"")]
+        public async Task ResolvePayloadProducesValidJson(string input, string expectedPayload)
+        {
+            var mockLambda = CreateAvailableLambdaMock();
+            InvokeRequest capturedRequest = null;
+            mockLambda.Setup(client => client.InvokeAsync(It.IsAny<InvokeRequest>(), It.IsAny<CancellationToken>()))
+                .Callback<InvokeRequest, CancellationToken>((r, t) => capturedRequest = r)
+                .Returns(Task.FromResult(new InvokeResponse { StatusCode = 202 }));
+
+            var logger = new TestToolLogger();
+            var command = CreateCommand(logger, mockLambda.Object, FunctionName, "--invoke-mode", "Event", "--payload", input);
+
+            Assert.True(await command.ExecuteAsync());
+
+            Assert.NotNull(capturedRequest);
+            Assert.Equal(expectedPayload, capturedRequest.Payload);
         }
     }
 }

--- a/test/Amazon.Lambda.Tools.Test/InvokeFunctionCommandTests.cs
+++ b/test/Amazon.Lambda.Tools.Test/InvokeFunctionCommandTests.cs
@@ -1,0 +1,437 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Net;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Amazon.Common.DotNetCli.Tools;
+using Amazon.Lambda.Model;
+using Amazon.Lambda.Tools.Commands;
+
+using Moq;
+using Xunit;
+
+namespace Amazon.Lambda.Tools.Test
+{
+    public class InvokeFunctionCommandTests
+    {
+        const string FunctionName = "fakeFunction";
+
+        /// <summary>
+        /// Creates a mock Lambda client that reports the function as immediately available so the
+        /// WaitTillFunctionAvailableAsync call made by the command completes without delay.
+        /// </summary>
+        private static Mock<IAmazonLambda> CreateAvailableLambdaMock()
+        {
+            var mockLambda = new Mock<IAmazonLambda>();
+            mockLambda.Setup(client => client.GetFunctionConfigurationAsync(It.IsAny<GetFunctionConfigurationRequest>(), It.IsAny<CancellationToken>()))
+                .Returns(Task.FromResult(new GetFunctionConfigurationResponse
+                {
+                    State = State.Active,
+                    LastUpdateStatus = LastUpdateStatus.Successful
+                }));
+            return mockLambda;
+        }
+
+        private static InvokeFunctionCommand CreateCommand(TestToolLogger logger, IAmazonLambda lambdaClient, params string[] args)
+        {
+            var command = new InvokeFunctionCommand(logger, Directory.GetCurrentDirectory(), args)
+            {
+                LambdaClient = lambdaClient,
+                DisableInteractive = true
+            };
+            return command;
+        }
+
+        [Theory]
+        [InlineData("RequestResponse", InvokeFunctionCommand.InvokeMode.RequestResponse)]
+        [InlineData("requestresponse", InvokeFunctionCommand.InvokeMode.RequestResponse)]
+        [InlineData("Event", InvokeFunctionCommand.InvokeMode.Event)]
+        [InlineData("event", InvokeFunctionCommand.InvokeMode.Event)]
+        [InlineData("Stream", InvokeFunctionCommand.InvokeMode.Stream)]
+        [InlineData("STREAM", InvokeFunctionCommand.InvokeMode.Stream)]
+        [InlineData("DurableExecution", InvokeFunctionCommand.InvokeMode.DurableExecution)]
+        [InlineData("durableexecution", InvokeFunctionCommand.InvokeMode.DurableExecution)]
+        public void ParseInvokeModeOption(string value, InvokeFunctionCommand.InvokeMode expected)
+        {
+            var command = new InvokeFunctionCommand(new TestToolLogger(), Directory.GetCurrentDirectory(),
+                new[] { FunctionName, "--invoke-mode", value });
+
+            Assert.Equal(expected, command.Mode);
+        }
+
+        [Fact]
+        public void InvokeModeDefaultsToNull()
+        {
+            var command = new InvokeFunctionCommand(new TestToolLogger(), Directory.GetCurrentDirectory(),
+                new[] { FunctionName });
+
+            Assert.Null(command.Mode);
+        }
+
+        [Fact]
+        public void ParseInvalidInvokeModeThrows()
+        {
+            var ex = Assert.Throws<LambdaToolsException>(() =>
+                new InvokeFunctionCommand(new TestToolLogger(), Directory.GetCurrentDirectory(),
+                    new[] { FunctionName, "--invoke-mode", "NotAMode" }));
+
+            Assert.Contains("NotAMode", ex.Message);
+            Assert.Contains("RequestResponse", ex.Message);
+        }
+
+        [Fact]
+        public async Task RequestResponseIsTheDefaultInvocationType()
+        {
+            var mockLambda = CreateAvailableLambdaMock();
+            InvokeRequest capturedRequest = null;
+            mockLambda.Setup(client => client.InvokeAsync(It.IsAny<InvokeRequest>(), It.IsAny<CancellationToken>()))
+                .Callback<InvokeRequest, CancellationToken>((r, t) => capturedRequest = r)
+                .Returns(Task.FromResult(new InvokeResponse
+                {
+                    StatusCode = 200,
+                    Payload = new MemoryStream(Encoding.UTF8.GetBytes("\"hello\"")),
+                    LogResult = Convert.ToBase64String(Encoding.UTF8.GetBytes("the logs"))
+                }));
+
+            var logger = new TestToolLogger();
+            var command = CreateCommand(logger, mockLambda.Object, FunctionName);
+
+            Assert.True(await command.ExecuteAsync());
+
+            Assert.NotNull(capturedRequest);
+            Assert.Equal(InvocationType.RequestResponse, capturedRequest.InvocationType);
+            Assert.Equal(LogType.Tail, capturedRequest.LogType);
+            Assert.Contains("\"hello\"", logger.Buffer);
+            Assert.Contains("the logs", logger.Buffer);
+        }
+
+        [Fact]
+        public async Task RequestResponseReportsFunctionError()
+        {
+            var mockLambda = CreateAvailableLambdaMock();
+            mockLambda.Setup(client => client.InvokeAsync(It.IsAny<InvokeRequest>(), It.IsAny<CancellationToken>()))
+                .Returns(Task.FromResult(new InvokeResponse
+                {
+                    StatusCode = 200,
+                    FunctionError = "Unhandled",
+                    Payload = new MemoryStream(Encoding.UTF8.GetBytes("{\"errorMessage\":\"boom\"}")),
+                    LogResult = Convert.ToBase64String(Encoding.UTF8.GetBytes("the logs"))
+                }));
+
+            var logger = new TestToolLogger();
+            var command = CreateCommand(logger, mockLambda.Object, FunctionName, "--invoke-mode", "RequestResponse");
+
+            Assert.True(await command.ExecuteAsync());
+
+            Assert.Contains("Unhandled", logger.Buffer);
+        }
+
+        [Fact]
+        public async Task EventModeUsesEventInvocationType()
+        {
+            var mockLambda = CreateAvailableLambdaMock();
+            InvokeRequest capturedRequest = null;
+            mockLambda.Setup(client => client.InvokeAsync(It.IsAny<InvokeRequest>(), It.IsAny<CancellationToken>()))
+                .Callback<InvokeRequest, CancellationToken>((r, t) => capturedRequest = r)
+                .Returns(Task.FromResult(new InvokeResponse
+                {
+                    StatusCode = 202
+                }));
+
+            var logger = new TestToolLogger();
+            var command = CreateCommand(logger, mockLambda.Object, FunctionName, "--invoke-mode", "Event");
+
+            Assert.True(await command.ExecuteAsync());
+
+            Assert.NotNull(capturedRequest);
+            Assert.Equal(InvocationType.Event, capturedRequest.InvocationType);
+        }
+
+        [Fact]
+        public async Task EventModeDisplaysFunctionErrorAndDurableExecutionArn()
+        {
+            const string durableArn = "arn:aws:lambda:us-east-1:123456789012:function:fakeFunction:$LATEST/durable-execution/abc/def";
+            var mockLambda = CreateAvailableLambdaMock();
+            mockLambda.Setup(client => client.InvokeAsync(It.IsAny<InvokeRequest>(), It.IsAny<CancellationToken>()))
+                .Returns(Task.FromResult(new InvokeResponse
+                {
+                    StatusCode = 202,
+                    FunctionError = "Unhandled",
+                    DurableExecutionArn = durableArn
+                }));
+
+            var logger = new TestToolLogger();
+            var command = CreateCommand(logger, mockLambda.Object, FunctionName, "--invoke-mode", "Event");
+
+            Assert.True(await command.ExecuteAsync());
+
+            Assert.Contains("Unhandled", logger.Buffer);
+            Assert.Contains(durableArn, logger.Buffer);
+        }
+
+        [Fact]
+        public async Task DurableExecutionResolvesLatestVersionArnWhenNameIsNotArn()
+        {
+            const string functionArnV2 = "arn:aws:lambda:us-east-1:123456789012:function:fakeFunction:2";
+            const string durableArn = "arn:aws:lambda:us-east-1:123456789012:function:fakeFunction:2/durable-execution/abc/def";
+
+            var mockLambda = CreateAvailableLambdaMock();
+            mockLambda.Setup(client => client.ListVersionsByFunctionAsync(It.IsAny<ListVersionsByFunctionRequest>(), It.IsAny<CancellationToken>()))
+                .Returns(Task.FromResult(new ListVersionsByFunctionResponse
+                {
+                    Versions = new System.Collections.Generic.List<FunctionConfiguration>
+                    {
+                        new FunctionConfiguration { Version = "$LATEST", FunctionArn = "arn:aws:lambda:us-east-1:123456789012:function:fakeFunction:$LATEST" },
+                        new FunctionConfiguration { Version = "1", FunctionArn = "arn:aws:lambda:us-east-1:123456789012:function:fakeFunction:1" },
+                        new FunctionConfiguration { Version = "2", FunctionArn = functionArnV2 }
+                    }
+                }));
+
+            InvokeRequest capturedInvoke = null;
+            mockLambda.Setup(client => client.InvokeAsync(It.IsAny<InvokeRequest>(), It.IsAny<CancellationToken>()))
+                .Callback<InvokeRequest, CancellationToken>((r, t) => capturedInvoke = r)
+                .Returns(Task.FromResult(new InvokeResponse { StatusCode = 202, DurableExecutionArn = durableArn }));
+
+            mockLambda.Setup(client => client.GetDurableExecutionAsync(It.IsAny<GetDurableExecutionRequest>(), It.IsAny<CancellationToken>()))
+                .Returns(Task.FromResult(new GetDurableExecutionResponse { Status = ExecutionStatus.SUCCEEDED, Result = "\"done\"" }));
+            mockLambda.Setup(client => client.GetDurableExecutionHistoryAsync(It.IsAny<GetDurableExecutionHistoryRequest>(), It.IsAny<CancellationToken>()))
+                .Returns(Task.FromResult(new GetDurableExecutionHistoryResponse()));
+
+            var logger = new TestToolLogger();
+            var command = CreateCommand(logger, mockLambda.Object, FunctionName, "--invoke-mode", "DurableExecution");
+
+            Assert.True(await command.ExecuteAsync());
+
+            // The latest published version (2) should be resolved and used for the invocation.
+            Assert.Equal(functionArnV2, capturedInvoke.FunctionName);
+            Assert.Equal(InvocationType.Event, capturedInvoke.InvocationType);
+            Assert.Contains("Resolved latest version 2", logger.Buffer);
+            Assert.Contains(functionArnV2, logger.Buffer);
+            Assert.Contains("SUCCEEDED", logger.Buffer);
+            Assert.Contains("\"done\"", logger.Buffer);
+        }
+
+        [Fact]
+        public async Task DurableExecutionUsesProvidedArnWithoutVersionLookup()
+        {
+            const string functionArn = "arn:aws:lambda:us-east-1:123456789012:function:fakeFunction:3";
+            const string durableArn = "arn:aws:lambda:us-east-1:123456789012:function:fakeFunction:3/durable-execution/abc/def";
+
+            var mockLambda = CreateAvailableLambdaMock();
+            InvokeRequest capturedInvoke = null;
+            mockLambda.Setup(client => client.InvokeAsync(It.IsAny<InvokeRequest>(), It.IsAny<CancellationToken>()))
+                .Callback<InvokeRequest, CancellationToken>((r, t) => capturedInvoke = r)
+                .Returns(Task.FromResult(new InvokeResponse { StatusCode = 202, DurableExecutionArn = durableArn }));
+            mockLambda.Setup(client => client.GetDurableExecutionAsync(It.IsAny<GetDurableExecutionRequest>(), It.IsAny<CancellationToken>()))
+                .Returns(Task.FromResult(new GetDurableExecutionResponse { Status = ExecutionStatus.SUCCEEDED }));
+            mockLambda.Setup(client => client.GetDurableExecutionHistoryAsync(It.IsAny<GetDurableExecutionHistoryRequest>(), It.IsAny<CancellationToken>()))
+                .Returns(Task.FromResult(new GetDurableExecutionHistoryResponse()));
+
+            var logger = new TestToolLogger();
+            var command = CreateCommand(logger, mockLambda.Object, functionArn, "--invoke-mode", "DurableExecution");
+
+            Assert.True(await command.ExecuteAsync());
+
+            Assert.Equal(functionArn, capturedInvoke.FunctionName);
+            mockLambda.Verify(client => client.ListVersionsByFunctionAsync(It.IsAny<ListVersionsByFunctionRequest>(), It.IsAny<CancellationToken>()), Times.Never);
+        }
+
+        [Fact]
+        public async Task DurableExecutionThrowsWhenNoVersionsFound()
+        {
+            var mockLambda = CreateAvailableLambdaMock();
+            mockLambda.Setup(client => client.ListVersionsByFunctionAsync(It.IsAny<ListVersionsByFunctionRequest>(), It.IsAny<CancellationToken>()))
+                .Returns(Task.FromResult(new ListVersionsByFunctionResponse
+                {
+                    Versions = new System.Collections.Generic.List<FunctionConfiguration>
+                    {
+                        new FunctionConfiguration { Version = "$LATEST", FunctionArn = "arn:aws:lambda:us-east-1:123456789012:function:fakeFunction:$LATEST" }
+                    }
+                }));
+
+            var logger = new TestToolLogger();
+            var command = CreateCommand(logger, mockLambda.Object, FunctionName, "--invoke-mode", "DurableExecution");
+
+            // ExecuteAsync catches ToolsException, reports it, and returns false.
+            Assert.False(await command.ExecuteAsync());
+            var ex = Assert.IsType<LambdaToolsException>(command.LastException);
+            Assert.Equal(LambdaToolsException.LambdaErrorCode.NoFunctionVersionsFound.ToString(), ex.Code);
+            Assert.Contains("No published versions", ex.Message);
+        }
+
+        [Fact]
+        public async Task DurableExecutionPollsUntilTerminalStatusAndWritesHistory()
+        {
+            const string durableArn = "arn:aws:lambda:us-east-1:123456789012:function:fakeFunction:1/durable-execution/abc/def";
+
+            var mockLambda = CreateAvailableLambdaMock();
+            mockLambda.Setup(client => client.InvokeAsync(It.IsAny<InvokeRequest>(), It.IsAny<CancellationToken>()))
+                .Returns(Task.FromResult(new InvokeResponse { StatusCode = 202, DurableExecutionArn = durableArn }));
+
+            // First two polls report RUNNING, then SUCCEEDED.
+            var statusSequence = new Queue<ExecutionStatus>(new[] { ExecutionStatus.RUNNING, ExecutionStatus.RUNNING, ExecutionStatus.SUCCEEDED });
+            mockLambda.Setup(client => client.GetDurableExecutionAsync(It.IsAny<GetDurableExecutionRequest>(), It.IsAny<CancellationToken>()))
+                .Returns(() => Task.FromResult(new GetDurableExecutionResponse
+                {
+                    Status = statusSequence.Count > 1 ? statusSequence.Dequeue() : statusSequence.Peek()
+                }));
+
+            var historyCallCount = 0;
+            mockLambda.Setup(client => client.GetDurableExecutionHistoryAsync(It.IsAny<GetDurableExecutionHistoryRequest>(), It.IsAny<CancellationToken>()))
+                .Returns(() =>
+                {
+                    historyCallCount++;
+                    var events = new System.Collections.Generic.List<Event>();
+                    // Surface a new event on the first poll and a duplicate plus a new one on later polls.
+                    if (historyCallCount == 1)
+                    {
+                        events.Add(new Event { EventId = 1, EventType = EventType.ExecutionStarted });
+                    }
+                    else
+                    {
+                        events.Add(new Event { EventId = 1, EventType = EventType.ExecutionStarted });
+                        events.Add(new Event { EventId = 2, EventType = EventType.ExecutionSucceeded });
+                    }
+                    return Task.FromResult(new GetDurableExecutionHistoryResponse { Events = events });
+                });
+
+            var logger = new TestToolLogger();
+            var command = CreateCommand(logger, mockLambda.Object, "arn:aws:lambda:us-east-1:123456789012:function:fakeFunction:1", "--invoke-mode", "DurableExecution");
+
+            Assert.True(await command.ExecuteAsync());
+
+            Assert.Contains("ExecutionStarted", logger.Buffer);
+            Assert.Contains("ExecutionSucceeded", logger.Buffer);
+            Assert.Contains("status: SUCCEEDED", logger.Buffer);
+            // Each event should only be written once even though the history is returned repeatedly.
+            var startedOccurrences = logger.Buffer.Split(new[] { "ExecutionStarted" }, StringSplitOptions.None).Length - 1;
+            Assert.Equal(1, startedOccurrences);
+        }
+
+        [Fact]
+        public async Task DurableExecutionDisplaysEventDetailsAndTruncatesLargePayloads()
+        {
+            const string durableArn = "arn:aws:lambda:us-east-1:123456789012:function:fakeFunction:1/durable-execution/abc/def";
+            const string functionArn = "arn:aws:lambda:us-east-1:123456789012:function:fakeFunction:1";
+
+            // A result payload larger than the 1000 character display limit so we can verify truncation.
+            var largePayload = new string('x', 2500);
+
+            var mockLambda = CreateAvailableLambdaMock();
+            mockLambda.Setup(client => client.InvokeAsync(It.IsAny<InvokeRequest>(), It.IsAny<CancellationToken>()))
+                .Returns(Task.FromResult(new InvokeResponse { StatusCode = 202, DurableExecutionArn = durableArn }));
+            mockLambda.Setup(client => client.GetDurableExecutionAsync(It.IsAny<GetDurableExecutionRequest>(), It.IsAny<CancellationToken>()))
+                .Returns(Task.FromResult(new GetDurableExecutionResponse { Status = ExecutionStatus.SUCCEEDED }));
+
+            mockLambda.Setup(client => client.GetDurableExecutionHistoryAsync(It.IsAny<GetDurableExecutionHistoryRequest>(), It.IsAny<CancellationToken>()))
+                .Returns(() => Task.FromResult(new GetDurableExecutionHistoryResponse
+                {
+                    Events = new List<Event>
+                    {
+                        new Event
+                        {
+                            EventId = 1,
+                            EventType = EventType.StepSucceeded,
+                            Name = "MyStep",
+                            StepSucceededDetails = new StepSucceededDetails
+                            {
+                                Result = new EventResult { Payload = largePayload }
+                            }
+                        },
+                        new Event
+                        {
+                            EventId = 2,
+                            EventType = EventType.StepFailed,
+                            Name = "MyFailingStep",
+                            StepFailedDetails = new StepFailedDetails
+                            {
+                                Error = new EventError
+                                {
+                                    Payload = new ErrorObject
+                                    {
+                                        ErrorType = "MyError",
+                                        ErrorMessage = "something went wrong"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }));
+
+            var logger = new TestToolLogger();
+            var command = CreateCommand(logger, mockLambda.Object, functionArn, "--invoke-mode", "DurableExecution");
+
+            Assert.True(await command.ExecuteAsync());
+
+            // Detail fields should be expanded and displayed.
+            Assert.Contains("Result:", logger.Buffer);
+            Assert.Contains("Type: MyError", logger.Buffer);
+            Assert.Contains("Message: something went wrong", logger.Buffer);
+
+            // The large payload should be truncated and a truncation note shown.
+            Assert.Contains("payload truncated, showing first 1000 of 2500 characters", logger.Buffer);
+            Assert.DoesNotContain(new string('x', 1001), logger.Buffer);
+            Assert.Contains(new string('x', 1000), logger.Buffer);
+        }
+
+        [Fact]
+        public async Task DurableExecutionDoesNotReportTruncatedWhenPayloadIsNull()
+        {
+            const string durableArn = "arn:aws:lambda:us-east-1:123456789012:function:fakeFunction:1/durable-execution/abc/def";
+            const string functionArn = "arn:aws:lambda:us-east-1:123456789012:function:fakeFunction:1";
+
+            var mockLambda = CreateAvailableLambdaMock();
+            mockLambda.Setup(client => client.InvokeAsync(It.IsAny<InvokeRequest>(), It.IsAny<CancellationToken>()))
+                .Returns(Task.FromResult(new InvokeResponse { StatusCode = 202, DurableExecutionArn = durableArn }));
+            mockLambda.Setup(client => client.GetDurableExecutionAsync(It.IsAny<GetDurableExecutionRequest>(), It.IsAny<CancellationToken>()))
+                .Returns(Task.FromResult(new GetDurableExecutionResponse { Status = ExecutionStatus.SUCCEEDED }));
+
+            mockLambda.Setup(client => client.GetDurableExecutionHistoryAsync(It.IsAny<GetDurableExecutionHistoryRequest>(), It.IsAny<CancellationToken>()))
+                .Returns(() => Task.FromResult(new GetDurableExecutionHistoryResponse
+                {
+                    Events = new List<Event>
+                    {
+                        // Result event whose payload is null but the service set Truncated to true.
+                        new Event
+                        {
+                            EventId = 1,
+                            EventType = EventType.StepSucceeded,
+                            Name = "EmptyResultStep",
+                            StepSucceededDetails = new StepSucceededDetails
+                            {
+                                Result = new EventResult { Payload = null, Truncated = true }
+                            }
+                        },
+                        // Error event whose error payload is null but the service set Truncated to true.
+                        new Event
+                        {
+                            EventId = 2,
+                            EventType = EventType.StepFailed,
+                            Name = "EmptyErrorStep",
+                            StepFailedDetails = new StepFailedDetails
+                            {
+                                Error = new EventError { Payload = null, Truncated = true }
+                            }
+                        }
+                    }
+                }));
+
+            var logger = new TestToolLogger();
+            var command = CreateCommand(logger, mockLambda.Object, functionArn, "--invoke-mode", "DurableExecution");
+
+            Assert.True(await command.ExecuteAsync());
+
+            // The event headers are still written.
+            Assert.Contains("EmptyResultStep", logger.Buffer);
+            Assert.Contains("EmptyErrorStep", logger.Buffer);
+
+            // But nothing should be written about a result/error payload or truncation when there was no payload.
+            Assert.DoesNotContain("Result:", logger.Buffer);
+            Assert.DoesNotContain("Error:", logger.Buffer);
+            Assert.DoesNotContain("truncated", logger.Buffer);
+        }
+    }
+}

--- a/test/Amazon.Lambda.Tools.Test/TestToolLogger.cs
+++ b/test/Amazon.Lambda.Tools.Test/TestToolLogger.cs
@@ -30,6 +30,12 @@ namespace Amazon.Lambda.Tools.Test
             this.WriteLine(string.Format(message, args));
         }
 
+        public void Write(string message)
+        {
+            this._buffer.Append(message);
+            _testOutputHelper?.WriteLine(message);
+        }
+
         public void ClearBuffer()
         {
             this._buffer.Clear();

--- a/test/Amazon.Tools.TestHelpers/TestToolLogger.cs
+++ b/test/Amazon.Tools.TestHelpers/TestToolLogger.cs
@@ -19,6 +19,11 @@ namespace Amazon.Tools.TestHelpers
             this._buffer.AppendLine(string.Format(message, args));
         }
 
+        public void Write(string message)
+        {
+            this._buffer.Append(message);
+        }
+
         public void ClearBuffer()
         {
             this._buffer.Clear();


### PR DESCRIPTION
*Description of changes:*

Adds a new `--invoke-mode` (`-im`) switch to the `dotnet lambda invoke-function` command. The switch controls how the function is invoked and supports four values:

| Value | Behavior |
| --- | --- |
| `RequestResponse` (default) | Existing behavior. Invokes synchronously, then writes the response payload, any function error, and the log tail. |
| `Event` | Invokes asynchronously (`InvocationType=Event`). Displays any function error and the durable execution ARN returned by the service. |
| `Stream` | Invokes with `InvokeWithResponseStream` and streams the response payload to the console as it is produced. |
| `DurableExecution` | Invokes a durable function and monitors the execution to completion (details below). |

`RequestResponse` remains the default, so existing usage is unchanged.

### DurableExecution mode

When `--invoke-mode DurableExecution` is used:

1. **Version resolution** — Durable executions must target a published version. If the supplied function name is **not** an ARN, the command resolves the latest published version via `ListVersionsByFunction` and uses that version's ARN, writing the resolved ARN to the console. If the function has no published versions, an error is reported. If an ARN is supplied it is used as-is.
2. **Invoke** — The function is invoked asynchronously (`InvocationType=Event`) and the `DurableExecutionArn` is read from the response.
3. **Monitor** — The execution is monitored by polling `GetDurableExecution` and `GetDurableExecutionHistory` until it reaches a terminal state. Each history event is printed once, along with its associated details (step inputs, results, errors, wait/retry/invocation info, etc.). Large string payload fields are truncated to the first 1000 characters with a note that the payload was truncated. A `Truncated` flag is only ever reported when an actual payload was present.

### Other changes

* The `deploy-function` and `update-function-config` commands now write the new function version ARN to the output when `--function-publish` is set to `true`.
* Added a `Write` (no newline) method to `IToolLogger` to support streaming output.

### Example: durable function

Given a durable workflow that fans out into three branches, each generating a GUID inside a step and then performing a durable wait (forcing a suspend/resume cycle so the second invocation must replay the cached GUID rather than re-running the step):

```csharp
private async Task<TestResult> Workflow(TestEvent input, IDurableContext context)
{
    // Three branches. Each branch generates a fresh GUID inside a step,
    // then does a durable wait. The wait forces a suspend/resume cycle,
    // so the second invocation MUST replay the cached GUID rather than
    // re-running the step. If replay determinism is broken, the GUID
    // would change between the original execution and replay.
    var batch = await context.ParallelAsync(
        new[]
        {
            new DurableBranch<string>("a", BranchAsync),
            new DurableBranch<string>("b", BranchAsync),
            new DurableBranch<string>("c", BranchAsync),
        },
        name: "fanout");

    var joined = string.Join(",", batch.GetResults());
    return new TestResult { Status = "completed", Data = joined };
}

private static async Task<string> BranchAsync(IDurableContext ctx, System.Threading.CancellationToken cancellationToken)
{
    var generatedId = await ctx.StepAsync(
        async (_, _) => { await Task.CompletedTask; return Guid.NewGuid().ToString(); },
        name: "generate");

    // Force a suspend/resume cycle to trigger replay of the parallel.
    await ctx.WaitAsync(TimeSpan.FromSeconds(2), name: "boundary");

    return generatedId;
}
```

Running `dotnet lambda invoke-function DurableFunctionContainerExample --invoke-mode DurableExecution` produces:

```
Project Home: https://github.com/aws/aws-extensions-for-dotnet-cli, https://github.com/aws/aws-lambda-dotnet

Resolved latest version 8 for function DurableFunctionContainerExample to ARN: arn:aws:lambda:us-west-2:626492997873:function:DurableFunctionContainerExample:8
Durable execution ARN: arn:aws:lambda:us-west-2:626492997873:function:DurableFunctionContainerExample:8/durable-execution/f11d786c-562c-4498-b4f4-fb05692b1a8f/253387b0-654c-3fb1-911f-7890b53c054e

Monitoring durable execution progress:
   [2026-06-17 23:53:05Z] f11d786c-562c-4498-b4f4-fb05692b1a8f: ExecutionStarted
      Execution Timeout: 900
      Input: {"OrderId": "foo"}
   [2026-06-17 23:53:08Z] fanout: ContextStarted
   [2026-06-17 23:53:08Z] a: ContextStarted
   [2026-06-17 23:53:08Z] b: ContextStarted
   [2026-06-17 23:53:08Z] c: ContextStarted
   [2026-06-17 23:53:08Z] generate: StepStarted
   [2026-06-17 23:53:08Z] generate: StepSucceeded
      Result: "f99a44ea-fa6c-4ede-af29-14a0189cbe92"
      Current Attempt: 1
   [2026-06-17 23:53:08Z] generate: StepStarted
   [2026-06-17 23:53:08Z] generate: StepStarted
   [2026-06-17 23:53:08Z] generate: StepSucceeded
      Result: "8fc93e46-24e5-497d-b8fa-7b2ce1787424"
      Current Attempt: 1
   [2026-06-17 23:53:08Z] generate: StepSucceeded
      Result: "4b556bda-b988-4fae-b7ec-3b8bbba2fd2a"
      Current Attempt: 1
   [2026-06-17 23:53:08Z] boundary: WaitStarted
      Duration: 2
      Scheduled End Timestamp: 6/17/2026 11:53:10 PM
   [2026-06-17 23:53:08Z] boundary: WaitStarted
      Duration: 2
      Scheduled End Timestamp: 6/17/2026 11:53:10 PM
   [2026-06-17 23:53:08Z] boundary: WaitStarted
      Duration: 2
      Scheduled End Timestamp: 6/17/2026 11:53:10 PM
   [2026-06-17 23:53:08Z] : InvocationCompleted
      Request Id: b6851360-3705-48df-8356-e361d1006360
      Start Timestamp: 6/17/2026 11:53:05 PM
      End Timestamp: 6/17/2026 11:53:08 PM
   [2026-06-17 23:53:10Z] boundary: WaitSucceeded
      Duration: 2
   [2026-06-17 23:53:10Z] boundary: WaitSucceeded
      Duration: 2
   [2026-06-17 23:53:10Z] boundary: WaitSucceeded
      Duration: 2
   [2026-06-17 23:53:10Z] a: ContextSucceeded
      Result: "f99a44ea-fa6c-4ede-af29-14a0189cbe92"
   [2026-06-17 23:53:10Z] b: ContextSucceeded
      Result: "4b556bda-b988-4fae-b7ec-3b8bbba2fd2a"
   [2026-06-17 23:53:10Z] c: ContextSucceeded
      Result: "8fc93e46-24e5-497d-b8fa-7b2ce1787424"
   [2026-06-17 23:53:10Z] fanout: ContextSucceeded
      Result: {"CompletionReason":"ALL_COMPLETED","Branches":[{"Index":0,"Name":"a","Status":"SUCCEEDED"},{"Index":1,"Name":"b","Status":"SUCCEEDED"},{"Index":2,"Name":"c","Status":"SUCCEEDED"}]}
   [2026-06-17 23:53:10Z] : InvocationCompleted
      Request Id: 84646b4a-36f0-4a3a-91ed-c23a9b6823aa
      Start Timestamp: 6/17/2026 11:53:10 PM
      End Timestamp: 6/17/2026 11:53:10 PM
   [2026-06-17 23:53:10Z] f11d786c-562c-4498-b4f4-fb05692b1a8f: ExecutionSucceeded
      Result: {"Status":"completed","Data":"f99a44ea-fa6c-4ede-af29-14a0189cbe92,4b556bda-b988-4fae-b7ec-3b8bbba2fd2a,8fc93e46-24e5-497d-b8fa-7b2ce1787424"}

Durable execution finished with status: SUCCEEDED
Result:
{"Status":"completed","Data":"f99a44ea-fa6c-4ede-af29-14a0189cbe92,4b556bda-b988-4fae-b7ec-3b8bbba2fd2a,8fc93e46-24e5-497d-b8fa-7b2ce1787424"}
```

Note how the replayed `generate` step results (the GUIDs) match between the original execution and the post-wait replay, confirming replay determinism.

### Testing

Added unit tests in `InvokeFunctionCommandTests` covering invoke-mode parsing/validation, the RequestResponse/Event/Stream paths, durable version resolution (including the no-published-versions error), execution monitoring/polling, history event detail rendering, and payload truncation (including that the `Truncated` flag is not reported when there is no payload).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
