### PR TITLE
Add license headers

### DIFF
--- a/src/Amazon.Common.DotNetCli.Tools/AbstractCLIWrapper.cs
+++ b/src/Amazon.Common.DotNetCli.Tools/AbstractCLIWrapper.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;

--- a/src/Amazon.Common.DotNetCli.Tools/AssumeRoleMfaTokenCodeCallback.cs
+++ b/src/Amazon.Common.DotNetCli.Tools/AssumeRoleMfaTokenCodeCallback.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
 using System.Collections.Generic;
 using System.Text;
 

--- a/src/Amazon.Common.DotNetCli.Tools/Cli/Application.cs
+++ b/src/Amazon.Common.DotNetCli.Tools/Cli/Application.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
 using System.Collections.Generic;
 using System.Text;
 using System.Reflection;

--- a/src/Amazon.Common.DotNetCli.Tools/Commands/BaseCommand.cs
+++ b/src/Amazon.Common.DotNetCli.Tools/Commands/BaseCommand.cs
@@ -1,4 +1,7 @@
-﻿using Amazon.Common.DotNetCli.Tools.Options;
+﻿// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using Amazon.Common.DotNetCli.Tools.Options;
 using Amazon.Runtime;
 using Amazon.Runtime.CredentialManagement;
 using System;

--- a/src/Amazon.Common.DotNetCli.Tools/Commands/BasePushDockerImageCommand.cs
+++ b/src/Amazon.Common.DotNetCli.Tools/Commands/BasePushDockerImageCommand.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
 using System.Collections.Generic;
 using System.Text;
 using System.Threading.Tasks;

--- a/src/Amazon.Common.DotNetCli.Tools/Commands/CommandInfo.cs
+++ b/src/Amazon.Common.DotNetCli.Tools/Commands/CommandInfo.cs
@@ -1,4 +1,7 @@
-﻿using Amazon.Common.DotNetCli.Tools.Options;
+﻿// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using Amazon.Common.DotNetCli.Tools.Options;
 using System;
 using System.Collections.Generic;
 using System.Text;

--- a/src/Amazon.Common.DotNetCli.Tools/Commands/ICommand.cs
+++ b/src/Amazon.Common.DotNetCli.Tools/Commands/ICommand.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;

--- a/src/Amazon.Common.DotNetCli.Tools/Constants.cs
+++ b/src/Amazon.Common.DotNetCli.Tools/Constants.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/src/Amazon.Common.DotNetCli.Tools/DefaultConfigFile.cs
+++ b/src/Amazon.Common.DotNetCli.Tools/DefaultConfigFile.cs
@@ -1,4 +1,7 @@
-﻿using Amazon.Common.DotNetCli.Tools.Options;
+﻿// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using Amazon.Common.DotNetCli.Tools.Options;
 using System;
 using System.Collections.Generic;
 using System.IO;

--- a/src/Amazon.Common.DotNetCli.Tools/DockerCLIWrapper.cs
+++ b/src/Amazon.Common.DotNetCli.Tools/DockerCLIWrapper.cs
@@ -1,4 +1,7 @@
-﻿using Amazon.Common.DotNetCli.Tools;
+﻿// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using Amazon.Common.DotNetCli.Tools;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;

--- a/src/Amazon.Common.DotNetCli.Tools/DotNetCLIWrapper.cs
+++ b/src/Amazon.Common.DotNetCli.Tools/DotNetCLIWrapper.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;

--- a/src/Amazon.Common.DotNetCli.Tools/ExtensionMethods.cs
+++ b/src/Amazon.Common.DotNetCli.Tools/ExtensionMethods.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Text;

--- a/src/Amazon.Common.DotNetCli.Tools/IToolLogger.cs
+++ b/src/Amazon.Common.DotNetCli.Tools/IToolLogger.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;

--- a/src/Amazon.Common.DotNetCli.Tools/Options/CommandLineParser.cs
+++ b/src/Amazon.Common.DotNetCli.Tools/Options/CommandLineParser.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 

--- a/src/Amazon.Common.DotNetCli.Tools/Options/CommandOption.cs
+++ b/src/Amazon.Common.DotNetCli.Tools/Options/CommandOption.cs
@@ -1,3 +1,6 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/src/Amazon.Common.DotNetCli.Tools/Options/CommandOptionValue.cs
+++ b/src/Amazon.Common.DotNetCli.Tools/Options/CommandOptionValue.cs
@@ -1,3 +1,6 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/src/Amazon.Common.DotNetCli.Tools/Options/CommandOptions.cs
+++ b/src/Amazon.Common.DotNetCli.Tools/Options/CommandOptions.cs
@@ -1,3 +1,6 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/src/Amazon.Common.DotNetCli.Tools/Options/CommonDefinedCommandOptions.cs
+++ b/src/Amazon.Common.DotNetCli.Tools/Options/CommonDefinedCommandOptions.cs
@@ -1,4 +1,7 @@
-﻿
+﻿// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+
 using System;
 using System.Collections.Generic;
 using System.Text;

--- a/src/Amazon.Common.DotNetCli.Tools/PosixUserHelper.cs
+++ b/src/Amazon.Common.DotNetCli.Tools/PosixUserHelper.cs
@@ -1,3 +1,6 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 using System.Diagnostics;
 #if NETCOREAPP3_1_OR_GREATER
 using System.Runtime.InteropServices;

--- a/src/Amazon.Common.DotNetCli.Tools/ProcessFactory.cs
+++ b/src/Amazon.Common.DotNetCli.Tools/ProcessFactory.cs
@@ -1,3 +1,6 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 using System.Diagnostics;
 using System.Text;
 

--- a/src/Amazon.Common.DotNetCli.Tools/RoleHelper.cs
+++ b/src/Amazon.Common.DotNetCli.Tools/RoleHelper.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net;

--- a/src/Amazon.Common.DotNetCli.Tools/ToolkitConfigFileFetcher.cs
+++ b/src/Amazon.Common.DotNetCli.Tools/ToolkitConfigFileFetcher.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
 using System.Collections.Generic;
 using System.Net.Http;
 using System.Text;

--- a/src/Amazon.Common.DotNetCli.Tools/ToolsException.cs
+++ b/src/Amazon.Common.DotNetCli.Tools/ToolsException.cs
@@ -1,4 +1,7 @@
-﻿using Amazon.Runtime;
+﻿// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using Amazon.Runtime;
 using System;
 using System.Collections.Generic;
 using System.Text;

--- a/src/Amazon.Common.DotNetCli.Tools/Utilities.cs
+++ b/src/Amazon.Common.DotNetCli.Tools/Utilities.cs
@@ -1,4 +1,7 @@
-﻿using Amazon.Runtime;
+﻿// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using Amazon.Runtime;
 using Amazon.S3;
 using Amazon.S3.Model;
 using Amazon.S3.Transfer;

--- a/src/Amazon.ECS.Tools/Commands/CommandProperties.cs
+++ b/src/Amazon.ECS.Tools/Commands/CommandProperties.cs
@@ -1,4 +1,7 @@
-﻿using Amazon.Common.DotNetCli.Tools;
+﻿// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using Amazon.Common.DotNetCli.Tools;
 using Amazon.Common.DotNetCli.Tools.Options;
 using Amazon.Common.DotNetCli.Tools.Commands;
 using System;

--- a/src/Amazon.ECS.Tools/Commands/DeployScheduledTaskCommand.cs
+++ b/src/Amazon.ECS.Tools/Commands/DeployScheduledTaskCommand.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
 using System.Collections.Generic;
 using System.Text;
 using System.Threading.Tasks;

--- a/src/Amazon.ECS.Tools/Commands/DeployServiceCommand.cs
+++ b/src/Amazon.ECS.Tools/Commands/DeployServiceCommand.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
 using System.Linq;
 using System.Collections.Generic;
 using System.Text;

--- a/src/Amazon.ECS.Tools/Commands/DeployTaskCommand.cs
+++ b/src/Amazon.ECS.Tools/Commands/DeployTaskCommand.cs
@@ -1,4 +1,7 @@
-﻿using Amazon.Common.DotNetCli.Tools;
+﻿// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using Amazon.Common.DotNetCli.Tools;
 using Amazon.Common.DotNetCli.Tools.Options;
 using System;
 using System.Collections.Generic;

--- a/src/Amazon.ECS.Tools/Commands/ECSBaseCommand.cs
+++ b/src/Amazon.ECS.Tools/Commands/ECSBaseCommand.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;

--- a/src/Amazon.ECS.Tools/Commands/ECSBaseDeployCommand.cs
+++ b/src/Amazon.ECS.Tools/Commands/ECSBaseDeployCommand.cs
@@ -1,4 +1,7 @@
-﻿using Amazon.Common.DotNetCli.Tools;
+﻿// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using Amazon.Common.DotNetCli.Tools;
 using Amazon.Common.DotNetCli.Tools.Commands;
 using Amazon.Common.DotNetCli.Tools.Options;
 using System;

--- a/src/Amazon.ECS.Tools/Commands/PushDockerImageCommand.cs
+++ b/src/Amazon.ECS.Tools/Commands/PushDockerImageCommand.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
 using System.Collections.Generic;
 using System.Text;
 using System.Threading.Tasks;

--- a/src/Amazon.ECS.Tools/Constants.cs
+++ b/src/Amazon.ECS.Tools/Constants.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/src/Amazon.ECS.Tools/ECSDefinedCommandOptions.cs
+++ b/src/Amazon.ECS.Tools/ECSDefinedCommandOptions.cs
@@ -1,3 +1,6 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 using Amazon.Common.DotNetCli.Tools.Options;
 using System;
 using System.Collections.Generic;

--- a/src/Amazon.ECS.Tools/ECSToolsDefaults.cs
+++ b/src/Amazon.ECS.Tools/ECSToolsDefaults.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Text;

--- a/src/Amazon.ECS.Tools/ECSUtilities.cs
+++ b/src/Amazon.ECS.Tools/ECSUtilities.cs
@@ -1,4 +1,7 @@
-﻿using Amazon.Common.DotNetCli.Tools;
+﻿// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using Amazon.Common.DotNetCli.Tools;
 using Amazon.ECR;
 using Amazon.ECR.Model;
 using System;

--- a/src/Amazon.ECS.Tools/Exceptions.cs
+++ b/src/Amazon.ECS.Tools/Exceptions.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;

--- a/src/Amazon.ECS.Tools/Program.cs
+++ b/src/Amazon.ECS.Tools/Program.cs
@@ -1,4 +1,7 @@
-﻿using Amazon.Common.DotNetCli.Tools;
+﻿// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using Amazon.Common.DotNetCli.Tools;
 using Amazon.Common.DotNetCli.Tools.Commands;
 using Amazon.Common.DotNetCli.Tools.Options;
 using Amazon.ECS.Tools.Commands;

--- a/src/Amazon.ElasticBeanstalk.Tools/Commands/CommandProperties.cs
+++ b/src/Amazon.ElasticBeanstalk.Tools/Commands/CommandProperties.cs
@@ -1,4 +1,7 @@
-﻿using Amazon.Common.DotNetCli.Tools;
+﻿// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using Amazon.Common.DotNetCli.Tools;
 using Amazon.Common.DotNetCli.Tools.Options;
 using System;
 using System.Collections.Generic;

--- a/src/Amazon.ElasticBeanstalk.Tools/Commands/DeleteEnvironmentCommand.cs
+++ b/src/Amazon.ElasticBeanstalk.Tools/Commands/DeleteEnvironmentCommand.cs
@@ -1,4 +1,7 @@
-﻿using Amazon.Common.DotNetCli.Tools;
+﻿// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using Amazon.Common.DotNetCli.Tools;
 using Amazon.Common.DotNetCli.Tools.Options;
 using Amazon.ElasticBeanstalk.Model;
 using System;

--- a/src/Amazon.ElasticBeanstalk.Tools/Commands/DeployEnvironmentCommand.cs
+++ b/src/Amazon.ElasticBeanstalk.Tools/Commands/DeployEnvironmentCommand.cs
@@ -1,4 +1,7 @@
-﻿using Amazon.Common.DotNetCli.Tools;
+﻿// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using Amazon.Common.DotNetCli.Tools;
 using Amazon.Common.DotNetCli.Tools.Options;
 using Amazon.ElasticBeanstalk.Model;
 using System;

--- a/src/Amazon.ElasticBeanstalk.Tools/Commands/EBBaseCommand.cs
+++ b/src/Amazon.ElasticBeanstalk.Tools/Commands/EBBaseCommand.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/src/Amazon.ElasticBeanstalk.Tools/Commands/ListEnvironmentsCommand.cs
+++ b/src/Amazon.ElasticBeanstalk.Tools/Commands/ListEnvironmentsCommand.cs
@@ -1,4 +1,7 @@
-﻿using Amazon.Common.DotNetCli.Tools;
+﻿// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using Amazon.Common.DotNetCli.Tools;
 using Amazon.Common.DotNetCli.Tools.Options;
 using Amazon.ElasticBeanstalk.Model;
 using System;

--- a/src/Amazon.ElasticBeanstalk.Tools/Commands/PackageCommand.cs
+++ b/src/Amazon.ElasticBeanstalk.Tools/Commands/PackageCommand.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Threading.Tasks;

--- a/src/Amazon.ElasticBeanstalk.Tools/EBConstants.cs
+++ b/src/Amazon.ElasticBeanstalk.Tools/EBConstants.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
 using System.Collections.Generic;
 using System.Text;
 

--- a/src/Amazon.ElasticBeanstalk.Tools/EBDefinedCommandOptions.cs
+++ b/src/Amazon.ElasticBeanstalk.Tools/EBDefinedCommandOptions.cs
@@ -1,4 +1,7 @@
-﻿using Amazon.Common.DotNetCli.Tools.Options;
+﻿// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using Amazon.Common.DotNetCli.Tools.Options;
 using System;
 using System.Collections.Generic;
 using System.Text;

--- a/src/Amazon.ElasticBeanstalk.Tools/EBUtilities.cs
+++ b/src/Amazon.ElasticBeanstalk.Tools/EBUtilities.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;

--- a/src/Amazon.ElasticBeanstalk.Tools/ElasticBeanstalkToolsDefaults.cs
+++ b/src/Amazon.ElasticBeanstalk.Tools/ElasticBeanstalkToolsDefaults.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
 using System.Collections.Generic;
 using System.Text;
 using System.Text.Json;

--- a/src/Amazon.ElasticBeanstalk.Tools/Exceptions.cs
+++ b/src/Amazon.ElasticBeanstalk.Tools/Exceptions.cs
@@ -1,4 +1,7 @@
-﻿using Amazon.Common.DotNetCli.Tools;
+﻿// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using Amazon.Common.DotNetCli.Tools;
 using System;
 using System.Collections.Generic;
 using System.Text;

--- a/src/Amazon.ElasticBeanstalk.Tools/Program.cs
+++ b/src/Amazon.ElasticBeanstalk.Tools/Program.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
 
 using Amazon.Common.DotNetCli.Tools.CLi;
 using Amazon.Common.DotNetCli.Tools.Commands;

--- a/src/Amazon.ElasticBeanstalk.Tools/PublishOptions.cs
+++ b/src/Amazon.ElasticBeanstalk.Tools/PublishOptions.cs
@@ -1,4 +1,7 @@
-﻿using System.Globalization;
+﻿// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System.Globalization;
 using System.Text;
 
 namespace Amazon.ElasticBeanstalk.Tools

--- a/src/Amazon.Lambda.Tools/Commands/DeleteFunctionCommand.cs
+++ b/src/Amazon.Lambda.Tools/Commands/DeleteFunctionCommand.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Amazon.Common.DotNetCli.Tools;

--- a/src/Amazon.Lambda.Tools/Commands/DeleteLayerVersionCommand.cs
+++ b/src/Amazon.Lambda.Tools/Commands/DeleteLayerVersionCommand.cs
@@ -1,3 +1,6 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;

--- a/src/Amazon.Lambda.Tools/Commands/DeleteServerlessCommand.cs
+++ b/src/Amazon.Lambda.Tools/Commands/DeleteServerlessCommand.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 

--- a/src/Amazon.Lambda.Tools/Commands/DeployFunctionCommand.cs
+++ b/src/Amazon.Lambda.Tools/Commands/DeployFunctionCommand.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;

--- a/src/Amazon.Lambda.Tools/Commands/DeployServerlessCommand.cs
+++ b/src/Amazon.Lambda.Tools/Commands/DeployServerlessCommand.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;

--- a/src/Amazon.Lambda.Tools/Commands/GetFunctionConfigCommand.cs
+++ b/src/Amazon.Lambda.Tools/Commands/GetFunctionConfigCommand.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
 using System.Collections.Generic;
 using System.Net;
 using System.Text;

--- a/src/Amazon.Lambda.Tools/Commands/GetLayerVersionDetailsCommand.cs
+++ b/src/Amazon.Lambda.Tools/Commands/GetLayerVersionDetailsCommand.cs
@@ -1,3 +1,6 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 using System;
 using System.Collections.Generic;
 using System.IO;

--- a/src/Amazon.Lambda.Tools/Commands/InvokeFunctionCommand.cs
+++ b/src/Amazon.Lambda.Tools/Commands/InvokeFunctionCommand.cs
@@ -1,3 +1,6 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 using System;
 using System.Collections.Generic;
 using System.IO;

--- a/src/Amazon.Lambda.Tools/Commands/LambdaBaseCommand.cs
+++ b/src/Amazon.Lambda.Tools/Commands/LambdaBaseCommand.cs
@@ -1,4 +1,7 @@
-﻿using System.Collections.Generic;
+﻿// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System.Collections.Generic;
 
 using Amazon.CloudFormation;
 

--- a/src/Amazon.Lambda.Tools/Commands/ListFunctionCommand.cs
+++ b/src/Amazon.Lambda.Tools/Commands/ListFunctionCommand.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Amazon.Common.DotNetCli.Tools;

--- a/src/Amazon.Lambda.Tools/Commands/ListLayerVersionsCommand.cs
+++ b/src/Amazon.Lambda.Tools/Commands/ListLayerVersionsCommand.cs
@@ -1,3 +1,6 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;

--- a/src/Amazon.Lambda.Tools/Commands/ListLayersCommand.cs
+++ b/src/Amazon.Lambda.Tools/Commands/ListLayersCommand.cs
@@ -1,3 +1,6 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/src/Amazon.Lambda.Tools/Commands/ListServerlessCommand.cs
+++ b/src/Amazon.Lambda.Tools/Commands/ListServerlessCommand.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;

--- a/src/Amazon.Lambda.Tools/Commands/PackageCICommand.cs
+++ b/src/Amazon.Lambda.Tools/Commands/PackageCICommand.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Threading.Tasks;

--- a/src/Amazon.Lambda.Tools/Commands/PackageCommand.cs
+++ b/src/Amazon.Lambda.Tools/Commands/PackageCommand.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Threading.Tasks;

--- a/src/Amazon.Lambda.Tools/Commands/PublishLayerCommand.cs
+++ b/src/Amazon.Lambda.Tools/Commands/PublishLayerCommand.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Text.Json;

--- a/src/Amazon.Lambda.Tools/Commands/PushDockerImageCommand.cs
+++ b/src/Amazon.Lambda.Tools/Commands/PushDockerImageCommand.cs
@@ -1,4 +1,7 @@
-﻿using Amazon.Common.DotNetCli.Tools;
+﻿// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using Amazon.Common.DotNetCli.Tools;
 using Amazon.Common.DotNetCli.Tools.Commands;
 using Amazon.Common.DotNetCli.Tools.Options;
 using System;

--- a/src/Amazon.Lambda.Tools/Commands/PushLambdaImageResult.cs
+++ b/src/Amazon.Lambda.Tools/Commands/PushLambdaImageResult.cs
@@ -1,4 +1,7 @@
-﻿using Amazon.Common.DotNetCli.Tools;
+﻿// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using Amazon.Common.DotNetCli.Tools;
 using System;
 using System.Collections.Generic;
 using System.Text;

--- a/src/Amazon.Lambda.Tools/Commands/UpdateFunctionConfigCommand.cs
+++ b/src/Amazon.Lambda.Tools/Commands/UpdateFunctionConfigCommand.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;

--- a/src/Amazon.Lambda.Tools/Exceptions.cs
+++ b/src/Amazon.Lambda.Tools/Exceptions.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;

--- a/src/Amazon.Lambda.Tools/LambdaConstants.cs
+++ b/src/Amazon.Lambda.Tools/LambdaConstants.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;

--- a/src/Amazon.Lambda.Tools/LambdaDefinedCommandOptions.cs
+++ b/src/Amazon.Lambda.Tools/LambdaDefinedCommandOptions.cs
@@ -1,3 +1,6 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 using Amazon.Common.DotNetCli.Tools.Options;
 
 namespace Amazon.Lambda.Tools

--- a/src/Amazon.Lambda.Tools/LambdaDotNetCLIWrapper.cs
+++ b/src/Amazon.Lambda.Tools/LambdaDotNetCLIWrapper.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Text;

--- a/src/Amazon.Lambda.Tools/LambdaImageTagData.cs
+++ b/src/Amazon.Lambda.Tools/LambdaImageTagData.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/src/Amazon.Lambda.Tools/LambdaPackager.cs
+++ b/src/Amazon.Lambda.Tools/LambdaPackager.cs
@@ -1,3 +1,6 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;

--- a/src/Amazon.Lambda.Tools/LambdaToolsDefaults.cs
+++ b/src/Amazon.Lambda.Tools/LambdaToolsDefaults.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
 using System.Collections.Generic;
 using System.Text.Json;
 using Amazon.Common.DotNetCli.Tools;

--- a/src/Amazon.Lambda.Tools/LambdaUtilities.cs
+++ b/src/Amazon.Lambda.Tools/LambdaUtilities.cs
@@ -1,4 +1,7 @@
-﻿using Amazon.Common.DotNetCli.Tools;
+﻿// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using Amazon.Common.DotNetCli.Tools;
 using Amazon.Lambda.Model;
 using Amazon.S3;
 using Amazon.S3.Model;

--- a/src/Amazon.Lambda.Tools/LayerDescriptionManifest.cs
+++ b/src/Amazon.Lambda.Tools/LayerDescriptionManifest.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
 using System.Collections.Generic;
 using System.Text;
 

--- a/src/Amazon.Lambda.Tools/LayerPackageInfo.cs
+++ b/src/Amazon.Lambda.Tools/LayerPackageInfo.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
 using System.Collections.Generic;
 using System.Text;
 

--- a/src/Amazon.Lambda.Tools/Program.cs
+++ b/src/Amazon.Lambda.Tools/Program.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
 using System.Collections.Generic;
 using Amazon.Common.DotNetCli.Tools.CLi;
 using Amazon.Common.DotNetCli.Tools.Commands;

--- a/src/Amazon.Lambda.Tools/TemplateProcessor/DefaultLocationOption.cs
+++ b/src/Amazon.Lambda.Tools/TemplateProcessor/DefaultLocationOption.cs
@@ -1,3 +1,6 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 namespace Amazon.Lambda.Tools.TemplateProcessor
 {
     /// <summary>

--- a/src/Amazon.Lambda.Tools/TemplateProcessor/ITemplateParser.cs
+++ b/src/Amazon.Lambda.Tools/TemplateProcessor/ITemplateParser.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
 using System.Collections.Generic;
 
 namespace Amazon.Lambda.Tools.TemplateProcessor

--- a/src/Amazon.Lambda.Tools/TemplateProcessor/JsonTemplateParser.cs
+++ b/src/Amazon.Lambda.Tools/TemplateProcessor/JsonTemplateParser.cs
@@ -1,4 +1,7 @@
-﻿using Amazon.Common.DotNetCli.Tools;
+﻿// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using Amazon.Common.DotNetCli.Tools;
 using System;
 using System.Collections.Generic;
 using System.Text;

--- a/src/Amazon.Lambda.Tools/TemplateProcessor/TemplateProcessorManager.cs
+++ b/src/Amazon.Lambda.Tools/TemplateProcessor/TemplateProcessorManager.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
 using System.Collections.Generic;
 using System.Data;
 using System.IO;

--- a/src/Amazon.Lambda.Tools/TemplateProcessor/UpdatableResource.cs
+++ b/src/Amazon.Lambda.Tools/TemplateProcessor/UpdatableResource.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 using System.Text;

--- a/src/Amazon.Lambda.Tools/TemplateProcessor/UpdatableResourceDefinition.cs
+++ b/src/Amazon.Lambda.Tools/TemplateProcessor/UpdatableResourceDefinition.cs
@@ -1,3 +1,6 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 using System;
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;

--- a/src/Amazon.Lambda.Tools/TemplateProcessor/YamlTemplateParser.cs
+++ b/src/Amazon.Lambda.Tools/TemplateProcessor/YamlTemplateParser.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Text;

--- a/test/Amazon.Common.DotNetCli.Tools.Test/CommandLineParserTest.cs
+++ b/test/Amazon.Common.DotNetCli.Tools.Test/CommandLineParserTest.cs
@@ -1,3 +1,6 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/test/Amazon.Common.DotNetCli.Tools.Test/EnvironmentReplacementTests.cs
+++ b/test/Amazon.Common.DotNetCli.Tools.Test/EnvironmentReplacementTests.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
 
 using Xunit;
 

--- a/test/Amazon.Common.DotNetCli.Tools.Test/Mocks/MockToolLogger.cs
+++ b/test/Amazon.Common.DotNetCli.Tools.Test/Mocks/MockToolLogger.cs
@@ -1,3 +1,6 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 using System;
 using System.Text;
 

--- a/test/Amazon.Common.DotNetCli.Tools.Test/OptionParseTests.cs
+++ b/test/Amazon.Common.DotNetCli.Tools.Test/OptionParseTests.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;

--- a/test/Amazon.Common.DotNetCli.Tools.Test/PosixUserHelperTest.cs
+++ b/test/Amazon.Common.DotNetCli.Tools.Test/PosixUserHelperTest.cs
@@ -1,3 +1,6 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 using System;
 using System.Diagnostics;
 using Xunit;

--- a/test/Amazon.Common.DotNetCli.Tools.Test/RelativePathTests.cs
+++ b/test/Amazon.Common.DotNetCli.Tools.Test/RelativePathTests.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
 using System.Collections.Generic;
 using System.Runtime.InteropServices;
 using System.Text;

--- a/test/Amazon.Common.DotNetCli.Tools.Test/UtilitiesTests.cs
+++ b/test/Amazon.Common.DotNetCli.Tools.Test/UtilitiesTests.cs
@@ -1,3 +1,6 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 using System;
 using System.Collections.Generic;
 using System.IO;

--- a/test/Amazon.ECS.Tools.Test/ECSToolsDefaultsReaderTest.cs
+++ b/test/Amazon.ECS.Tools.Test/ECSToolsDefaultsReaderTest.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;

--- a/test/Amazon.ElasticBeanstalk.Tools.Test/CreatePackageTests.cs
+++ b/test/Amazon.ElasticBeanstalk.Tools.Test/CreatePackageTests.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
 using System.Linq;
 using System.IO;
 using System.IO.Compression;

--- a/test/Amazon.ElasticBeanstalk.Tools.Test/DeployTests.cs
+++ b/test/Amazon.ElasticBeanstalk.Tools.Test/DeployTests.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
 using System.Linq;
 using System.IO;
 using System.Collections.Generic;

--- a/test/Amazon.ElasticBeanstalk.Tools.Test/EBUtilitiesTests.cs
+++ b/test/Amazon.ElasticBeanstalk.Tools.Test/EBUtilitiesTests.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
 using System.Collections.Generic;
 using System.Text;
 

--- a/test/Amazon.ElasticBeanstalk.Tools.Test/FilterSolutionStacksTest.cs
+++ b/test/Amazon.ElasticBeanstalk.Tools.Test/FilterSolutionStacksTest.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
 using System.Collections.Generic;
 using System.Text;
 

--- a/test/Amazon.ElasticBeanstalk.Tools.Test/TestUtilities.cs
+++ b/test/Amazon.ElasticBeanstalk.Tools.Test/TestUtilities.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Reflection;

--- a/test/Amazon.Lambda.Tools.Integ.Tests/DeployProjectTests.cs
+++ b/test/Amazon.Lambda.Tools.Integ.Tests/DeployProjectTests.cs
@@ -1,3 +1,6 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 using Amazon.CloudFormation;
 using Amazon.CloudFormation.Model;
 using Amazon.Lambda.Model;

--- a/test/Amazon.Lambda.Tools.Integ.Tests/DeployServerlessTests.cs
+++ b/test/Amazon.Lambda.Tools.Integ.Tests/DeployServerlessTests.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
 using System.IO;
 using System.Reflection;
 using System.Threading.Tasks;

--- a/test/Amazon.Lambda.Tools.Integ.Tests/DeployTestFixture.cs
+++ b/test/Amazon.Lambda.Tools.Integ.Tests/DeployTestFixture.cs
@@ -1,4 +1,7 @@
-﻿using Amazon.S3;
+﻿// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using Amazon.S3;
 using Amazon.S3.Util;
 using System;
 using System.Collections.Generic;

--- a/test/Amazon.Lambda.Tools.Integ.Tests/TestConstants.cs
+++ b/test/Amazon.Lambda.Tools.Integ.Tests/TestConstants.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
 using System.Collections.Generic;
 using System.Text;
 

--- a/test/Amazon.Lambda.Tools.Integ.Tests/TestHelper.cs
+++ b/test/Amazon.Lambda.Tools.Integ.Tests/TestHelper.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
 using System.Collections.Generic;
 using System.Text;
 using System.Threading;

--- a/test/Amazon.Lambda.Tools.Integ.Tests/TestToolLogger.cs
+++ b/test/Amazon.Lambda.Tools.Integ.Tests/TestToolLogger.cs
@@ -1,4 +1,7 @@
-﻿using System.Text;
+﻿// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System.Text;
 using Xunit.Abstractions;
 using Amazon.Common.DotNetCli.Tools;
 

--- a/test/Amazon.Lambda.Tools.Test/Amazon.Lambda.Tools.Test.csproj
+++ b/test/Amazon.Lambda.Tools.Test/Amazon.Lambda.Tools.Test.csproj
@@ -63,7 +63,6 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="System.IO.Compression.ZipFile" Version="4.3.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="YamlDotNet.Signed" Version="5.2.1" />
 	<PackageReference Include="Moq" Version="4.20.72" />

--- a/test/Amazon.Lambda.Tools.Test/ApplySettingsTest.cs
+++ b/test/Amazon.Lambda.Tools.Test/ApplySettingsTest.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;

--- a/test/Amazon.Lambda.Tools.Test/ArmTests.cs
+++ b/test/Amazon.Lambda.Tools.Test/ArmTests.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
 using System.Collections.Generic;
 using System.IO.Compression;
 using System.IO;

--- a/test/Amazon.Lambda.Tools.Test/CommandLineParserTest.cs
+++ b/test/Amazon.Lambda.Tools.Test/CommandLineParserTest.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
 using System.Collections.Generic;
 using Amazon.Common.DotNetCli.Tools;
 using Amazon.Common.DotNetCli.Tools.Options;

--- a/test/Amazon.Lambda.Tools.Test/ConvertLayerManifestTests.cs
+++ b/test/Amazon.Lambda.Tools.Test/ConvertLayerManifestTests.cs
@@ -1,3 +1,6 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 using System;
 using System.IO;
 using System.Linq;

--- a/test/Amazon.Lambda.Tools.Test/ConvertToMapOfFilesTests.cs
+++ b/test/Amazon.Lambda.Tools.Test/ConvertToMapOfFilesTests.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
 using System.Collections.Generic;
 using System.Runtime.InteropServices;
 using System.Text;

--- a/test/Amazon.Lambda.Tools.Test/DeployTest.cs
+++ b/test/Amazon.Lambda.Tools.Test/DeployTest.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
 using System.Linq;
 using System.Collections.Generic;
 using System.IO;

--- a/test/Amazon.Lambda.Tools.Test/EnvironmentVariableTests.cs
+++ b/test/Amazon.Lambda.Tools.Test/EnvironmentVariableTests.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Reflection;

--- a/test/Amazon.Lambda.Tools.Test/InvokeFunctionCommandTests.cs
+++ b/test/Amazon.Lambda.Tools.Test/InvokeFunctionCommandTests.cs
@@ -1,3 +1,6 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 using System;
 using System.Collections.Generic;
 using System.IO;

--- a/test/Amazon.Lambda.Tools.Test/LambdaSingleFilePackageTests.cs
+++ b/test/Amazon.Lambda.Tools.Test/LambdaSingleFilePackageTests.cs
@@ -1,4 +1,7 @@
-﻿using Amazon.Common.DotNetCli.Tools;
+﻿// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using Amazon.Common.DotNetCli.Tools;
 using Amazon.Lambda.Tools.Commands;
 using System;
 using System.IO;

--- a/test/Amazon.Lambda.Tools.Test/LambdaToolsDefaultsReaderTest.cs
+++ b/test/Amazon.Lambda.Tools.Test/LambdaToolsDefaultsReaderTest.cs
@@ -1,4 +1,7 @@
-﻿using System.IO;
+﻿// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System.IO;
 using System.Reflection;
 using Amazon.Common.DotNetCli.Tools;
 using Amazon.Common.DotNetCli.Tools.Options;

--- a/test/Amazon.Lambda.Tools.Test/LayerTests.cs
+++ b/test/Amazon.Lambda.Tools.Test/LayerTests.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
 using System.Linq;
 using System.Collections.Generic;
 using System.IO;

--- a/test/Amazon.Lambda.Tools.Test/OptionParseTests.cs
+++ b/test/Amazon.Lambda.Tools.Test/OptionParseTests.cs
@@ -1,4 +1,7 @@
-﻿using Xunit;
+﻿// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using Xunit;
 using Amazon.Common.DotNetCli.Tools;
 using Amazon.Common.DotNetCli.Tools.Options;
 using Amazon.Lambda.Tools.Commands;

--- a/test/Amazon.Lambda.Tools.Test/Properties/AssemblyInfo.cs
+++ b/test/Amazon.Lambda.Tools.Test/Properties/AssemblyInfo.cs
@@ -1,4 +1,7 @@
-﻿using System.Reflection;
+﻿// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using Xunit;

--- a/test/Amazon.Lambda.Tools.Test/TemplateCodeUpdateYamlTest.cs
+++ b/test/Amazon.Lambda.Tools.Test/TemplateCodeUpdateYamlTest.cs
@@ -1,4 +1,7 @@
-﻿using System.Collections.Generic;
+﻿// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System.Collections.Generic;
 using System.IO;
 using System.Reflection;
 using YamlDotNet.Serialization;

--- a/test/Amazon.Lambda.Tools.Test/TemplateParserTests.cs
+++ b/test/Amazon.Lambda.Tools.Test/TemplateParserTests.cs
@@ -1,4 +1,7 @@
-﻿using System.Collections.Generic;
+﻿// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System.Collections.Generic;
 using System.IO;
 using System.Reflection;
 using System.Text.Json;

--- a/test/Amazon.Lambda.Tools.Test/TemplateSubsitutionTests.cs
+++ b/test/Amazon.Lambda.Tools.Test/TemplateSubsitutionTests.cs
@@ -1,4 +1,7 @@
-﻿using System.Collections.Generic;
+﻿// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System.Collections.Generic;
 using System.IO;
 using System.Reflection;
 using Newtonsoft.Json;

--- a/test/Amazon.Lambda.Tools.Test/TestHelper.cs
+++ b/test/Amazon.Lambda.Tools.Test/TestHelper.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
 using System.Collections.Generic;
 using System.Text;
 using System.Threading;

--- a/test/Amazon.Lambda.Tools.Test/TestToolLogger.cs
+++ b/test/Amazon.Lambda.Tools.Test/TestToolLogger.cs
@@ -1,4 +1,7 @@
-﻿using System.Text;
+﻿// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System.Text;
 using Amazon.Common.DotNetCli.Tools;
 using Xunit.Abstractions;
 

--- a/test/Amazon.Lambda.Tools.Test/UtilitiesTests.cs
+++ b/test/Amazon.Lambda.Tools.Test/UtilitiesTests.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
 using System.Collections.Generic;
 using System.Runtime.InteropServices;
 using Xunit;

--- a/test/Amazon.Lambda.Tools.Test/WaitTillFunctionAvailableTests.cs
+++ b/test/Amazon.Lambda.Tools.Test/WaitTillFunctionAvailableTests.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
 using System.Collections.Generic;
 using System.Text;
 

--- a/test/Amazon.Tools.TestHelpers/TestToolLogger.cs
+++ b/test/Amazon.Tools.TestHelpers/TestToolLogger.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
 using System.Collections.Generic;
 using System.Text;
 

--- a/test/Amazon.Tools.TestHelpers/TestUtilities.cs
+++ b/test/Amazon.Tools.TestHelpers/TestUtilities.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
 using System.IO;
 using System.Reflection;
 

--- a/testapps/HelloWorldWebApp/Program.cs
+++ b/testapps/HelloWorldWebApp/Program.cs
@@ -1,4 +1,7 @@
-﻿using Microsoft.AspNetCore.Builder;
+﻿// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 
 var builder = WebApplication.CreateBuilder(args);

--- a/testapps/ImageBasedProjects/MultiStageBuildWithClassLibraries/Supportlibrary/Message.cs
+++ b/testapps/ImageBasedProjects/MultiStageBuildWithClassLibraries/Supportlibrary/Message.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
 
 namespace Supportlibrary
 {

--- a/testapps/ImageBasedProjects/MultiStageBuildWithClassLibraries/TheFunction/Function.cs
+++ b/testapps/ImageBasedProjects/MultiStageBuildWithClassLibraries/TheFunction/Function.cs
@@ -1,3 +1,6 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/testapps/ImageBasedProjects/ServerlessTemplateExamples/UseDefaultDocker/Function.cs
+++ b/testapps/ImageBasedProjects/ServerlessTemplateExamples/UseDefaultDocker/Function.cs
@@ -1,3 +1,6 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/testapps/ImageBasedProjects/ServerlessTemplateExamples/UseDockerMetadata/Function.cs
+++ b/testapps/ImageBasedProjects/ServerlessTemplateExamples/UseDockerMetadata/Function.cs
@@ -1,3 +1,6 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/testapps/ImageBasedProjects/TestSimpleImageProject/Function.cs
+++ b/testapps/ImageBasedProjects/TestSimpleImageProject/Function.cs
@@ -1,3 +1,6 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/testapps/MPDeployServerless/CurrentDirectoryTest/Function.cs
+++ b/testapps/MPDeployServerless/CurrentDirectoryTest/Function.cs
@@ -1,3 +1,6 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/testapps/MPDeployServerless/SiblingProjectTest/Function.cs
+++ b/testapps/MPDeployServerless/SiblingProjectTest/Function.cs
@@ -1,3 +1,6 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/testapps/ServerlessWithYamlFunction/Function.cs
+++ b/testapps/ServerlessWithYamlFunction/Function.cs
@@ -1,3 +1,6 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/testapps/SingleFileLambdaFunctions/ToUpperFunctionImplicitAOT.cs
+++ b/testapps/SingleFileLambdaFunctions/ToUpperFunctionImplicitAOT.cs
@@ -1,3 +1,6 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 #:package Amazon.Lambda.Core@2.8.0
 #:package Amazon.Lambda.RuntimeSupport@1.14.1
 #:package Amazon.Lambda.Serialization.SystemTextJson@2.4.4

--- a/testapps/SingleFileLambdaFunctions/ToUpperFunctionNoAOT.cs
+++ b/testapps/SingleFileLambdaFunctions/ToUpperFunctionNoAOT.cs
@@ -1,3 +1,6 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 #:package Amazon.Lambda.Core@2.8.0
 #:package Amazon.Lambda.RuntimeSupport@1.14.1
 #:package Amazon.Lambda.Serialization.SystemTextJson@2.4.4

--- a/testapps/TemplateSubstitutionTestProjects/StateMachineDefinitionStringTest/Function.cs
+++ b/testapps/TemplateSubstitutionTestProjects/StateMachineDefinitionStringTest/Function.cs
@@ -1,3 +1,6 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/testapps/TestBeanstalkWebApp/Program.cs
+++ b/testapps/TestBeanstalkWebApp/Program.cs
@@ -1,4 +1,7 @@
-﻿using Microsoft.AspNetCore.Builder;
+﻿// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 
 var builder = WebApplication.CreateBuilder(args);

--- a/testapps/TestFunction/Function.cs
+++ b/testapps/TestFunction/Function.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;

--- a/testapps/TestFunction/Properties/AssemblyInfo.cs
+++ b/testapps/TestFunction/Properties/AssemblyInfo.cs
@@ -1,4 +1,7 @@
-﻿using System.Reflection;
+﻿// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 

--- a/testapps/TestFunction/ValidateHandlerFunctionSignatures.cs
+++ b/testapps/TestFunction/ValidateHandlerFunctionSignatures.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;

--- a/testapps/TestFunctionBuildProps/TestFunctionBuildProps/Function.cs
+++ b/testapps/TestFunctionBuildProps/TestFunctionBuildProps/Function.cs
@@ -1,3 +1,6 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 using Amazon.Lambda.Core;
 
 // Assembly attribute to enable the Lambda function's JSON input to be converted into a .NET class.

--- a/testapps/TestHttpFunction/Function.cs
+++ b/testapps/TestHttpFunction/Function.cs
@@ -1,3 +1,6 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 using Amazon.Lambda.Core;
 using Amazon.Lambda.APIGatewayEvents;
 using System.Net;

--- a/testapps/TestIntegerFunction/Function.cs
+++ b/testapps/TestIntegerFunction/Function.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;

--- a/testapps/TestLayerAspNetCore/Controllers/ValuesController.cs
+++ b/testapps/TestLayerAspNetCore/Controllers/ValuesController.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;

--- a/testapps/TestLayerAspNetCore/LambdaEntryPoint.cs
+++ b/testapps/TestLayerAspNetCore/LambdaEntryPoint.cs
@@ -1,3 +1,6 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/testapps/TestLayerAspNetCore/LocalEntryPoint.cs
+++ b/testapps/TestLayerAspNetCore/LocalEntryPoint.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;

--- a/testapps/TestLayerAspNetCore/Startup.cs
+++ b/testapps/TestLayerAspNetCore/Startup.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;

--- a/testapps/TestLayerExample/Function.cs
+++ b/testapps/TestLayerExample/Function.cs
@@ -1,3 +1,6 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/testapps/TestLayerServerless/Function.cs
+++ b/testapps/TestLayerServerless/Function.cs
@@ -1,3 +1,6 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/testapps/TestNativeAotMultipleProjects/EntryPoint/Function.cs
+++ b/testapps/TestNativeAotMultipleProjects/EntryPoint/Function.cs
@@ -1,3 +1,6 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 using Amazon.Lambda.Core;
 using Amazon.Lambda.RuntimeSupport;
 using Amazon.Lambda.Serialization.SystemTextJson;

--- a/testapps/TestNativeAotMultipleProjects/Library1/Class1.cs
+++ b/testapps/TestNativeAotMultipleProjects/Library1/Class1.cs
@@ -1,4 +1,7 @@
-﻿namespace NativeAotTest;
+﻿// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+namespace NativeAotTest;
 
 public class Class1
 {

--- a/testapps/TestNativeAotNet8WebApp/LambdaFunction.cs
+++ b/testapps/TestNativeAotNet8WebApp/LambdaFunction.cs
@@ -1,3 +1,6 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 using Amazon.Lambda.AspNetCoreServer;
 
 namespace TestNativeAotNet8WebApp;

--- a/testapps/TestNativeAotNet8WebApp/Program.cs
+++ b/testapps/TestNativeAotNet8WebApp/Program.cs
@@ -1,3 +1,6 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 var builder = WebApplication.CreateSlimBuilder(args);
 
 var app = builder.Build();

--- a/testapps/TestNativeAotSingleProject/Function.cs
+++ b/testapps/TestNativeAotSingleProject/Function.cs
@@ -1,3 +1,6 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 using Amazon.Lambda.Core;
 using Amazon.Lambda.RuntimeSupport;
 using Amazon.Lambda.Serialization.SystemTextJson;

--- a/testapps/TestPowerShellParallelTest/Bootstrap.cs
+++ b/testapps/TestPowerShellParallelTest/Bootstrap.cs
@@ -1,3 +1,6 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 using Amazon.Lambda.PowerShellHost;
 
 namespace TestPowerShellParallelTest

--- a/testapps/TestServerlessWebApp/Controllers/AuthTestController.cs
+++ b/testapps/TestServerlessWebApp/Controllers/AuthTestController.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;

--- a/testapps/TestServerlessWebApp/Controllers/BinaryContentController.cs
+++ b/testapps/TestServerlessWebApp/Controllers/BinaryContentController.cs
@@ -1,3 +1,6 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 using System.IO;
 using Microsoft.AspNetCore.Mvc;
 

--- a/testapps/TestServerlessWebApp/Controllers/BodyTestsController.cs
+++ b/testapps/TestServerlessWebApp/Controllers/BodyTestsController.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;

--- a/testapps/TestServerlessWebApp/Controllers/ErrorTestsController.cs
+++ b/testapps/TestServerlessWebApp/Controllers/ErrorTestsController.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
 using System.IO;
 using System.Reflection;
 using Microsoft.AspNetCore.Mvc;

--- a/testapps/TestServerlessWebApp/Controllers/QueryStringController.cs
+++ b/testapps/TestServerlessWebApp/Controllers/QueryStringController.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;

--- a/testapps/TestServerlessWebApp/Controllers/ResourcePathController.cs
+++ b/testapps/TestServerlessWebApp/Controllers/ResourcePathController.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;

--- a/testapps/TestServerlessWebApp/LambdaFunction.cs
+++ b/testapps/TestServerlessWebApp/LambdaFunction.cs
@@ -1,4 +1,7 @@
-﻿using System.IO;
+﻿// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System.IO;
 
 using Amazon.Lambda.AspNetCoreServer;
 using Microsoft.AspNetCore.Hosting;

--- a/testapps/TestServerlessWebApp/Middleware.cs
+++ b/testapps/TestServerlessWebApp/Middleware.cs
@@ -1,4 +1,7 @@
-﻿using Amazon.Lambda.Core;
+﻿// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using Amazon.Lambda.Core;
 using Microsoft.AspNetCore.Http;
 using System;
 using System.Collections.Generic;

--- a/testapps/TestServerlessWebApp/Program.cs
+++ b/testapps/TestServerlessWebApp/Program.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Hosting;

--- a/testapps/TestServerlessWebApp/Startup.cs
+++ b/testapps/TestServerlessWebApp/Startup.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;


### PR DESCRIPTION
*Description of changes:*
All the source files in this repo were missing the license header. This PR adds no logic changes just adds the license header to all C# source files in the repo.

There was a warning about the compression library package reference not needed in the Amazon.Lambda.Tools.Test project that I also took care of.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
