### PR TITLE
Auto-attach durable execution IAM policy in deploy-function

### DIFF
--- a/.autover/changes/5f52ddf5-4a83-4b78-8fa8-3dcfff58a2f0.json
+++ b/.autover/changes/5f52ddf5-4a83-4b78-8fa8-3dcfff58a2f0.json
@@ -1,0 +1,11 @@
+{
+  "Projects": [
+    {
+      "Name": "Amazon.Lambda.Tools",
+      "Type": "Patch",
+      "ChangelogMessages": [
+        "When deploying a durable function with `deploy-function` or `update-function-config`, automatically attach the `AWSLambdaBasicDurableExecutionRolePolicy` managed policy to a tool-created execution role, and warn when a user-supplied role is missing it."
+      ]
+    }
+  ]
+}

--- a/src/Amazon.Common.DotNetCli.Tools/RoleHelper.cs
+++ b/src/Amazon.Common.DotNetCli.Tools/RoleHelper.cs
@@ -147,6 +147,66 @@ namespace Amazon.Common.DotNetCli.Tools
             return task.Result;
         }
 
+        /// <summary>
+        /// Extracts the IAM role name from a role identifier that may be either a bare name or a full ARN
+        /// (e.g. "arn:aws:iam::123456789012:role/path/MyRole" -> "MyRole"). IAM role names are unique within
+        /// an account, so the trailing path segment after the last '/' is the name.
+        /// </summary>
+        public static string GetRoleNameFromArnOrName(string roleArnOrName)
+        {
+            if (string.IsNullOrEmpty(roleArnOrName))
+                return roleArnOrName;
+
+            var slashIndex = roleArnOrName.LastIndexOf('/');
+            return slashIndex >= 0 ? roleArnOrName.Substring(slashIndex + 1) : roleArnOrName;
+        }
+
+        /// <summary>
+        /// Returns true if the given managed policy ARN is already attached to the role.
+        /// </summary>
+        public static async Task<bool> IsManagedPolicyAttachedAsync(IAmazonIdentityManagementService iamClient, string roleArnOrName, string policyArn)
+        {
+            var roleName = GetRoleNameFromArnOrName(roleArnOrName);
+
+            ListAttachedRolePoliciesResponse response = null;
+            do
+            {
+                response = await iamClient.ListAttachedRolePoliciesAsync(new ListAttachedRolePoliciesRequest
+                {
+                    RoleName = roleName,
+                    Marker = response?.Marker
+                }).ConfigureAwait(false);
+
+                if (response.AttachedPolicies != null &&
+                    response.AttachedPolicies.Any(p => string.Equals(p.PolicyArn, policyArn, StringComparison.Ordinal)))
+                {
+                    return true;
+                }
+
+            } while (response.IsTruncated.GetValueOrDefault());
+
+            return false;
+        }
+
+        /// <summary>
+        /// Idempotently attaches a managed policy to a role: checks whether the policy is already attached and only
+        /// calls AttachRolePolicy if it is missing. Returns true if a new attachment was made, false if it was already present.
+        /// </summary>
+        public static async Task<bool> EnsureManagedPolicyAttachedAsync(IAmazonIdentityManagementService iamClient, string roleArnOrName, string policyArn)
+        {
+            if (await IsManagedPolicyAttachedAsync(iamClient, roleArnOrName, policyArn).ConfigureAwait(false))
+                return false;
+
+            var roleName = GetRoleNameFromArnOrName(roleArnOrName);
+            await iamClient.AttachRolePolicyAsync(new AttachRolePolicyRequest
+            {
+                RoleName = roleName,
+                PolicyArn = policyArn
+            }).ConfigureAwait(false);
+
+            return true;
+        }
+
         public static string CreateRole(IAmazonIdentityManagementService iamClient, string roleName, string assumeRolePolicy, params string[] managedPolicies)
         {
             if (managedPolicies != null && managedPolicies.Length > 0)

--- a/src/Amazon.Lambda.Tools/Commands/DeployFunctionCommand.cs
+++ b/src/Amazon.Lambda.Tools/Commands/DeployFunctionCommand.cs
@@ -348,15 +348,23 @@ namespace Amazon.Lambda.Tools.Commands
                 if (currentConfiguration == null)
                 {
                     this.Logger.WriteLine($"Creating new Lambda function {this.FunctionName}");
+
+                    // Track whether the role is one the tool resolves/creates interactively versus one the user
+                    // explicitly supplied. Only a tool-created role is safe to mutate (attach the durable policy);
+                    // for a user-supplied role we warn instead. The role is "user-supplied" when a value comes from
+                    // the --function-role switch or the defaults file rather than the interactive create-role prompt.
+                    var roleWasSupplied = !string.IsNullOrEmpty(this.Role)
+                        || !string.IsNullOrEmpty(this.DefaultConfig[LambdaDefinedCommandOptions.ARGUMENT_FUNCTION_ROLE.Switch] as string);
+
                     var createRequest = new CreateFunctionRequest
                     {
                         PackageType = packageType,
                         FunctionName = this.GetStringValueOrDefault(this.FunctionName, LambdaDefinedCommandOptions.ARGUMENT_FUNCTION_NAME, true),
                         Description = this.GetStringValueOrDefault(this.Description, LambdaDefinedCommandOptions.ARGUMENT_FUNCTION_DESCRIPTION, false),
-                        Role = this.GetRoleValueOrDefault(this.Role, LambdaDefinedCommandOptions.ARGUMENT_FUNCTION_ROLE, 
-                            Constants.LAMBDA_PRINCIPAL, LambdaConstants.AWS_LAMBDA_MANAGED_POLICY_PREFIX, 
+                        Role = this.GetRoleValueOrDefault(this.Role, LambdaDefinedCommandOptions.ARGUMENT_FUNCTION_ROLE,
+                            Constants.LAMBDA_PRINCIPAL, LambdaConstants.AWS_LAMBDA_MANAGED_POLICY_PREFIX,
                             LambdaConstants.KNOWN_MANAGED_POLICY_DESCRIPTIONS, true),
-                        
+
                         Publish = this.GetBoolValueOrDefault(this.Publish, LambdaDefinedCommandOptions.ARGUMENT_FUNCTION_PUBLISH, false).GetValueOrDefault(),
                         MemorySize = this.GetIntValueOrDefault(this.MemorySize, LambdaDefinedCommandOptions.ARGUMENT_FUNCTION_MEMORY_SIZE, true).GetValueOrDefault(),
                         Timeout = this.GetIntValueOrDefault(this.Timeout, LambdaDefinedCommandOptions.ARGUMENT_FUNCTION_TIMEOUT, true).GetValueOrDefault(),
@@ -494,15 +502,10 @@ namespace Amazon.Lambda.Tools.Commands
                             .ToList();
                     }
 
-                    var durableExecutionTimeout = this.GetIntValueOrDefault(this.DurableExecutionTimeout, LambdaDefinedCommandOptions.ARGUMENT_DURABLE_EXECUTION_TIMEOUT, false);
-                    var durableRetentionPeriodInDays = this.GetIntValueOrDefault(this.DurableRetentionPeriodInDays, LambdaDefinedCommandOptions.ARGUMENT_DURABLE_RETENTION_PERIOD_IN_DAYS, false);
-                    if (durableExecutionTimeout.HasValue || durableRetentionPeriodInDays.HasValue)
+                    var isDurable = this.TryResolveDurableConfig(out var durableConfig);
+                    if (isDurable)
                     {
-                        createRequest.DurableConfig = new DurableConfig();
-                        if (durableExecutionTimeout.HasValue)
-                            createRequest.DurableConfig.ExecutionTimeout = durableExecutionTimeout.Value;
-                        if (durableRetentionPeriodInDays.HasValue)
-                            createRequest.DurableConfig.RetentionPeriodInDays = durableRetentionPeriodInDays.Value;
+                        createRequest.DurableConfig = durableConfig;
                     }
 
                     try
@@ -513,6 +516,13 @@ namespace Amazon.Lambda.Tools.Commands
                     catch (Exception e)
                     {
                         throw new LambdaToolsException($"Error creating Lambda function: {e.Message}", LambdaToolsException.LambdaErrorCode.LambdaCreateFunction, e);
+                    }
+
+                    // A durable function's execution role needs the durable-execution checkpoint permissions. Attach
+                    // the managed policy when the tool created the role; warn (but don't mutate) for a user-supplied role.
+                    if (isDurable)
+                    {
+                        await this.EnsureDurableExecutionPolicyAsync(createRequest.Role, toolCreatedRole: !roleWasSupplied);
                     }
 
                     if(this.GetBoolValueOrDefault(this.FunctionUrlEnable, LambdaDefinedCommandOptions.ARGUMENT_FUNCTION_URL_ENABLE, false).GetValueOrDefault())

--- a/src/Amazon.Lambda.Tools/Commands/UpdateFunctionConfigCommand.cs
+++ b/src/Amazon.Lambda.Tools/Commands/UpdateFunctionConfigCommand.cs
@@ -496,7 +496,7 @@ namespace Amazon.Lambda.Tools.Commands
         /// A durable function's execution role must carry the AWSLambdaBasicDurableExecutionRolePolicy managed policy
         /// so the function can call the durable-execution checkpoint APIs. When the tool created the role it attaches
         /// the policy automatically. For a role the user supplied (or an existing function's role on update) the tool
-        /// does not mutate IAM it does not own; it only warns when the policy is missing.
+        /// does not mutate IAM it does not own; it only emits an informational note when the policy is not attached.
         /// </summary>
         /// <param name="roleArn">The resolved role ARN (or name) the function uses.</param>
         /// <param name="toolCreatedRole">True when this deployment created the role, in which case the policy is attached.</param>
@@ -517,16 +517,17 @@ namespace Amazon.Lambda.Tools.Commands
                 }
                 else if (!await RoleHelper.IsManagedPolicyAttachedAsync(this.IAMClient, roleArn, policyArn))
                 {
-                    this.Logger.WriteLine($"Warning: durable function role {roleArn} is missing the {policyArn} managed policy. " +
-                        "Durable execution checkpointing will fail until this policy is attached to the role.");
+                    this.Logger.WriteLine($"Using existing IAM role {roleArn} for Lambda function. Ensure this role has the " +
+                        $"required permissions for Durable Functions. The {policyArn} managed policy can be attached to grant permissions.");
                 }
             }
             catch (Exception e)
             {
-                // Don't fail the deployment over an IAM read/attach issue (e.g. the caller lacks iam:AttachRolePolicy
-                // or iam:ListAttachedRolePolicies on a user-managed role). Surface a warning so the user can act.
-                this.Logger.WriteLine($"Warning: unable to verify or attach the durable execution managed policy {policyArn} " +
-                    $"on role {roleArn}: {e.Message}. Ensure the policy is attached for durable execution to work.");
+                // The deployment role may have no IAM permissions (e.g. the caller lacks iam:AttachRolePolicy or
+                // iam:ListAttachedRolePolicies), which can be a best practice for locking down permissions. Don't fail
+                // the deployment over it; surface the same informational message so the user can act if needed.
+                this.Logger.WriteLine($"Using existing IAM role {roleArn} for Lambda function ({e.Message}). Ensure this role " +
+                    $"has the required permissions for Durable Functions. The {policyArn} managed policy can be attached to grant permissions.");
             }
         }
 

--- a/src/Amazon.Lambda.Tools/Commands/UpdateFunctionConfigCommand.cs
+++ b/src/Amazon.Lambda.Tools/Commands/UpdateFunctionConfigCommand.cs
@@ -310,6 +310,16 @@ namespace Amazon.Lambda.Tools.Commands
                 }
             }
 
+            // When updating a function with durable configuration, the function's execution role must carry the
+            // durable-execution managed policy. On update the role always pre-exists (the tool never creates a role
+            // here), so warn rather than mutate a role the tool does not own. Use the updated role if it changed,
+            // otherwise the existing one.
+            if (this.TryResolveDurableConfig(out _))
+            {
+                var roleArn = request?.Role ?? existingConfiguration.Role;
+                await this.EnsureDurableExecutionPolicyAsync(roleArn, toolCreatedRole: false);
+            }
+
             // only attempt to modify function url if the user has explicitly opted-in to use FunctionUrl
             if (GetBoolValueOrDefault(FunctionUrlEnable, LambdaDefinedCommandOptions.ARGUMENT_FUNCTION_URL_ENABLE, false).HasValue)
             {
@@ -456,6 +466,68 @@ namespace Amazon.Lambda.Tools.Commands
             }
 
             return request;
+        }
+
+        /// <summary>
+        /// Resolves the durable execution configuration from the command options/defaults. A function is treated
+        /// as "durable" if either the durable execution timeout or retention period is set. Returns true and the
+        /// resolved <see cref="DurableConfig"/> when durable, otherwise false.
+        /// </summary>
+        protected bool TryResolveDurableConfig(out DurableConfig durableConfig)
+        {
+            var durableExecutionTimeout = this.GetIntValueOrDefault(this.DurableExecutionTimeout, LambdaDefinedCommandOptions.ARGUMENT_DURABLE_EXECUTION_TIMEOUT, false);
+            var durableRetentionPeriodInDays = this.GetIntValueOrDefault(this.DurableRetentionPeriodInDays, LambdaDefinedCommandOptions.ARGUMENT_DURABLE_RETENTION_PERIOD_IN_DAYS, false);
+
+            if (!durableExecutionTimeout.HasValue && !durableRetentionPeriodInDays.HasValue)
+            {
+                durableConfig = null;
+                return false;
+            }
+
+            durableConfig = new DurableConfig();
+            if (durableExecutionTimeout.HasValue)
+                durableConfig.ExecutionTimeout = durableExecutionTimeout.Value;
+            if (durableRetentionPeriodInDays.HasValue)
+                durableConfig.RetentionPeriodInDays = durableRetentionPeriodInDays.Value;
+            return true;
+        }
+
+        /// <summary>
+        /// A durable function's execution role must carry the AWSLambdaBasicDurableExecutionRolePolicy managed policy
+        /// so the function can call the durable-execution checkpoint APIs. When the tool created the role it attaches
+        /// the policy automatically. For a role the user supplied (or an existing function's role on update) the tool
+        /// does not mutate IAM it does not own; it only warns when the policy is missing.
+        /// </summary>
+        /// <param name="roleArn">The resolved role ARN (or name) the function uses.</param>
+        /// <param name="toolCreatedRole">True when this deployment created the role, in which case the policy is attached.</param>
+        protected async Task EnsureDurableExecutionPolicyAsync(string roleArn, bool toolCreatedRole)
+        {
+            if (string.IsNullOrEmpty(roleArn))
+                return;
+
+            var policyArn = LambdaConstants.AWS_LAMBDA_BASIC_DURABLE_EXECUTION_MANAGED_POLICY;
+
+            try
+            {
+                if (toolCreatedRole)
+                {
+                    var attached = await RoleHelper.EnsureManagedPolicyAttachedAsync(this.IAMClient, roleArn, policyArn);
+                    if (attached)
+                        this.Logger.WriteLine($"Attached durable execution managed policy {policyArn} to role {roleArn}");
+                }
+                else if (!await RoleHelper.IsManagedPolicyAttachedAsync(this.IAMClient, roleArn, policyArn))
+                {
+                    this.Logger.WriteLine($"Warning: durable function role {roleArn} is missing the {policyArn} managed policy. " +
+                        "Durable execution checkpointing will fail until this policy is attached to the role.");
+                }
+            }
+            catch (Exception e)
+            {
+                // Don't fail the deployment over an IAM read/attach issue (e.g. the caller lacks iam:AttachRolePolicy
+                // or iam:ListAttachedRolePolicies on a user-managed role). Surface a warning so the user can act.
+                this.Logger.WriteLine($"Warning: unable to verify or attach the durable execution managed policy {policyArn} " +
+                    $"on role {roleArn}: {e.Message}. Ensure the policy is attached for durable execution to work.");
+            }
         }
 
         /// <summary>

--- a/src/Amazon.Lambda.Tools/LambdaConstants.cs
+++ b/src/Amazon.Lambda.Tools/LambdaConstants.cs
@@ -58,10 +58,16 @@ namespace Amazon.Lambda.Tools
 
         public const string AWS_LAMBDA_MANAGED_POLICY_PREFIX = "AWSLambda";
 
+        // Durable functions need permission to call the durable-execution checkpoint APIs in addition to writing
+        // CloudWatch Logs. This AWS-managed policy bundles both. It must be attached to the function's execution
+        // role for durable execution (checkpoint/resume) to work at runtime.
+        public const string AWS_LAMBDA_BASIC_DURABLE_EXECUTION_MANAGED_POLICY = "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicDurableExecutionRolePolicy";
+
         public static readonly Dictionary<string, string> KNOWN_MANAGED_POLICY_DESCRIPTIONS = new Dictionary<string, string>
         {
             {"arn:aws:iam::aws:policy/PowerUserAccess","Provides full access to AWS services and resources, but does not allow management of users and groups."},
             {"arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole","Provides write permissions to CloudWatch Logs."},
+            {AWS_LAMBDA_BASIC_DURABLE_EXECUTION_MANAGED_POLICY,"Provides permissions to call the durable-execution checkpoint APIs plus write permissions to CloudWatch Logs."},
             {"arn:aws:iam::aws:policy/service-role/AWSLambdaDynamoDBExecutionRole","Provides list and read access to DynamoDB streams and write permissions to CloudWatch Logs."},
             {"arn:aws:iam::aws:policy/AWSLambdaExecute","Provides Put, Get access to S3 and full access to CloudWatch Logs."},
             {"arn:aws:iam::aws:policy/AWSLambdaInvocation-DynamoDB","Provides read access to DynamoDB Streams."},

--- a/test/Amazon.Lambda.Tools.Test/DurableConfigTest.cs
+++ b/test/Amazon.Lambda.Tools.Test/DurableConfigTest.cs
@@ -1,0 +1,213 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+using Amazon.IdentityManagement;
+using Amazon.IdentityManagement.Model;
+using Amazon.Lambda.Model;
+using Amazon.Lambda.Tools.Commands;
+using Moq;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Amazon.Lambda.Tools.Test
+{
+    /// <summary>
+    /// Verifies the durable-execution wiring on deploy-function/update-function-config: the DurableConfig is mapped
+    /// onto the create/update requests, and the AWSLambdaBasicDurableExecutionRolePolicy managed policy is attached
+    /// to a tool-created role (and only warned about for a user-supplied role).
+    /// </summary>
+    public class DurableConfigTest
+    {
+        // A real-looking ARN so RoleHelper.ExpandRoleName short-circuits without calling IAM.
+        private const string TestRoleArn = "arn:aws:iam::123456789012:role/durable-test-role";
+        private const string DurablePolicyArn = LambdaConstants.AWS_LAMBDA_BASIC_DURABLE_EXECUTION_MANAGED_POLICY;
+
+        private readonly ITestOutputHelper _testOutputHelper;
+
+        public DurableConfigTest(ITestOutputHelper testOutputHelper)
+        {
+            this._testOutputHelper = testOutputHelper;
+        }
+
+        private static string GetTestFunctionPath()
+        {
+            var assembly = typeof(DurableConfigTest).GetTypeInfo().Assembly;
+            return Path.GetFullPath(Path.GetDirectoryName(assembly.Location) + "../../../../../../testapps/TestFunction");
+        }
+
+        /// <summary>
+        /// Builds an IAM mock where the role has only the given policies attached. Records every AttachRolePolicy call.
+        /// </summary>
+        private static Mock<IAmazonIdentityManagementService> BuildIamMock(List<string> attachCalls, params string[] alreadyAttached)
+        {
+            var iamMock = new Mock<IAmazonIdentityManagementService>();
+
+            iamMock.Setup(c => c.ListAttachedRolePoliciesAsync(It.IsAny<ListAttachedRolePoliciesRequest>(), It.IsAny<CancellationToken>()))
+                .Returns((ListAttachedRolePoliciesRequest r, CancellationToken token) =>
+                {
+                    var response = new ListAttachedRolePoliciesResponse
+                    {
+                        IsTruncated = false,
+                        AttachedPolicies = new List<AttachedPolicyType>()
+                    };
+                    foreach (var arn in alreadyAttached)
+                        response.AttachedPolicies.Add(new AttachedPolicyType { PolicyArn = arn, PolicyName = arn });
+                    return Task.FromResult(response);
+                });
+
+            iamMock.Setup(c => c.AttachRolePolicyAsync(It.IsAny<AttachRolePolicyRequest>(), It.IsAny<CancellationToken>()))
+                .Callback<AttachRolePolicyRequest, CancellationToken>((r, token) => attachCalls.Add(r.PolicyArn))
+                .Returns(Task.FromResult(new AttachRolePolicyResponse()));
+
+            return iamMock;
+        }
+
+        [Fact]
+        public async Task DurableConfigMappedOntoCreateRequest()
+        {
+            DurableConfig captured = null;
+            var lambdaMock = new Mock<IAmazonLambda>();
+            lambdaMock.Setup(c => c.CreateFunctionAsync(It.IsAny<CreateFunctionRequest>(), It.IsAny<CancellationToken>()))
+                .Callback<CreateFunctionRequest, CancellationToken>((request, token) => captured = request.DurableConfig)
+                .Returns(Task.FromResult(new CreateFunctionResponse()));
+
+            var attachCalls = new List<string>();
+            // User-supplied role (Role set explicitly) that already has the durable policy => no attach, no warn.
+            var iamMock = BuildIamMock(attachCalls, DurablePolicyArn);
+
+            var command = NewDeployCommand();
+            command.Role = TestRoleArn;
+            command.DurableExecutionTimeout = 3600;
+            command.DurableRetentionPeriodInDays = 30;
+            command.LambdaClient = lambdaMock.Object;
+            command.IAMClient = iamMock.Object;
+
+            var created = await command.ExecuteAsync();
+
+            Assert.True(created, command.LastToolsException?.Message);
+            Assert.NotNull(captured);
+            Assert.Equal(3600, captured.ExecutionTimeout);
+            Assert.Equal(30, captured.RetentionPeriodInDays);
+            // Role was user-supplied, so the tool must not mutate it.
+            Assert.Empty(attachCalls);
+        }
+
+        [Fact]
+        public async Task NonDurableCreateDoesNotAttachDurablePolicy()
+        {
+            var lambdaMock = new Mock<IAmazonLambda>();
+            CreateFunctionRequest captured = null;
+            lambdaMock.Setup(c => c.CreateFunctionAsync(It.IsAny<CreateFunctionRequest>(), It.IsAny<CancellationToken>()))
+                .Callback<CreateFunctionRequest, CancellationToken>((request, token) => captured = request)
+                .Returns(Task.FromResult(new CreateFunctionResponse()));
+
+            var attachCalls = new List<string>();
+            var iamMock = BuildIamMock(attachCalls);
+
+            var command = NewDeployCommand();
+            command.Role = TestRoleArn;
+            // No durable options set.
+            command.LambdaClient = lambdaMock.Object;
+            command.IAMClient = iamMock.Object;
+
+            var created = await command.ExecuteAsync();
+
+            Assert.True(created, command.LastToolsException?.Message);
+            Assert.NotNull(captured);
+            Assert.Null(captured.DurableConfig);
+            Assert.Empty(attachCalls);
+        }
+
+        [Fact]
+        public async Task UserSuppliedRoleMissingDurablePolicyWarnsButDoesNotAttach()
+        {
+            var lambdaMock = new Mock<IAmazonLambda>();
+            lambdaMock.Setup(c => c.CreateFunctionAsync(It.IsAny<CreateFunctionRequest>(), It.IsAny<CancellationToken>()))
+                .Returns(Task.FromResult(new CreateFunctionResponse()));
+
+            var attachCalls = new List<string>();
+            // User-supplied role with only the basic-execution policy => durable policy missing => warn only.
+            var iamMock = BuildIamMock(attachCalls, "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole");
+
+            var logger = new TestToolLogger(_testOutputHelper);
+            var command = NewDeployCommand(logger);
+            command.Role = TestRoleArn;
+            command.DurableExecutionTimeout = 1200;
+            command.LambdaClient = lambdaMock.Object;
+            command.IAMClient = iamMock.Object;
+
+            var created = await command.ExecuteAsync();
+
+            Assert.True(created, command.LastToolsException?.Message);
+            Assert.Empty(attachCalls);
+            Assert.Contains("missing", logger.Buffer, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains(DurablePolicyArn, logger.Buffer);
+        }
+
+        [Fact]
+        public async Task DurableConfigMappedOntoUpdateRequestAndWarnsWhenRoleMissingPolicy()
+        {
+            DurableConfig captured = null;
+            var lambdaMock = new Mock<IAmazonLambda>();
+
+            lambdaMock.Setup(c => c.GetFunctionConfigurationAsync(It.IsAny<GetFunctionConfigurationRequest>(), It.IsAny<CancellationToken>()))
+                .Returns((GetFunctionConfigurationRequest r, CancellationToken token) => Task.FromResult(new GetFunctionConfigurationResponse
+                {
+                    FunctionName = r.FunctionName,
+                    Handler = "TestFunction::TestFunction.Function::ToUpper",
+                    Timeout = 10,
+                    MemorySize = 512,
+                    Role = TestRoleArn,
+                    Runtime = "dotnet8",
+                    PackageType = PackageType.Zip
+                    // No existing DurableConfig => the update flips the function to durable.
+                }));
+
+            lambdaMock.Setup(c => c.UpdateFunctionConfigurationAsync(It.IsAny<UpdateFunctionConfigurationRequest>(), It.IsAny<CancellationToken>()))
+                .Callback<UpdateFunctionConfigurationRequest, CancellationToken>((request, token) => captured = request.DurableConfig)
+                .Returns(Task.FromResult(new UpdateFunctionConfigurationResponse()));
+
+            // Code update is also attempted on a deploy; stub it so the deploy path completes.
+            lambdaMock.Setup(c => c.UpdateFunctionCodeAsync(It.IsAny<UpdateFunctionCodeRequest>(), It.IsAny<CancellationToken>()))
+                .Returns(Task.FromResult(new UpdateFunctionCodeResponse()));
+
+            var attachCalls = new List<string>();
+            var iamMock = BuildIamMock(attachCalls); // role has no durable policy
+
+            var logger = new TestToolLogger(_testOutputHelper);
+            var command = NewDeployCommand(logger);
+            command.Role = TestRoleArn;
+            command.DurableExecutionTimeout = 900;
+            command.LambdaClient = lambdaMock.Object;
+            command.IAMClient = iamMock.Object;
+
+            var updated = await command.ExecuteAsync();
+
+            Assert.True(updated, command.LastToolsException?.Message);
+            Assert.NotNull(captured);
+            Assert.Equal(900, captured.ExecutionTimeout);
+            // Update never creates a role, so it must warn rather than attach.
+            Assert.Empty(attachCalls);
+            Assert.Contains(DurablePolicyArn, logger.Buffer);
+        }
+
+        private DeployFunctionCommand NewDeployCommand(TestToolLogger logger = null)
+        {
+            var command = new DeployFunctionCommand(logger ?? new TestToolLogger(_testOutputHelper), GetTestFunctionPath(), new string[0]);
+            command.FunctionName = "durable-test-function-" + DateTime.Now.Ticks;
+            command.Handler = "TestFunction::TestFunction.Function::ToUpper";
+            command.Timeout = 10;
+            command.MemorySize = 512;
+            command.Configuration = "Release";
+            command.Runtime = "dotnet8";
+            command.DisableInteractive = true;
+            return command;
+        }
+    }
+}

--- a/test/Amazon.Lambda.Tools.Test/DurableConfigTest.cs
+++ b/test/Amazon.Lambda.Tools.Test/DurableConfigTest.cs
@@ -125,14 +125,14 @@ namespace Amazon.Lambda.Tools.Test
         }
 
         [Fact]
-        public async Task UserSuppliedRoleMissingDurablePolicyWarnsButDoesNotAttach()
+        public async Task UserSuppliedRoleMissingDurablePolicyNotifiesButDoesNotAttach()
         {
             var lambdaMock = new Mock<IAmazonLambda>();
             lambdaMock.Setup(c => c.CreateFunctionAsync(It.IsAny<CreateFunctionRequest>(), It.IsAny<CancellationToken>()))
                 .Returns(Task.FromResult(new CreateFunctionResponse()));
 
             var attachCalls = new List<string>();
-            // User-supplied role with only the basic-execution policy => durable policy missing => warn only.
+            // User-supplied role with only the basic-execution policy => durable policy missing => notify only.
             var iamMock = BuildIamMock(attachCalls, "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole");
 
             var logger = new TestToolLogger(_testOutputHelper);
@@ -146,12 +146,12 @@ namespace Amazon.Lambda.Tools.Test
 
             Assert.True(created, command.LastToolsException?.Message);
             Assert.Empty(attachCalls);
-            Assert.Contains("missing", logger.Buffer, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("required permissions for Durable Functions", logger.Buffer, StringComparison.OrdinalIgnoreCase);
             Assert.Contains(DurablePolicyArn, logger.Buffer);
         }
 
         [Fact]
-        public async Task DurableConfigMappedOntoUpdateRequestAndWarnsWhenRoleMissingPolicy()
+        public async Task DurableConfigMappedOntoUpdateRequestAndNotifiesWhenRoleMissingPolicy()
         {
             DurableConfig captured = null;
             var lambdaMock = new Mock<IAmazonLambda>();
@@ -192,7 +192,7 @@ namespace Amazon.Lambda.Tools.Test
             Assert.True(updated, command.LastToolsException?.Message);
             Assert.NotNull(captured);
             Assert.Equal(900, captured.ExecutionTimeout);
-            // Update never creates a role, so it must warn rather than attach.
+            // Update never creates a role, so it must notify rather than attach.
             Assert.Empty(attachCalls);
             Assert.Contains(DurablePolicyArn, logger.Buffer);
         }

--- a/test/Amazon.Lambda.Tools.Test/RoleHelperDurableTests.cs
+++ b/test/Amazon.Lambda.Tools.Test/RoleHelperDurableTests.cs
@@ -1,0 +1,92 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Amazon.Common.DotNetCli.Tools;
+using Amazon.IdentityManagement;
+using Amazon.IdentityManagement.Model;
+using Moq;
+using Xunit;
+
+namespace Amazon.Lambda.Tools.Test
+{
+    /// <summary>
+    /// Unit tests for the RoleHelper managed-policy helpers added for durable execution. Fully mocked, no AWS calls.
+    /// </summary>
+    public class RoleHelperDurableTests
+    {
+        private const string PolicyArn = "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicDurableExecutionRolePolicy";
+
+        [Theory]
+        [InlineData("arn:aws:iam::123456789012:role/MyRole", "MyRole")]
+        [InlineData("arn:aws:iam::123456789012:role/path/segment/MyRole", "MyRole")]
+        [InlineData("MyRole", "MyRole")]
+        public void GetRoleNameFromArnOrName_ExtractsName(string input, string expected)
+        {
+            Assert.Equal(expected, RoleHelper.GetRoleNameFromArnOrName(input));
+        }
+
+        private static Mock<IAmazonIdentityManagementService> BuildMock(List<AttachRolePolicyRequest> attachCalls, params string[] alreadyAttached)
+        {
+            var mock = new Mock<IAmazonIdentityManagementService>();
+            mock.Setup(c => c.ListAttachedRolePoliciesAsync(It.IsAny<ListAttachedRolePoliciesRequest>(), It.IsAny<CancellationToken>()))
+                .Returns(() =>
+                {
+                    var response = new ListAttachedRolePoliciesResponse
+                    {
+                        IsTruncated = false,
+                        AttachedPolicies = new List<AttachedPolicyType>()
+                    };
+                    foreach (var arn in alreadyAttached)
+                        response.AttachedPolicies.Add(new AttachedPolicyType { PolicyArn = arn, PolicyName = arn });
+                    return Task.FromResult(response);
+                });
+            mock.Setup(c => c.AttachRolePolicyAsync(It.IsAny<AttachRolePolicyRequest>(), It.IsAny<CancellationToken>()))
+                .Callback<AttachRolePolicyRequest, CancellationToken>((r, token) => attachCalls.Add(r))
+                .Returns(Task.FromResult(new AttachRolePolicyResponse()));
+            return mock;
+        }
+
+        [Fact]
+        public async Task IsManagedPolicyAttached_TrueWhenPresent()
+        {
+            var mock = BuildMock(new List<AttachRolePolicyRequest>(), PolicyArn);
+            Assert.True(await RoleHelper.IsManagedPolicyAttachedAsync(mock.Object, "arn:aws:iam::123456789012:role/MyRole", PolicyArn));
+        }
+
+        [Fact]
+        public async Task IsManagedPolicyAttached_FalseWhenAbsent()
+        {
+            var mock = BuildMock(new List<AttachRolePolicyRequest>());
+            Assert.False(await RoleHelper.IsManagedPolicyAttachedAsync(mock.Object, "arn:aws:iam::123456789012:role/MyRole", PolicyArn));
+        }
+
+        [Fact]
+        public async Task EnsureManagedPolicyAttached_AttachesWhenMissing()
+        {
+            var attachCalls = new List<AttachRolePolicyRequest>();
+            var mock = BuildMock(attachCalls);
+
+            var attached = await RoleHelper.EnsureManagedPolicyAttachedAsync(mock.Object, "arn:aws:iam::123456789012:role/MyRole", PolicyArn);
+
+            Assert.True(attached);
+            Assert.Single(attachCalls);
+            Assert.Equal(PolicyArn, attachCalls[0].PolicyArn);
+            Assert.Equal("MyRole", attachCalls[0].RoleName);
+        }
+
+        [Fact]
+        public async Task EnsureManagedPolicyAttached_IdempotentWhenAlreadyPresent()
+        {
+            var attachCalls = new List<AttachRolePolicyRequest>();
+            var mock = BuildMock(attachCalls, PolicyArn);
+
+            var attached = await RoleHelper.EnsureManagedPolicyAttachedAsync(mock.Object, "arn:aws:iam::123456789012:role/MyRole", PolicyArn);
+
+            Assert.False(attached);
+            Assert.Empty(attachCalls);
+        }
+    }
+}


### PR DESCRIPTION
## Description

A durable Lambda function's execution role must carry the AWS-managed `AWSLambdaBasicDurableExecutionRolePolicy` so the function can call the durable-execution checkpoint APIs. The `--durable-execution-timeout` / `--durable-retention-period` switches (added previously) set `DurableConfig` on the function, but nothing ensured the role had the required policy — a function deployed with `deploy-function` and a tool-created role would fail at runtime because it couldn't checkpoint.

This PR makes `deploy-function` / `update-function-config` ensure the durable IAM policy is in place whenever the deploy is durable (i.e. either `--durable-*` value resolves).

## Changes

- **`LambdaConstants`**: add `AWS_LAMBDA_BASIC_DURABLE_EXECUTION_MANAGED_POLICY` and register it in `KNOWN_MANAGED_POLICY_DESCRIPTIONS` so it shows up in the interactive role-creation picker.
- **`RoleHelper`**: add idempotent `EnsureManagedPolicyAttachedAsync` / `IsManagedPolicyAttachedAsync` plus a `GetRoleNameFromArnOrName` helper.
- **`DeployFunctionCommand` (create path)**: factor durable config resolution into `TryResolveDurableConfig`; after create, attach the durable policy when the tool created the role, and warn (without mutating) when the role was user-supplied.
- **`UpdateFunctionConfigCommand` (update path)**: warn-only when a durable function's existing role is missing the policy (the tool never creates a role on update).

## Behavior decisions

- **Trigger**: presence of either `--durable-*` value (no new flag) — matches the existing wiring.
- **User-supplied role**: warn only, never mutate IAM the tool doesn't own. IAM read/attach errors are downgraded to warnings so a deploy isn't failed over a missing `iam:AttachRolePolicy` permission.

## Testing

### Unit tests (fully mocked, no AWS)
- `RoleHelperDurableTests` — name extraction, is-attached true/false, attach-when-missing, idempotent-when-present (7 tests).
- `DurableConfigTest` — `DurableConfig` mapped onto create + update requests; non-durable deploy attaches nothing; user-supplied role missing the policy warns without attaching (4 tests).

All 11 new tests pass; existing `OptionParseTests` still green.

### End-to-end (real AWS, us-east-1, managed `dotnet10` runtime)

Deployed a real durable function (executable model, `DurableFunction.WrapAsync` + a single `StepAsync`) with the locally-built tool and exercised every path:

**Confirmed the problem exists (old behavior).** A durable function deployed on a role with only `AWSLambdaBasicExecutionRole` (what the tool produced before this change) fails at the first checkpoint:

```
Status: FAILED
Error: Failed to checkpoint operations ... User: .../<role> is not authorized to perform:
lambda:CheckpointDurableExecution ... because no identity-based policy allows the
lambda:CheckpointDurableExecution action
```

So before this fix the function deploys fine but fails at runtime, with no warning.

**Attach path (interactive role creation).** Created a fresh role through the prompt and deliberately chose "No policy" — the tool still auto-attached the durable policy:

```
Attached durable execution managed policy arn:aws:iam::aws:policy/service-role/AWSLambdaBasicDurableExecutionRolePolicy to role arn:aws:iam::<acct>:role/<new-role>
```

`list-attached-role-policies` showed the policy present, and the durable execution then ran to **SUCCEEDED**. The new known-policy entry also appeared in the interactive picker.

**Warn path (user-supplied role, `--disable-interactive`).** On both create and update the tool emitted the warning and did **not** mutate the user's role:

```
Warning: durable function role arn:aws:iam::<acct>:role/<role> is missing the
arn:aws:iam::aws:policy/service-role/AWSLambdaBasicDurableExecutionRolePolicy managed policy.
Durable execution checkpointing will fail until this policy is attached to the role.
```

`DurableConfig` (e.g. `ExecutionTimeout=300`) was correctly set on the function in all cases.

**Positive control.** Attaching the durable policy to the previously-failing role and re-invoking → **SUCCEEDED** (`Error: null`). (Note: a cold start + ~60–90s for managed-policy propagation into the execution role's session was needed before the new permission took effect.)

All test functions and IAM roles created during the run were torn down afterward.

> Draft: opening for review of the approach before finalizing.
