### PR TITLE
Validate ExecutionTimeout is required for durable functions

### DIFF
--- a/.autover/changes/65c3c6ef-986e-49df-8160-d2473aa232b3.json
+++ b/.autover/changes/65c3c6ef-986e-49df-8160-d2473aa232b3.json
@@ -1,0 +1,11 @@
+{
+  "Projects": [
+    {
+      "Name": "Amazon.Lambda.Tools",
+      "Type": "Patch",
+      "ChangelogMessages": [
+        "The `deploy-function` and `update-function-config` commands now validate that `--durable-execution-timeout` is specified when configuring a durable function. Previously, supplying only `--durable-retention-period` produced a durable configuration with no execution timeout that the Lambda service rejects; the tools now fail fast with a clear message instead."
+      ]
+    }
+  ]
+}

--- a/src/Amazon.Lambda.Tools/Commands/UpdateFunctionConfigCommand.cs
+++ b/src/Amazon.Lambda.Tools/Commands/UpdateFunctionConfigCommand.cs
@@ -484,9 +484,21 @@ namespace Amazon.Lambda.Tools.Commands
                 return false;
             }
 
+            // Reaching here means at least one durable option was set, so the user is opting into durable
+            // execution. ExecutionTimeout is required for a durable configuration: the Lambda service rejects a
+            // DurableConfig with no ExecutionTimeout ("You cannot create a function with a durable configuration
+            // without an executionTimeout"). If only the retention period was supplied, fail fast with a clear
+            // message instead of surfacing the raw service error.
+            if (!durableExecutionTimeout.HasValue)
+            {
+                throw new LambdaToolsException(
+                    $"The {LambdaDefinedCommandOptions.ARGUMENT_DURABLE_EXECUTION_TIMEOUT.Switch} switch is required for a durable " +
+                    $"function. Specify it (in seconds) when configuring durable execution.",
+                    ToolsException.CommonErrorCode.CommandLineParseError);
+            }
+
             durableConfig = new DurableConfig();
-            if (durableExecutionTimeout.HasValue)
-                durableConfig.ExecutionTimeout = durableExecutionTimeout.Value;
+            durableConfig.ExecutionTimeout = durableExecutionTimeout.Value;
             if (durableRetentionPeriodInDays.HasValue)
                 durableConfig.RetentionPeriodInDays = durableRetentionPeriodInDays.Value;
             return true;
@@ -841,6 +853,21 @@ namespace Amazon.Lambda.Tools.Commands
             }
 
             var durableExecutionTimeout = this.GetIntValueOrDefault(this.DurableExecutionTimeout, LambdaDefinedCommandOptions.ARGUMENT_DURABLE_EXECUTION_TIMEOUT, false);
+            var durableRetentionPeriodInDays = this.GetIntValueOrDefault(this.DurableRetentionPeriodInDays, LambdaDefinedCommandOptions.ARGUMENT_DURABLE_RETENTION_PERIOD_IN_DAYS, false);
+
+            // ExecutionTimeout is required for a durable configuration. Setting a retention period on a function
+            // that is not already durable, with no ExecutionTimeout, produces a DurableConfig the service rejects.
+            // Retention-only is allowed when the function already has an ExecutionTimeout (the existing value is
+            // preserved by the service).
+            if (durableRetentionPeriodInDays.HasValue && !durableExecutionTimeout.HasValue &&
+                !(existingConfiguration.DurableConfig?.ExecutionTimeout).HasValue)
+            {
+                throw new LambdaToolsException(
+                    $"The {LambdaDefinedCommandOptions.ARGUMENT_DURABLE_EXECUTION_TIMEOUT.Switch} switch is required for a durable " +
+                    $"function. Specify it (in seconds) when configuring durable execution.",
+                    ToolsException.CommonErrorCode.CommandLineParseError);
+            }
+
             if (durableExecutionTimeout.HasValue && durableExecutionTimeout.Value != existingConfiguration.DurableConfig?.ExecutionTimeout)
             {
                 if (request.DurableConfig == null)
@@ -850,7 +877,6 @@ namespace Amazon.Lambda.Tools.Commands
                 different = true;
             }
 
-            var durableRetentionPeriodInDays = this.GetIntValueOrDefault(this.DurableRetentionPeriodInDays, LambdaDefinedCommandOptions.ARGUMENT_DURABLE_RETENTION_PERIOD_IN_DAYS, false);
             if (durableRetentionPeriodInDays.HasValue && durableRetentionPeriodInDays.Value != existingConfiguration.DurableConfig?.RetentionPeriodInDays)
             {
                 if (request.DurableConfig == null)

--- a/test/Amazon.Lambda.Tools.Test/DurableConfigTest.cs
+++ b/test/Amazon.Lambda.Tools.Test/DurableConfigTest.cs
@@ -125,6 +125,61 @@ namespace Amazon.Lambda.Tools.Test
         }
 
         [Fact]
+        public async Task RetentionPeriodWithoutExecutionTimeoutFailsWithClearError()
+        {
+            var lambdaMock = new Mock<IAmazonLambda>();
+            var createCalled = false;
+            lambdaMock.Setup(c => c.CreateFunctionAsync(It.IsAny<CreateFunctionRequest>(), It.IsAny<CancellationToken>()))
+                .Callback<CreateFunctionRequest, CancellationToken>((request, token) => createCalled = true)
+                .Returns(Task.FromResult(new CreateFunctionResponse()));
+
+            var attachCalls = new List<string>();
+            var iamMock = BuildIamMock(attachCalls);
+
+            var command = NewDeployCommand();
+            command.Role = TestRoleArn;
+            // Retention period set but no execution timeout: the service would reject this DurableConfig, so
+            // the tool must fail fast with a clear message before calling CreateFunction.
+            command.DurableRetentionPeriodInDays = 30;
+            command.LambdaClient = lambdaMock.Object;
+            command.IAMClient = iamMock.Object;
+
+            var created = await command.ExecuteAsync();
+
+            Assert.False(created);
+            Assert.False(createCalled, "CreateFunction should not be called when the durable config is invalid.");
+            Assert.NotNull(command.LastToolsException);
+            Assert.Contains(LambdaDefinedCommandOptions.ARGUMENT_DURABLE_EXECUTION_TIMEOUT.Switch, command.LastToolsException.Message);
+        }
+
+        [Fact]
+        public async Task ExecutionTimeoutWithoutRetentionPeriodSucceeds()
+        {
+            DurableConfig captured = null;
+            var lambdaMock = new Mock<IAmazonLambda>();
+            lambdaMock.Setup(c => c.CreateFunctionAsync(It.IsAny<CreateFunctionRequest>(), It.IsAny<CancellationToken>()))
+                .Callback<CreateFunctionRequest, CancellationToken>((request, token) => captured = request.DurableConfig)
+                .Returns(Task.FromResult(new CreateFunctionResponse()));
+
+            var attachCalls = new List<string>();
+            var iamMock = BuildIamMock(attachCalls, DurablePolicyArn);
+
+            var command = NewDeployCommand();
+            command.Role = TestRoleArn;
+            // Only the execution timeout is set; RetentionPeriodInDays is optional and omitted.
+            command.DurableExecutionTimeout = 3600;
+            command.LambdaClient = lambdaMock.Object;
+            command.IAMClient = iamMock.Object;
+
+            var created = await command.ExecuteAsync();
+
+            Assert.True(created, command.LastToolsException?.Message);
+            Assert.NotNull(captured);
+            Assert.Equal(3600, captured.ExecutionTimeout);
+            Assert.Null(captured.RetentionPeriodInDays);
+        }
+
+        [Fact]
         public async Task UserSuppliedRoleMissingDurablePolicyNotifiesButDoesNotAttach()
         {
             var lambdaMock = new Mock<IAmazonLambda>();


### PR DESCRIPTION
## Summary

Adds client-side validation that `--durable-execution-timeout` is supplied when configuring a durable function via `deploy-function` or `update-function-config`.

## Why

The Lambda service requires `ExecutionTimeout` on a `DurableConfig`:

```
InvalidParameterValueException: You cannot create a function with a durable
configuration without an executionTimeout
```

Today, `TryResolveDurableConfig` treats a function as durable if **either** `--durable-execution-timeout` **or** `--durable-retention-period` is set, and there is no check that the timeout is present. So `dotnet lambda deploy-function --durable-retention-period 7` (with no timeout) builds a `DurableConfig` that has only `RetentionPeriodInDays`, sends it to the service, and fails at deploy time with the opaque error above. The same gap exists on the `update-function-config` request builder.

## Changes

- **`TryResolveDurableConfig`** (deploy/create path): throws a clear `CommandLineParseError` when a durable config is requested without `--durable-execution-timeout`.
- **`CreateConfigurationRequestToUpdate`** (update path): throws the same error when a retention period is set on a function that is **not already durable** and no timeout is supplied. Retention-only stays valid when the function already has an `ExecutionTimeout` (the service preserves it).
- Both messages point the user at `--durable-execution-timeout`.

## Testing

- New `DurableConfigTest` cases: retention-only fails fast (asserts `CreateFunction` is never called and the error names the switch); timeout-only succeeds. Existing durable tests still pass.
- `DurableConfigTest`: **6/6 pass**. Durable + option-parse tests: **29/29 pass** (net10.0).

## Notes

Relates to the durable-execution preview. Companion generator-side fix (making `ExecutionTimeout` required on the `[DurableExecution]` annotation) is in aws/aws-lambda-dotnet#2453.
