### PR TITLE
sync: merge dev into master before retiring dev

### DIFF
--- a/.autover/changes/65c3c6ef-986e-49df-8160-d2473aa232b3.json
+++ b/.autover/changes/65c3c6ef-986e-49df-8160-d2473aa232b3.json
@@ -1,0 +1,11 @@
+{
+  "Projects": [
+    {
+      "Name": "Amazon.Lambda.Tools",
+      "Type": "Patch",
+      "ChangelogMessages": [
+        "The `deploy-function` and `update-function-config` commands now validate that `--durable-execution-timeout` is specified when configuring a durable function. Previously, supplying only `--durable-retention-period` produced a durable configuration with no execution timeout that the Lambda service rejects; the tools now fail fast with a clear message instead."
+      ]
+    }
+  ]
+}

--- a/src/Amazon.Lambda.Tools/Commands/UpdateFunctionConfigCommand.cs
+++ b/src/Amazon.Lambda.Tools/Commands/UpdateFunctionConfigCommand.cs
@@ -484,9 +484,21 @@ namespace Amazon.Lambda.Tools.Commands
                 return false;
             }
 
+            // Reaching here means at least one durable option was set, so the user is opting into durable
+            // execution. ExecutionTimeout is required for a durable configuration: the Lambda service rejects a
+            // DurableConfig with no ExecutionTimeout ("You cannot create a function with a durable configuration
+            // without an executionTimeout"). If only the retention period was supplied, fail fast with a clear
+            // message instead of surfacing the raw service error.
+            if (!durableExecutionTimeout.HasValue)
+            {
+                throw new LambdaToolsException(
+                    $"The {LambdaDefinedCommandOptions.ARGUMENT_DURABLE_EXECUTION_TIMEOUT.Switch} switch is required for a durable " +
+                    $"function. Specify it (in seconds) when configuring durable execution.",
+                    ToolsException.CommonErrorCode.CommandLineParseError);
+            }
+
             durableConfig = new DurableConfig();
-            if (durableExecutionTimeout.HasValue)
-                durableConfig.ExecutionTimeout = durableExecutionTimeout.Value;
+            durableConfig.ExecutionTimeout = durableExecutionTimeout.Value;
             if (durableRetentionPeriodInDays.HasValue)
                 durableConfig.RetentionPeriodInDays = durableRetentionPeriodInDays.Value;
             return true;
@@ -841,6 +853,21 @@ namespace Amazon.Lambda.Tools.Commands
             }
 
             var durableExecutionTimeout = this.GetIntValueOrDefault(this.DurableExecutionTimeout, LambdaDefinedCommandOptions.ARGUMENT_DURABLE_EXECUTION_TIMEOUT, false);
+            var durableRetentionPeriodInDays = this.GetIntValueOrDefault(this.DurableRetentionPeriodInDays, LambdaDefinedCommandOptions.ARGUMENT_DURABLE_RETENTION_PERIOD_IN_DAYS, false);
+
+            // ExecutionTimeout is required for a durable configuration. Setting a retention period on a function
+            // that is not already durable, with no ExecutionTimeout, produces a DurableConfig the service rejects.
+            // Retention-only is allowed when the function already has an ExecutionTimeout (the existing value is
+            // preserved by the service).
+            if (durableRetentionPeriodInDays.HasValue && !durableExecutionTimeout.HasValue &&
+                !(existingConfiguration.DurableConfig?.ExecutionTimeout).HasValue)
+            {
+                throw new LambdaToolsException(
+                    $"The {LambdaDefinedCommandOptions.ARGUMENT_DURABLE_EXECUTION_TIMEOUT.Switch} switch is required for a durable " +
+                    $"function. Specify it (in seconds) when configuring durable execution.",
+                    ToolsException.CommonErrorCode.CommandLineParseError);
+            }
+
             if (durableExecutionTimeout.HasValue && durableExecutionTimeout.Value != existingConfiguration.DurableConfig?.ExecutionTimeout)
             {
                 if (request.DurableConfig == null)
@@ -850,7 +877,6 @@ namespace Amazon.Lambda.Tools.Commands
                 different = true;
             }
 
-            var durableRetentionPeriodInDays = this.GetIntValueOrDefault(this.DurableRetentionPeriodInDays, LambdaDefinedCommandOptions.ARGUMENT_DURABLE_RETENTION_PERIOD_IN_DAYS, false);
             if (durableRetentionPeriodInDays.HasValue && durableRetentionPeriodInDays.Value != existingConfiguration.DurableConfig?.RetentionPeriodInDays)
             {
                 if (request.DurableConfig == null)

--- a/test/Amazon.Lambda.Tools.Test/DurableConfigTest.cs
+++ b/test/Amazon.Lambda.Tools.Test/DurableConfigTest.cs
@@ -125,6 +125,61 @@ namespace Amazon.Lambda.Tools.Test
         }
 
         [Fact]
+        public async Task RetentionPeriodWithoutExecutionTimeoutFailsWithClearError()
+        {
+            var lambdaMock = new Mock<IAmazonLambda>();
+            var createCalled = false;
+            lambdaMock.Setup(c => c.CreateFunctionAsync(It.IsAny<CreateFunctionRequest>(), It.IsAny<CancellationToken>()))
+                .Callback<CreateFunctionRequest, CancellationToken>((request, token) => createCalled = true)
+                .Returns(Task.FromResult(new CreateFunctionResponse()));
+
+            var attachCalls = new List<string>();
+            var iamMock = BuildIamMock(attachCalls);
+
+            var command = NewDeployCommand();
+            command.Role = TestRoleArn;
+            // Retention period set but no execution timeout: the service would reject this DurableConfig, so
+            // the tool must fail fast with a clear message before calling CreateFunction.
+            command.DurableRetentionPeriodInDays = 30;
+            command.LambdaClient = lambdaMock.Object;
+            command.IAMClient = iamMock.Object;
+
+            var created = await command.ExecuteAsync();
+
+            Assert.False(created);
+            Assert.False(createCalled, "CreateFunction should not be called when the durable config is invalid.");
+            Assert.NotNull(command.LastToolsException);
+            Assert.Contains(LambdaDefinedCommandOptions.ARGUMENT_DURABLE_EXECUTION_TIMEOUT.Switch, command.LastToolsException.Message);
+        }
+
+        [Fact]
+        public async Task ExecutionTimeoutWithoutRetentionPeriodSucceeds()
+        {
+            DurableConfig captured = null;
+            var lambdaMock = new Mock<IAmazonLambda>();
+            lambdaMock.Setup(c => c.CreateFunctionAsync(It.IsAny<CreateFunctionRequest>(), It.IsAny<CancellationToken>()))
+                .Callback<CreateFunctionRequest, CancellationToken>((request, token) => captured = request.DurableConfig)
+                .Returns(Task.FromResult(new CreateFunctionResponse()));
+
+            var attachCalls = new List<string>();
+            var iamMock = BuildIamMock(attachCalls, DurablePolicyArn);
+
+            var command = NewDeployCommand();
+            command.Role = TestRoleArn;
+            // Only the execution timeout is set; RetentionPeriodInDays is optional and omitted.
+            command.DurableExecutionTimeout = 3600;
+            command.LambdaClient = lambdaMock.Object;
+            command.IAMClient = iamMock.Object;
+
+            var created = await command.ExecuteAsync();
+
+            Assert.True(created, command.LastToolsException?.Message);
+            Assert.NotNull(captured);
+            Assert.Equal(3600, captured.ExecutionTimeout);
+            Assert.Null(captured.RetentionPeriodInDays);
+        }
+
+        [Fact]
         public async Task UserSuppliedRoleMissingDurablePolicyNotifiesButDoesNotAttach()
         {
             var lambdaMock = new Mock<IAmazonLambda>();


### PR DESCRIPTION
## Purpose
Pre-cutover sync: ensure the trunk has every commit from its dev branch **before** the single-trunk cutover retires that dev branch. Shows exactly the commits `dev` is ahead of `master`.

## Sequence
1. Review the ahead commits below; resolve any conflicts (branches may have diverged).
2. Merge this **before** the `onboard: single-trunk Execute Release workflow` PR (that PR deletes `create-release-pr.yml` + `sync-*.yml`; doing the sync first avoids re-introducing them).
3. After merge, the `dev` branch can be safely deleted.

DRAFT until reviewed.