### PR TITLE
chore: suppress unsafe-path-combine Semgrep findings (internal CLI paths)

### DIFF
--- a/src/Amazon.Common.DotNetCli.Tools/DefaultConfigFile.cs
+++ b/src/Amazon.Common.DotNetCli.Tools/DefaultConfigFile.cs
@@ -57,7 +57,7 @@ namespace Amazon.Common.DotNetCli.Tools
                     CommentHandling = JsonCommentHandling.Skip
                 };
 
-                string json = File.ReadAllText(path);
+                string json = File.ReadAllText(path); // nosemgrep: csharp.lang.security.filesystem.unsafe-path-combine.unsafe-path-combine -- projectLocation/configFile are the developer's own CLI inputs, not attacker-controlled.
                 using (JsonDocument doc = JsonDocument.Parse(json, options))
                 {
                     this._rootData = doc.RootElement.Clone();

--- a/src/Amazon.ElasticBeanstalk.Tools/EBUtilities.cs
+++ b/src/Amazon.ElasticBeanstalk.Tools/EBUtilities.cs
@@ -87,7 +87,7 @@ namespace Amazon.ElasticBeanstalk.Tools
             logger?.WriteLine("\tIIS App Path: " + iisAppPath);
             logger?.WriteLine("\tIIS Web Site: " + iisWebSite);
 
-            File.WriteAllText(pathToManifest, manifest);
+            File.WriteAllText(pathToManifest, manifest); // nosemgrep: csharp.lang.security.filesystem.unsafe-path-combine.unsafe-path-combine -- publishLocation is the developer's own CLI publish dir, not attacker-controlled.
         }
 
         public static bool IsSolutionStackWindows(string solutionStackName)
@@ -151,7 +151,7 @@ namespace Amazon.ElasticBeanstalk.Tools
             var content = "web: " + webCommandLine;
             logger?.WriteLine($"... Procfile command used to start application");
             logger?.WriteLine($"    {content}");
-            File.WriteAllText(procfilePath, content);
+            File.WriteAllText(procfilePath, content); // nosemgrep: csharp.lang.security.filesystem.unsafe-path-combine.unsafe-path-combine -- publishLocation is the developer's own CLI publish dir, not attacker-controlled.
         }
 
         public static bool IsSelfContainedPublish(string runtimeConfigFile)

--- a/src/Amazon.Lambda.Tools/LambdaUtilities.cs
+++ b/src/Amazon.Lambda.Tools/LambdaUtilities.cs
@@ -279,7 +279,7 @@ namespace Amazon.Lambda.Tools
                 {
                     var path = Path.Combine(workingDirectory, kvp.Value);
                     logger?.WriteLine($"\tReading: {path}");
-                    replacementValue = File.ReadAllText(path);
+                    replacementValue = File.ReadAllText(path); // nosemgrep: csharp.lang.security.filesystem.unsafe-path-combine.unsafe-path-combine -- workingDirectory is the developer's own CLI working dir, not attacker-controlled.
                 }
                 else
                 {


### PR DESCRIPTION
Adds documented inline `nosemgrep` suppressions for the 4 `unsafe-path-combine` findings (DefaultConfigFile.cs, LambdaUtilities.cs, EBUtilities.cs ×2). All flagged paths are the developer's own CLI inputs (project location, config file, working/publish directories) — not attacker-controlled — so no behavior change is warranted. Clears the findings blocking the `master` Semgrep scan.