### PR TITLE
fix: include README.md in published NuGet tool packages

### DIFF
--- a/.autover/changes/4c2ac197-8c02-4b96-9a14-f596328eaf7b.json
+++ b/.autover/changes/4c2ac197-8c02-4b96-9a14-f596328eaf7b.json
@@ -1,0 +1,11 @@
+{
+  "Projects": [
+    {
+      "Name": "Amazon.ElasticBeanstalk.Tools",
+      "Type": "Patch",
+      "ChangelogMessages": [
+        "Include README.md in the published NuGet package."
+      ]
+    }
+  ]
+}

--- a/.autover/changes/6ccd3b59-130a-4694-9df9-3300b1797a3b.json
+++ b/.autover/changes/6ccd3b59-130a-4694-9df9-3300b1797a3b.json
@@ -1,0 +1,11 @@
+{
+  "Projects": [
+    {
+      "Name": "Amazon.Lambda.Tools",
+      "Type": "Patch",
+      "ChangelogMessages": [
+        "Include README.md in the published NuGet package."
+      ]
+    }
+  ]
+}

--- a/.autover/changes/c64c23c0-cabd-4a21-8804-f62f83e378d5.json
+++ b/.autover/changes/c64c23c0-cabd-4a21-8804-f62f83e378d5.json
@@ -1,0 +1,11 @@
+{
+  "Projects": [
+    {
+      "Name": "Amazon.ECS.Tools",
+      "Type": "Patch",
+      "ChangelogMessages": [
+        "Include README.md in the published NuGet package."
+      ]
+    }
+  ]
+}

--- a/buildtools/common.props
+++ b/buildtools/common.props
@@ -8,6 +8,7 @@
     
     <PackageIcon>icon.png</PackageIcon>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
     
     <PackageProjectUrl>https://github.com/aws/aws-extensions-for-dotnet-cli</PackageProjectUrl>
   </PropertyGroup>
@@ -20,6 +21,7 @@
   <ItemGroup>
     <None Include="$(MSBuildThisFileDirectory)/../LICENSE" Pack="true" PackagePath="" />
     <None Include="$(MSBuildThisFileDirectory)/../icon.png" Pack="true" PackagePath="" />
+    <None Include="$(MSBuildThisFileDirectory)/../README.md" Pack="true" PackagePath="" />
   </ItemGroup>
   
 </Project>


### PR DESCRIPTION
Fixes #299

## Root cause
The tool packages (`Amazon.Lambda.Tools`, `Amazon.ECS.Tools`, `Amazon.ElasticBeanstalk.Tools`) were published to NuGet.org without a README. The shared MSBuild config `buildtools/common.props` packed `LICENSE` and `icon.png` but never declared or packed a `PackageReadmeFile`, so NuGet showed no package documentation.

## Fix
In `buildtools/common.props`:
- Add `<PackageReadmeFile>README.md</PackageReadmeFile>`.
- Add a `<None Include=".../README.md" Pack="true" PackagePath="" />` entry so the repo-root `README.md` is packed into each `.nupkg`.

Because `common.props` is shared, this fixes all three tool packages at once.

## Versioning
Includes 3 AutoVer `Patch` change files (one per affected package), each with the changelog message "Include README.md in the published NuGet package."

## Reviewer notes
- **No unit tests:** This is a build/packaging config change with no runtime code path; correctness is verified by the produced `.nupkg` contents. No automated test guards regression here.