### PR TITLE
Enable deterministic builds and Source Link for produced NuGet packages

### DIFF
--- a/.autover/changes/75c619dd-8fe5-451a-b6cf-bfeae6e5336e.json
+++ b/.autover/changes/75c619dd-8fe5-451a-b6cf-bfeae6e5336e.json
@@ -1,0 +1,25 @@
+{
+  "Projects": [
+    {
+      "Name": "Amazon.ECS.Tools",
+      "Type": "Patch",
+      "ChangelogMessages": [
+        "Enable deterministic builds and Source Link for the produced NuGet packages."
+      ]
+    },
+    {
+      "Name": "Amazon.ElasticBeanstalk.Tools",
+      "Type": "Patch",
+      "ChangelogMessages": [
+        "Enable deterministic builds and Source Link for the produced NuGet packages."
+      ]
+    },
+    {
+      "Name": "Amazon.Lambda.Tools",
+      "Type": "Patch",
+      "ChangelogMessages": [
+        "Enable deterministic builds and Source Link for the produced NuGet packages."
+      ]
+    }
+  ]
+}

--- a/buildtools/common.props
+++ b/buildtools/common.props
@@ -10,12 +10,38 @@
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
     
     <PackageProjectUrl>https://github.com/aws/aws-extensions-for-dotnet-cli</PackageProjectUrl>
+
+    <!-- Deterministic builds and Source Link. Produces reproducible package output and
+         embeds source-control metadata so debuggers can step into the shipped libraries.
+         ContinuousIntegrationBuild is only enabled on a build server (CI/TF_BUILD/CodeBuild)
+         so it does not normalize paths for local developer builds. -->
+    <RepositoryUrl>https://github.com/aws/aws-extensions-for-dotnet-cli</RepositoryUrl>
+    <RepositoryType>git</RepositoryType>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <EmbedUntrackedSources>true</EmbedUntrackedSources>
+    <Deterministic>true</Deterministic>
+    <ContinuousIntegrationBuild Condition="'$(CI)' == 'true' or '$(TF_BUILD)' == 'true' or '$(CODEBUILD_BUILD_ID)' != ''">true</ContinuousIntegrationBuild>
   </PropertyGroup>
   
   <PropertyGroup>
     <AssemblyOriginatorKeyFile>$(MSBuildThisFileDirectory)/public.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>  
   </PropertyGroup>
+
+  <ItemGroup>
+    <!-- Source Link enables debuggers to download matching source from GitHub for the shipped packages. -->
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="all" />
+  </ItemGroup>
+
+  <!-- AWS release pipelines often pack from a .git-less source archive, so Source Link would otherwise
+       emit no source mapping. When the build provides a revision id, declare the source root explicitly.
+       Guarded on SourceRevisionId so local developer builds (which have a .git dir) are unaffected. -->
+  <ItemGroup Condition="'$(SourceRevisionId)' != ''">
+    <SourceRoot Include="$(MSBuildThisFileDirectory)"
+                SourceControl="git"
+                RepositoryUrl="$(RepositoryUrl)"
+                RevisionId="$(SourceRevisionId)" />
+  </ItemGroup>
 
   <ItemGroup>
     <None Include="$(MSBuildThisFileDirectory)/../LICENSE" Pack="true" PackagePath="" />


### PR DESCRIPTION
Fixes #460

Enables deterministic builds and Source Link for the produced NuGet packages (`Amazon.ECS.Tools`, `Amazon.ElasticBeanstalk.Tools`, `Amazon.Lambda.Tools`) so debuggers can step into shipped sources and package output is reproducible. Follows the canonical template aws/integrations-on-dotnet-aspire-for-aws#245.

## Changes
- `buildtools/common.props` (the shared props imported by the four packable `src/` projects):
  - `RepositoryUrl` + `RepositoryType=git`, `PublishRepositoryUrl=true`, `EmbedUntrackedSources=true`, `Deterministic=true`
  - `ContinuousIntegrationBuild` gated on a portable multi-signal CI condition: `'$(CI)' == 'true' or '$(TF_BUILD)' == 'true' or '$(CODEBUILD_BUILD_ID)' != ''`
  - `Microsoft.SourceLink.GitHub` 8.0.0 `PackageReference` (`PrivateAssets=all`)
  - explicit `SourceRoot` ItemGroup guarded on `'$(SourceRevisionId)' != ''` — AWS release pipelines pack from a `.git`-less source archive, so Source Link emits nothing without it; the guard keeps local dev builds unaffected
- `.autover/changes/*.json` — Patch entry for the three packable projects

## Reviewer notes
- **Shared file choice:** kept `buildtools/common.props` (this repo's established shared-props convention, imported only by the four packable `src/` projects) rather than adding a root `Directory.Build.props`, which would wrongly scope the SourceLink reference onto the `test/`/`testapps/` projects.
- **CI detection:** CI runs in CodeBuild, which sets `CODEBUILD_BUILD_ID` automatically, so the portable condition activates with no buildspec changes.
- **No central package management** (no `Directory.Packages.props`) → single versioned `PackageReference`.
- **Verified:** packed `Amazon.Lambda.Tools` with `CODEBUILD_BUILD_ID` set — `ContinuousIntegrationBuild=true`, `Deterministic=true`, and the nuspec carries `<repository type="git" url="https://github.com/aws/aws-extensions-for-dotnet-cli" branch="refs/heads/gcbeatty/issue-460-fix" commit="885db76..." />`. Without CI env vars, `ContinuousIntegrationBuild` stays unset (local dev unaffected).

Opened as a draft.